### PR TITLE
Refactor root app wrapper into AppProviders

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,101 +1,11 @@
-import { Toaster } from "@/components/ui/sonner";
-import { TooltipProvider } from "@/components/ui/tooltip";
-import NotFound from "@/pages/NotFound";
-import { Route, Switch, Redirect } from "wouter";
-import { lazy, Suspense } from "react";
-import ErrorBoundary from "./components/ErrorBoundary";
-import ScrollToTop from "./components/ScrollToTop";
-import { ThemeProvider } from "./contexts/ThemeContext";
-import { MotionConfig } from "framer-motion";
-
-// Home wird ebenfalls lazy geladen um den initialen Bundle zu verkleinern
-const Home = lazy(() => import("./pages/Home"));
-
-// Alle anderen Seiten werden lazy geladen für kleineres initiales Bundle
-const Verstehen = lazy(() => import("./pages/Verstehen"));
-const UnterstuetzenUebersicht = lazy(() => import("./pages/UnterstuetzenUebersicht"));
-const UnterstuetzenAlltag = lazy(() => import("./pages/UnterstuetzenAlltag"));
-const UnterstuetzenTherapie = lazy(() => import("./pages/UnterstuetzenTherapie"));
-const UnterstuetzenKrise = lazy(() => import("./pages/UnterstuetzenKrise"));
-const Kommunizieren = lazy(() => import("./pages/Kommunizieren"));
-const Grenzen = lazy(() => import("./pages/Grenzen"));
-const Selbstfuersorge = lazy(() => import("./pages/Selbstfuersorge"));
-const Soforthilfe = lazy(() => import("./pages/Soforthilfe"));
-const Materialien = lazy(() => import("./pages/Materialien"));
-const SelbsttestPage = lazy(() => import("./pages/SelbsttestPage"));
-const Impressum = lazy(() => import("./pages/Impressum"));
-const Datenschutz = lazy(() => import("./pages/Datenschutz"));
-const Genesung = lazy(() => import("./pages/Genesung"));
-const Selbsthilfegruppen = lazy(() => import("./pages/Selbsthilfegruppen"));
-const Feedback = lazy(() => import("./pages/Feedback"));
-const Glossar = lazy(() => import("./pages/Glossar"));
-const Buchempfehlungen = lazy(() => import("./pages/Buchempfehlungen"));
-const FAQ = lazy(() => import("./pages/FAQ"));
-const UeberUns = lazy(() => import("./pages/UeberUns"));
-const Fachstelle = lazy(() => import("./pages/Fachstelle"));
-
-// Minimaler Lade-Spinner für Suspense-Fallback
-function PageLoader() {
-  return (
-    <div className="min-h-[60vh] flex items-center justify-center">
-      <div className="flex flex-col items-center gap-3">
-        <div className="w-8 h-8 border-3 border-primary/30 border-t-primary rounded-full animate-spin" />
-        <p className="text-sm text-muted-foreground">Seite wird geladen…</p>
-      </div>
-    </div>
-  );
-}
-
-function Router() {
-  return (
-    <Suspense fallback={<PageLoader />}>
-      <Switch>
-        <Route path="/" component={Home} />
-        <Route path="/verstehen" component={Verstehen} />
-        <Route path="/unterstuetzen">{() => <Redirect to="/unterstuetzen/uebersicht" />}</Route>
-        <Route path="/unterstuetzen/uebersicht" component={UnterstuetzenUebersicht} />
-        <Route path="/unterstuetzen/alltag" component={UnterstuetzenAlltag} />
-        <Route path="/unterstuetzen/therapie" component={UnterstuetzenTherapie} />
-        <Route path="/unterstuetzen/krise" component={UnterstuetzenKrise} />
-        <Route path="/kommunizieren" component={Kommunizieren} />
-        <Route path="/grenzen" component={Grenzen} />
-        <Route path="/selbstfuersorge" component={Selbstfuersorge} />
-        <Route path="/soforthilfe" component={Soforthilfe} />
-        <Route path="/notfall">{() => <Redirect to="/soforthilfe" />}</Route>
-        <Route path="/materialien" component={Materialien} />
-        <Route path="/selbsttest" component={SelbsttestPage} />
-        <Route path="/impressum" component={Impressum} />
-        <Route path="/datenschutz" component={Datenschutz} />
-        <Route path="/genesung" component={Genesung} />
-        <Route path="/beratung" component={Selbsthilfegruppen} />
-        <Route path="/selbsthilfegruppen" component={Selbsthilfegruppen} />
-        <Route path="/feedback" component={Feedback} />
-        <Route path="/glossar" component={Glossar} />
-        <Route path="/buchempfehlungen" component={Buchempfehlungen} />
-        <Route path="/therapieangebote">{() => <Redirect to="/unterstuetzen/therapie#therapieangebote" />}</Route>
-        <Route path="/faq" component={FAQ} />
-        <Route path="/ueber-uns" component={UeberUns} />
-        <Route path="/fachstelle" component={Fachstelle} />
-        <Route path="/404" component={NotFound} />
-        <Route component={NotFound} />
-      </Switch>
-    </Suspense>
-  );
-}
+import AppProviders from "@/app/AppProviders";
+import Router from "@/app/Router";
 
 function App() {
   return (
-    <ErrorBoundary>
-      <MotionConfig reducedMotion="user">
-        <ThemeProvider defaultTheme="light">
-          <TooltipProvider>
-            <Toaster />
-            <ScrollToTop />
-            <Router />
-          </TooltipProvider>
-        </ThemeProvider>
-      </MotionConfig>
-    </ErrorBoundary>
+    <AppProviders>
+      <Router />
+    </AppProviders>
   );
 }
 

--- a/client/src/app/AppProviders.tsx
+++ b/client/src/app/AppProviders.tsx
@@ -1,0 +1,22 @@
+import { Toaster } from "@/components/ui/sonner";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import ErrorBoundary from "@/components/ErrorBoundary";
+import ScrollToTop from "@/components/ScrollToTop";
+import { ThemeProvider } from "@/contexts/ThemeContext";
+import { MotionConfig } from "framer-motion";
+
+export default function AppProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <ErrorBoundary>
+      <MotionConfig reducedMotion="user">
+        <ThemeProvider defaultTheme="light">
+          <TooltipProvider>
+            <Toaster />
+            <ScrollToTop />
+            {children}
+          </TooltipProvider>
+        </ThemeProvider>
+      </MotionConfig>
+    </ErrorBoundary>
+  );
+}


### PR DESCRIPTION
### Motivation
- Separate the top-level provider composition from the app entry to improve composition and reuse. 
- Make `App.tsx` smaller and focused on application wiring (rendering routes) while keeping provider concerns isolated for easier testing and maintenance.

### Description
- Add `client/src/app/AppProviders.tsx` which encapsulates the provider stack (`ErrorBoundary`, `MotionConfig`, `ThemeProvider`, `TooltipProvider`, `Toaster`, `ScrollToTop`) and renders its `children` inside that stack.  
- Simplify `client/src/App.tsx` to import `AppProviders` and `Router` and render `<Router />` inside `<AppProviders>` instead of keeping the provider stack inline.  
- No behavioral changes to the provider order or configuration were made; this is a refactor for clarity and modularity. 

### Testing
- Ran `pnpm run check` (which runs `tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c2678f608332b1e79b8b4f5d183a)