### PR TITLE
Add centralized lazy-loaded app routes configuration

### DIFF
--- a/client/src/app/routes.ts
+++ b/client/src/app/routes.ts
@@ -1,0 +1,60 @@
+import { lazy } from "react";
+
+export interface AppRoute {
+  path: string;
+  component?: React.ComponentType<any>;
+  redirectTo?: string;
+}
+
+// lazily load pages
+const Home = lazy(() => import("@/pages/Home"));
+const Verstehen = lazy(() => import("@/pages/Verstehen"));
+const UnterstuetzenUebersicht = lazy(() => import("@/pages/UnterstuetzenUebersicht"));
+const UnterstuetzenAlltag = lazy(() => import("@/pages/UnterstuetzenAlltag"));
+const UnterstuetzenTherapie = lazy(() => import("@/pages/UnterstuetzenTherapie"));
+const UnterstuetzenKrise = lazy(() => import("@/pages/UnterstuetzenKrise"));
+const Kommunizieren = lazy(() => import("@/pages/Kommunizieren"));
+const Grenzen = lazy(() => import("@/pages/Grenzen"));
+const Selbstfuersorge = lazy(() => import("@/pages/Selbstfuersorge"));
+const Soforthilfe = lazy(() => import("@/pages/Soforthilfe"));
+const Materialien = lazy(() => import("@/pages/Materialien"));
+const SelbsttestPage = lazy(() => import("@/pages/SelbsttestPage"));
+const Impressum = lazy(() => import("@/pages/Impressum"));
+const Datenschutz = lazy(() => import("@/pages/Datenschutz"));
+const Genesung = lazy(() => import("@/pages/Genesung"));
+const Selbsthilfegruppen = lazy(() => import("@/pages/Selbsthilfegruppen"));
+const Feedback = lazy(() => import("@/pages/Feedback"));
+const Glossar = lazy(() => import("@/pages/Glossar"));
+const Buchempfehlungen = lazy(() => import("@/pages/Buchempfehlungen"));
+const FAQ = lazy(() => import("@/pages/FAQ"));
+const UeberUns = lazy(() => import("@/pages/UeberUns"));
+const Fachstelle = lazy(() => import("@/pages/Fachstelle"));
+
+export const routes: AppRoute[] = [
+  { path: "/", component: Home },
+  { path: "/verstehen", component: Verstehen },
+  { path: "/unterstuetzen", redirectTo: "/unterstuetzen/uebersicht" },
+  { path: "/unterstuetzen/uebersicht", component: UnterstuetzenUebersicht },
+  { path: "/unterstuetzen/alltag", component: UnterstuetzenAlltag },
+  { path: "/unterstuetzen/therapie", component: UnterstuetzenTherapie },
+  { path: "/unterstuetzen/krise", component: UnterstuetzenKrise },
+  { path: "/kommunizieren", component: Kommunizieren },
+  { path: "/grenzen", component: Grenzen },
+  { path: "/selbstfuersorge", component: Selbstfuersorge },
+  { path: "/soforthilfe", component: Soforthilfe },
+  { path: "/notfall", redirectTo: "/soforthilfe" },
+  { path: "/materialien", component: Materialien },
+  { path: "/selbsttest", component: SelbsttestPage },
+  { path: "/impressum", component: Impressum },
+  { path: "/datenschutz", component: Datenschutz },
+  { path: "/genesung", component: Genesung },
+  { path: "/beratung", component: Selbsthilfegruppen },
+  { path: "/selbsthilfegruppen", component: Selbsthilfegruppen },
+  { path: "/feedback", component: Feedback },
+  { path: "/glossar", component: Glossar },
+  { path: "/buchempfehlungen", component: Buchempfehlungen },
+  { path: "/therapieangebote", redirectTo: "/unterstuetzen/therapie#therapieangebote" },
+  { path: "/faq", component: FAQ },
+  { path: "/ueber-uns", component: UeberUns },
+  { path: "/fachstelle", component: Fachstelle },
+];


### PR DESCRIPTION
### Motivation
- Centralize route definitions and enable code-splitting by lazily importing page components to simplify routing and reduce initial bundle size.
- Provide a single source of truth for paths and redirects (notably `/unterstuetzen`, `/notfall`, and `/therapieangebote`) so other parts of the app can consume the same route list.

### Description
- Added a new file `client/src/app/routes.ts` that exports a `routes: AppRoute[]` array.
- Introduced the `AppRoute` interface with `path`, optional `component`, and optional `redirectTo` fields.
- Lazily import all page components using `lazy(() => import("@/pages/...")` and register routes and redirect entries, including `/unterstuetzen`, `/notfall`, and `/therapieangebote`.

### Testing
- Ran type-checking with `pnpm -s check`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c0d314d08332ac893906dcc76d9b)