### PR TITLE
Add Router component with Suspense fallback and 404 handling

### DIFF
--- a/client/src/app/Router.tsx
+++ b/client/src/app/Router.tsx
@@ -1,0 +1,35 @@
+import { Suspense } from "react";
+import { Route, Switch, Redirect } from "wouter";
+import { routes } from "@/app/routes";
+import NotFound from "@/pages/NotFound";
+
+function PageLoader() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center">
+      <div className="flex flex-col items-center gap-3">
+        <div className="w-8 h-8 border-3 border-primary/30 border-t-primary rounded-full animate-spin" />
+        <p className="text-sm text-muted-foreground">Seite wird geladen…</p>
+      </div>
+    </div>
+  );
+}
+
+export default function Router() {
+  return (
+    <Suspense fallback={<PageLoader />}>
+      <Switch>
+        {routes.map((route) =>
+          route.redirectTo ? (
+            <Route key={route.path} path={route.path}>
+              {() => <Redirect to={route.redirectTo!} />}
+            </Route>
+          ) : (
+            <Route key={route.path} path={route.path} component={route.component!} />
+          ),
+        )}
+        <Route path="/404" component={NotFound} />
+        <Route component={NotFound} />
+      </Switch>
+    </Suspense>
+  );
+}


### PR DESCRIPTION
### Motivation
- Centralize client route rendering and improve UX by wrapping route switches in `Suspense` with a small localized loading state, support redirect routes, and provide explicit 404 handling.

### Description
- Add `client/src/app/Router.tsx` which defines a `PageLoader` and exports a `Router` component that maps the `routes` array to `wouter` `<Route>`s and handles `route.redirectTo` via `<Redirect />`.

### Testing
- Ran `pnpm check` (which runs `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c1bb1328833297bd3b485a591dc9)