### PR TITLE
Refactor: move large page content into content modules and section components

### DIFF
--- a/client/src/content/genesung.ts
+++ b/client/src/content/genesung.ts
@@ -1,0 +1,45 @@
+export type GenesungKategorie = "alle" | "verstehen" | "handeln";
+
+export const genesungCategories = [
+  { id: "alle", label: "Alle" },
+  { id: "verstehen", label: "Verstehen" },
+  { id: "handeln", label: "Handeln" },
+] as const;
+
+export const genesungItems = [
+  {
+    title: "Genesung in Zahlen",
+    desc: "Orientierungs-Tracker mit Langzeitdaten",
+    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tyFTHNjsUagqrXiS.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MunlHDCNqnsOhBFn.pdf",
+    category: "verstehen",
+  },
+  {
+    title: "Das Fortschritt-Paradox",
+    desc: "Warum Rückfälle zum Weg gehören",
+    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DPkqytVYFcreeBlC.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/UFLdEEGIDxKdRUZO.pdf",
+    category: "verstehen",
+  },
+  {
+    title: "Remission vs. Heilung",
+    desc: "Was Besserung wirklich bedeutet",
+    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/HPRsNmCUFirjnraj.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/KMjqRDjDjWVZpjhJ.pdf",
+    category: "verstehen",
+  },
+  {
+    title: "5 Faktoren, die Genesung fördern",
+    desc: "Säulen-Modell: Was positiv beeinflusst",
+    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/mFhtxtPMBkCEVPII.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/qgrRYtMKOvwWmuah.pdf",
+    category: "handeln",
+  },
+  {
+    title: "Ihre Rolle im Genesungsprozess",
+    desc: "Was Sie tun können (und was nicht)",
+    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GhgPDkJhqlqJkYzE.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/CZdiDaadpIWNOBFb.pdf",
+    category: "handeln",
+  },
+] as const;

--- a/client/src/content/selbstfuersorge.ts
+++ b/client/src/content/selbstfuersorge.ts
@@ -1,0 +1,63 @@
+export type SelbstfuersorgeKategorie = "alle" | "erkennen" | "techniken" | "ressourcen";
+
+export type SelbstfuersorgeInfografik = {
+  id: string;
+  title: string;
+  desc: string;
+  category: Exclude<SelbstfuersorgeKategorie, "alle">;
+  webp: string;
+  pdf: string;
+  featured?: boolean;
+};
+
+export const selbstfuersorgeInfografiken: SelbstfuersorgeInfografik[] = [
+  {
+    id: "warnsignale",
+    title: "Warnsignale der Überlastung",
+    desc: "Ampel-Stufenmodell: Grün → Gelb → Rot – erkennen Sie rechtzeitig, wann es zu viel wird.",
+    category: "erkennen",
+    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OEUNVdTyojBBYTic.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VdAxPxngFzgNImxg.pdf",
+    featured: true,
+  },
+  {
+    id: "sauerstoffmaske",
+    title: "Die Sauerstoffmaske",
+    desc: "Kreislauf-Diagramm: Teufelskreis vs. positiver Kreislauf – warum Selbstfürsorge keine Selbstsucht ist.",
+    category: "erkennen",
+    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/IQwhlqUMporMKdmH.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/yIWenSfOeiUHdMIc.pdf",
+  },
+  {
+    id: "radikale-akzeptanz",
+    title: "Radikale Akzeptanz",
+    desc: "2-Spalten-Vergleich: Was Radikale Akzeptanz NICHT ist vs. was sie IST, plus 4-Schritte-Übung.",
+    category: "techniken",
+    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OmxdguWaaXAkElDp.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/SkBpjnDHfNmPbmnd.pdf",
+  },
+  {
+    id: "stopp-technik",
+    title: "Die STOPP-Technik",
+    desc: "5 Schritte aus der Stressspirale: Stopp, Tief atmen, Orientieren, Perspektive, Plan – in 30 Sekunden.",
+    category: "techniken",
+    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/qvJDZrQvvOlErFQu.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VnQKfkkQbPunhDed.pdf",
+  },
+  {
+    id: "energie-konto",
+    title: "Ihr Energie-Konto",
+    desc: "Stock-&-Flow-Diagramm: Was füllt Ihre Batterie auf, was leert sie? Achten Sie auf die Balance.",
+    category: "ressourcen",
+    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/xqJbxqEDoAqplbhl.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/gvhhnlTvDmgPHFUq.pdf",
+  },
+  {
+    id: "erlaubnis-karte",
+    title: "Erlaubnis-Karte",
+    desc: "9 Erlaubnisse, die sich Angehörige oft nicht geben – gültig ab sofort, unbefristet.",
+    category: "ressourcen",
+    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OMXnbczdvCPBRNTA.webp",
+    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DSOVugQyCvvOACIO.pdf",
+  },
+];

--- a/client/src/content/verstehen.ts
+++ b/client/src/content/verstehen.ts
@@ -1,0 +1,70 @@
+export type VerstehenKategorie = "alle" | "grundlagen" | "neurobiologie";
+
+export type VerstehenInfografik = {
+  id: string;
+  title: string;
+  description: string;
+  category: Exclude<VerstehenKategorie, "alle">;
+  webpUrl: string;
+  pdfUrl: string;
+  alt: string;
+  featured?: boolean;
+};
+
+export const verstehenInfografiken: VerstehenInfografik[] = [
+  {
+    id: "leuchtturm",
+    title: "Der Leuchtturm",
+    description: "Ihre Rolle als Angehörige/r: Stabil bleiben trotz Sturm.",
+    category: "grundlagen",
+    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GbFCyQhEWIKomzXw.webp",
+    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DNGijMOYFghXAsLm.pdf",
+    alt: "Der Leuchtturm – Ihre Rolle als Angehörige/r",
+    featured: true,
+  },
+  {
+    id: "eisberg",
+    title: "Der Eisberg",
+    description: "Wut ist oft nur die Spitze – darunter liegen Schmerz und Angst.",
+    category: "grundlagen",
+    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MLLwefeyaKvtThbK.webp",
+    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RNKtfQQMvhlSyiIp.pdf",
+    alt: "Der Eisberg – Wut ist oft die Spitze",
+  },
+  {
+    id: "spaltung",
+    title: "Spaltung",
+    description: "Das Pendel zwischen Extremen – die Grauzone stärken.",
+    category: "grundlagen",
+    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WRORriPmZftmvKTL.webp",
+    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RtdVgflJuCNAhEKk.pdf",
+    alt: "Spaltung – das Pendel zwischen Extremen",
+  },
+  {
+    id: "alarm-modus",
+    title: "Alarm-Modus vs. Denk-Modus",
+    description: "Erst beruhigen, dann klären – warum Logik manchmal nicht ankommt.",
+    category: "neurobiologie",
+    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/sSUJoOUTiuWgrkiZ.webp",
+    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tlKAOpYHdCNAtovE.pdf",
+    alt: "Alarm-Modus vs. Denk-Modus",
+  },
+  {
+    id: "4-phasen",
+    title: "Der 4-Phasen-Zyklus",
+    description: "Das vorhersehbare Muster – Krisen folgen oft einem Ablauf.",
+    category: "neurobiologie",
+    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/BYDbBJaIhetrjHRq.webp",
+    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/PBYpNxZamAxjOHYd.pdf",
+    alt: "Der 4-Phasen-Zyklus",
+  },
+  {
+    id: "gehirn",
+    title: "Das Gehirn verstehen",
+    description: "Neurobiologie einfach erklärt – warum Stress Denken blockiert.",
+    category: "neurobiologie",
+    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/ImASzOTHYdFpxOUI.webp",
+    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/NViSBQtRBvGWOHPE.pdf",
+    alt: "Das Gehirn verstehen",
+  },
+];

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -3,135 +3,12 @@ import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
-import { Sparkles, TrendingUp, Heart, Clock, BookOpen, ExternalLink, ArrowRight, AlertTriangle, RefreshCw, Users, Download, Image as ImageIcon, Filter, Search, HandHeart } from "lucide-react";
-import { useState, useRef } from "react";
+import { Sparkles, TrendingUp, Heart, Clock, BookOpen, ExternalLink, ArrowRight, AlertTriangle, RefreshCw, Users, Download } from "lucide-react";
 import { Link } from "wouter";
 import CleanMindCheck from "@/components/interactive/CleanMindCheck";
 import ContentSection from "@/components/ContentSection";
 import { TableOfContents } from "@/components/UXEnhancements";
-
-const genesungCategories = [
-  { id: "alle", label: "Alle", icon: Filter },
-  { id: "verstehen", label: "Verstehen", icon: Search },
-  { id: "handeln", label: "Handeln", icon: HandHeart },
-];
-
-const genesungItems = [
-  {
-    title: "Genesung in Zahlen",
-    desc: "Orientierungs-Tracker mit Langzeitdaten",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tyFTHNjsUagqrXiS.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MunlHDCNqnsOhBFn.pdf",
-    category: "verstehen",
-  },
-  {
-    title: "Das Fortschritt-Paradox",
-    desc: "Warum Rückfälle zum Weg gehören",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DPkqytVYFcreeBlC.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/UFLdEEGIDxKdRUZO.pdf",
-    category: "verstehen",
-  },
-  {
-    title: "Remission vs. Heilung",
-    desc: "Was Besserung wirklich bedeutet",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/HPRsNmCUFirjnraj.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/KMjqRDjDjWVZpjhJ.pdf",
-    category: "verstehen",
-  },
-  {
-    title: "5 Faktoren, die Genesung fördern",
-    desc: "Säulen-Modell: Was positiv beeinflusst",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/mFhtxtPMBkCEVPII.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/qgrRYtMKOvwWmuah.pdf",
-    category: "handeln",
-  },
-  {
-    title: "Ihre Rolle im Genesungsprozess",
-    desc: "Was Sie tun können (und was nicht)",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GhgPDkJhqlqJkYzE.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/CZdiDaadpIWNOBFb.pdf",
-    category: "handeln",
-  },
-];
-
-function GenesungInfografiken() {
-  const [activeFilter, setActiveFilter] = useState("alle");
-  const gridRef = useRef<HTMLDivElement>(null);
-
-  const filteredItems = activeFilter === "alle"
-    ? genesungItems
-    : genesungItems.filter(i => i.category === activeFilter);
-
-  return (
-    <ContentSection
-      title="Genesung verstehen – auf einen Blick"
-      icon={<ImageIcon className="w-6 h-6 text-sage-dark" />}
-      id="infografiken"
-      preview="Alle Infografiken als hochauflösende PDFs zum Herunterladen und Ausdrucken."
-    >
-      <p className="text-muted-foreground mb-6">
-        Alle Infografiken als hochauflösende PDFs zum Herunterladen und Ausdrucken.{" "}
-        <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben rechts.
-      </p>
-
-      {/* Filter-Tabs */}
-      <div className="flex flex-wrap gap-2 mb-6">
-        {genesungCategories.map(cat => {
-          const count = cat.id === "alle" ? genesungItems.length : genesungItems.filter(i => i.category === cat.id).length;
-          return (
-            <Button
-              key={cat.id}
-              variant={activeFilter === cat.id ? "default" : "outline"}
-              size="sm"
-              onClick={() => {
-                setActiveFilter(cat.id);
-                setTimeout(() => {
-                  gridRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                }, 100);
-              }}
-              className={`whitespace-nowrap shrink-0 ${activeFilter === cat.id ? "bg-terracotta-mid hover:bg-terracotta-dark text-white" : ""}`}
-            >
-              <cat.icon className="w-4 h-4 mr-1.5" />
-              {cat.label} ({count})
-            </Button>
-          );
-        })}
-      </div>
-
-      <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        {filteredItems.map((item, index) => (
-          <Card key={item.title} className={`overflow-hidden border-border/50 hover:shadow-lg transition-all duration-500 group ${filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""}`}>
-            <div className="aspect-[3/4] overflow-hidden bg-muted">
-              <img src={item.img} alt={item.title} className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-700" loading="lazy" width={400} height={223} decoding="async" />
-            </div>
-            <CardContent className="p-4">
-              <h3 className="font-semibold text-foreground mb-1">{item.title}</h3>
-              <p className="text-muted-foreground text-sm mb-3">{item.desc}</p>
-              <a
-                href={item.pdf}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-              >
-                <ExternalLink className="w-4 h-4" />
-                PDF öffnen
-              </a>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-      <div className="text-center mt-8">
-        <Link href="/materialien">
-          <Button variant="outline">
-            Alle Materialien ansehen
-            <ArrowRight className="w-4 h-4 ml-2" />
-          </Button>
-        </Link>
-      </div>
-    </ContentSection>
-  );
-}
+import GenesungInfografikenSection from "@/sections/GenesungInfografikenSection";
 
 export default function Genesung() {
   return (
@@ -737,7 +614,7 @@ export default function Genesung() {
               </ContentSection>
 
               {/* ═══ 8. Infografiken zum Herunterladen ═══ */}
-              <GenesungInfografiken />
+              <GenesungInfografikenSection />
 
           </div>
         </div>

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -1,22 +1,22 @@
 import SEO from "@/components/SEO";
-import { useState, useRef } from "react";
+import { useState } from "react";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 import { 
   Sparkles, ArrowRight, CheckCircle2, Heart, AlertTriangle, Users, 
-  Clock, Brain, Wind, Lightbulb, Shield, BookOpen, Phone, Download, ExternalLink,
-  ChevronDown, ChevronUp, UserCircle, Filter, Activity, Zap
+  Clock, Brain, Wind, Lightbulb, Shield, BookOpen, Phone, Download,
+  ChevronDown, ChevronUp, UserCircle
 } from "lucide-react";
 import { Link } from "wouter";
+import SelbstfuersorgeInfografikenSection from "@/sections/SelbstfuersorgeInfografikenSection";
 import { kontaktById } from "@/data/kontakte";
 import GroundingTimer from "@/components/interactive/GroundingTimer";
 import SelbstfuersorgeCheck from "@/components/interactive/SelbstfuersorgeCheck";
 
 
 const proMente = kontaktById("INFO_PROMENTE")!;
-// useState and useRef imported at top
 import { TableOfContents } from "@/components/UXEnhancements";
 import ContentSection from "@/components/ContentSection";
 
@@ -155,70 +155,7 @@ function UebungAkkordeon({ title, icon: Icon, children, color }: {
   );
 }
 
-const selbstfuersorgeInfografiken = [
-  {
-    id: "warnsignale",
-    title: "Warnsignale der Überlastung",
-    desc: "Ampel-Stufenmodell: Grün → Gelb → Rot – erkennen Sie rechtzeitig, wann es zu viel wird.",
-    category: "erkennen",
-    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OEUNVdTyojBBYTic.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VdAxPxngFzgNImxg.pdf",
-    featured: true,
-  },
-  {
-    id: "sauerstoffmaske",
-    title: "Die Sauerstoffmaske",
-    desc: "Kreislauf-Diagramm: Teufelskreis vs. positiver Kreislauf – warum Selbstfürsorge keine Selbstsucht ist.",
-    category: "erkennen",
-    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/IQwhlqUMporMKdmH.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/yIWenSfOeiUHdMIc.pdf",
-  },
-  {
-    id: "radikale-akzeptanz",
-    title: "Radikale Akzeptanz",
-    desc: "2-Spalten-Vergleich: Was Radikale Akzeptanz NICHT ist vs. was sie IST, plus 4-Schritte-Übung.",
-    category: "techniken",
-    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OmxdguWaaXAkElDp.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/SkBpjnDHfNmPbmnd.pdf",
-  },
-  {
-    id: "stopp-technik",
-    title: "Die STOPP-Technik",
-    desc: "5 Schritte aus der Stressspirale: Stopp, Tief atmen, Orientieren, Perspektive, Plan – in 30 Sekunden.",
-    category: "techniken",
-    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/qvJDZrQvvOlErFQu.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VnQKfkkQbPunhDed.pdf",
-  },
-  {
-    id: "energie-konto",
-    title: "Ihr Energie-Konto",
-    desc: "Stock-&-Flow-Diagramm: Was füllt Ihre Batterie auf, was leert sie? Achten Sie auf die Balance.",
-    category: "ressourcen",
-    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/xqJbxqEDoAqplbhl.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/gvhhnlTvDmgPHFUq.pdf",
-  },
-  {
-    id: "erlaubnis-karte",
-    title: "Erlaubnis-Karte",
-    desc: "9 Erlaubnisse, die sich Angehörige oft nicht geben – gültig ab sofort, unbefristet.",
-    category: "ressourcen",
-    webp: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OMXnbczdvCPBRNTA.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DSOVugQyCvvOACIO.pdf",
-  },
-];
-
-const selbstfuersorgeCategories = [
-  { id: "alle", label: "Alle", icon: Filter, count: selbstfuersorgeInfografiken.length },
-  { id: "erkennen", label: "Erkennen", icon: Activity, count: selbstfuersorgeInfografiken.filter(i => i.category === "erkennen").length },
-  { id: "techniken", label: "Techniken", icon: Zap, count: selbstfuersorgeInfografiken.filter(i => i.category === "techniken").length },
-  { id: "ressourcen", label: "Ressourcen", icon: Heart, count: selbstfuersorgeInfografiken.filter(i => i.category === "ressourcen").length },
-];
-
 export default function Selbstfuersorge() {
-  const [sfActiveFilter, setSfActiveFilter] = useState("alle");
-  const sfGridRef = useRef<HTMLDivElement>(null);
-  const sfFilteredItems = sfActiveFilter === "alle" ? selbstfuersorgeInfografiken : selbstfuersorgeInfografiken.filter(i => i.category === sfActiveFilter);
-
   return (
     <Layout>
       <SEO title="Selbstfürsorge" description="Selbstfürsorge für Angehörige: Burnout vermeiden und eigene Bedürfnisse wahrnehmen." path="/selbstfuersorge" />
@@ -679,67 +616,7 @@ export default function Selbstfuersorge() {
               </ContentSection>
 
               {/* ═══ 8. Materialien zum Download ═══ */}
-              <ContentSection
-                title="Materialien zum Download"
-                icon={<Download className="w-6 h-6 text-sage-mid" />}
-                id="materialien-download"
-                preview="Infografiken als hochauflösende PDFs zum Herunterladen und Ausdrucken."
-              >
-                <p className="text-sm text-muted-foreground mb-4">
-                  <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben rechts.
-                </p>
-
-                {/* Filter Tabs */}
-                <div className="flex flex-wrap gap-2 mb-6">
-                  {selbstfuersorgeCategories.map((cat) => (
-                    <Button
-                      key={cat.id}
-                      variant={sfActiveFilter === cat.id ? "default" : "outline"}
-                      size="sm"
-                      onClick={() => {
-                        setSfActiveFilter(cat.id);
-                        setTimeout(() => {
-                          sfGridRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                        }, 50);
-                      }}
-                      className={`whitespace-nowrap shrink-0 ${sfActiveFilter === cat.id ? "bg-sage-dark hover:bg-sage-mid text-white" : ""}`}
-                    >
-                      <cat.icon className="w-4 h-4 mr-1.5" />
-                      {cat.label} ({cat.count})
-                    </Button>
-                  ))}
-                </div>
-
-                <div ref={sfGridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                  {sfFilteredItems.map((item) => (
-                    <Card key={item.id} className={`overflow-hidden border-border/50 hover:shadow-md transition-shadow ${item.featured && sfActiveFilter === "alle" ? "md:col-span-2" : ""}`}>
-                      <div className="aspect-[3/4] overflow-hidden bg-muted">
-                        <img src={item.webp} alt={item.title} className="w-full h-full object-cover object-top" loading="lazy" width={400} height={223} decoding="async" />
-                      </div>
-                      <CardContent className="p-4">
-                        <h3 className="font-medium text-foreground mb-1 text-sm">{item.title}</h3>
-                        <p className="text-xs text-muted-foreground mb-3">{item.desc}</p>
-                        <a
-                          href={item.pdf}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                          className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                        >
-                          <ExternalLink className="w-4 h-4" /> PDF öffnen
-                        </a>
-                      </CardContent>
-                    </Card>
-                  ))}
-                </div>
-                <div className="mt-4 text-center">
-                  <Link href="/materialien">
-                    <Button variant="outline" size="sm">
-                      Alle Materialien anzeigen
-                    </Button>
-                  </Link>
-                </div>
-              </ContentSection>
+              <SelbstfuersorgeInfografikenSection />
 
               {/* ═══ 9. Hinweise für Ihre Situation ═══ */}
               <ContentSection

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -1,86 +1,19 @@
-import { useState, useRef } from "react";
+import { useState } from "react";
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
-import { BookOpen, Brain, Heart, AlertCircle, Lightbulb, ArrowRight, ExternalLink, FileText, Clock, RefreshCw, Layers, Users, Activity, XCircle, Download, Filter } from "lucide-react";
+import { BookOpen, Brain, Heart, AlertCircle, Lightbulb, ArrowRight, ExternalLink, FileText, Clock, RefreshCw, Layers, Users, Activity, XCircle } from "lucide-react";
 import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
 import { TableOfContents } from "@/components/UXEnhancements";
 import ContentSection from "@/components/ContentSection";
 import MythosFlipCards from "@/components/interactive/MythosFlipCards";
 import EvidenceNote from "@/components/EvidenceNote";
+import VerstehenInfografikenSection from "@/sections/VerstehenInfografikenSection";
 
-
-const verstehenInfografiken = [
-  {
-    id: "leuchtturm",
-    title: "Der Leuchtturm",
-    description: "Ihre Rolle als Angehörige/r: Stabil bleiben trotz Sturm.",
-    category: "grundlagen",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GbFCyQhEWIKomzXw.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DNGijMOYFghXAsLm.pdf",
-    alt: "Der Leuchtturm – Ihre Rolle als Angehörige/r",
-    featured: true,
-  },
-  {
-    id: "eisberg",
-    title: "Der Eisberg",
-    description: "Wut ist oft nur die Spitze – darunter liegen Schmerz und Angst.",
-    category: "grundlagen",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MLLwefeyaKvtThbK.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RNKtfQQMvhlSyiIp.pdf",
-    alt: "Der Eisberg – Wut ist oft die Spitze",
-  },
-  {
-    id: "spaltung",
-    title: "Spaltung",
-    description: "Das Pendel zwischen Extremen – die Grauzone stärken.",
-    category: "grundlagen",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WRORriPmZftmvKTL.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RtdVgflJuCNAhEKk.pdf",
-    alt: "Spaltung – das Pendel zwischen Extremen",
-  },
-  {
-    id: "alarm-modus",
-    title: "Alarm-Modus vs. Denk-Modus",
-    description: "Erst beruhigen, dann klären – warum Logik manchmal nicht ankommt.",
-    category: "neurobiologie",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/sSUJoOUTiuWgrkiZ.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tlKAOpYHdCNAtovE.pdf",
-    alt: "Alarm-Modus vs. Denk-Modus",
-  },
-  {
-    id: "4-phasen",
-    title: "Der 4-Phasen-Zyklus",
-    description: "Das vorhersehbare Muster – Krisen folgen oft einem Ablauf.",
-    category: "neurobiologie",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/BYDbBJaIhetrjHRq.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/PBYpNxZamAxjOHYd.pdf",
-    alt: "Der 4-Phasen-Zyklus",
-  },
-  {
-    id: "gehirn",
-    title: "Das Gehirn verstehen",
-    description: "Neurobiologie einfach erklärt – warum Stress Denken blockiert.",
-    category: "neurobiologie",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/ImASzOTHYdFpxOUI.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/NViSBQtRBvGWOHPE.pdf",
-    alt: "Das Gehirn verstehen",
-  },
-];
-
-const verstehenCategories = [
-  { id: "alle", label: "Alle", icon: Filter, count: verstehenInfografiken.length },
-  { id: "grundlagen", label: "Grundlagen", icon: BookOpen, count: verstehenInfografiken.filter(i => i.category === "grundlagen").length },
-  { id: "neurobiologie", label: "Neurobiologie", icon: Brain, count: verstehenInfografiken.filter(i => i.category === "neurobiologie").length },
-];
 
 export default function Verstehen() {
-  const [activeFilter, setActiveFilter] = useState("alle");
-  const gridRef = useRef<HTMLDivElement>(null);
-  const filteredItems = activeFilter === "alle" ? verstehenInfografiken : verstehenInfografiken.filter(i => i.category === activeFilter);
-
   return (
     <Layout>
       <SEO title="Borderline verstehen" description="Was ist Borderline-Persönlichkeitsstörung? Symptome, Ursachen und Auswirkungen verständlich erklärt." path="/verstehen" />
@@ -542,78 +475,7 @@ export default function Verstehen() {
             </ContentSection>
 
             {/* Materialien zum Download – Kategorie 1: Verstehen */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              className="mb-12 wave-divider-top"
-              id="materialien"
-              style={{ '--wave-color': 'var(--background)' } as React.CSSProperties}
-            >
-              <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
-                <Download className="w-8 h-8 text-sage-dark" />
-                Infografiken zum Thema
-              </h2>
-              
-              <p className="text-muted-foreground mb-6">
-                Vorschau = Web-Bild. «PDF öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben rechts.
-              </p>
-
-              {/* Filter Tabs */}
-              <div className="flex flex-wrap gap-2 mb-6">
-                {verstehenCategories.map((cat) => (
-                  <Button
-                    key={cat.id}
-                    variant={activeFilter === cat.id ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => {
-                      setActiveFilter(cat.id);
-                      setTimeout(() => {
-                        gridRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                      }, 50);
-                    }}
-                    className={`whitespace-nowrap shrink-0 ${activeFilter === cat.id ? "bg-sage-dark hover:bg-sage-mid text-white" : ""}`}
-                  >
-                    <cat.icon className="w-4 h-4 mr-1.5" />
-                    {cat.label} ({cat.count})
-                  </Button>
-                ))}
-              </div>
-              
-              <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {filteredItems.map((item) => (
-                  <Card key={item.id} className={`${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""} overflow-hidden hover:shadow-lg transition-shadow`}>
-                    <button type="button" className="aspect-[3/4] bg-muted cursor-pointer w-full" onClick={() => window.open(item.webpUrl, '_blank')} aria-label={`${item.alt} – Vorschau öffnen`}>
-                      <img
-                        src={item.webpUrl}
-                        alt={item.alt}
-                        className="w-full h-full object-cover object-top"
-                        loading="lazy"
-                        width={400}
-                        height={223}
-                        decoding="async"
-                      />
-                    </button>
-                    <CardContent className="p-4">
-                      <h3 className="font-medium text-foreground mb-1">{item.title}</h3>
-                      <p className="text-sm text-muted-foreground mb-3">{item.description}</p>
-                      <a href={item.pdfUrl} target="_blank" rel="noopener noreferrer" aria-label={`PDF öffnen: ${item.title} (neuer Tab)`} className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors">
-                        <ExternalLink className="w-4 h-4" />
-                        PDF öffnen
-                      </a>
-                    </CardContent>
-                  </Card>
-                ))}
-              </div>
-
-              <div className="mt-6 text-center">
-                <Link href="/materialien">
-                  <Button variant="outline">
-                    Alle Materialien anzeigen
-                  </Button>
-                </Link>
-              </div>
-            </motion.div>
+            <VerstehenInfografikenSection />
 
             {/* Hoffnung */}
             <motion.div

--- a/client/src/sections/GenesungInfografikenSection.tsx
+++ b/client/src/sections/GenesungInfografikenSection.tsx
@@ -1,0 +1,92 @@
+import { useRef, useState } from "react";
+import { Link } from "wouter";
+import { ArrowRight, ExternalLink, Filter, HandHeart, Image as ImageIcon, Search } from "lucide-react";
+import ContentSection from "@/components/ContentSection";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { genesungCategories, genesungItems, type GenesungKategorie } from "@/content/genesung";
+
+const genesungIcons = {
+  alle: Filter,
+  verstehen: Search,
+  handeln: HandHeart,
+} as const;
+
+export default function GenesungInfografikenSection() {
+  const [activeFilter, setActiveFilter] = useState<GenesungKategorie>("alle");
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const filteredItems = activeFilter === "alle"
+    ? genesungItems
+    : genesungItems.filter((item) => item.category === activeFilter);
+
+  return (
+    <ContentSection
+      title="Genesung verstehen – auf einen Blick"
+      icon={<ImageIcon className="w-6 h-6 text-sage-dark" />}
+      id="infografiken"
+      preview="Alle Infografiken als hochauflösende PDFs zum Herunterladen und Ausdrucken."
+    >
+      <p className="text-muted-foreground mb-6">
+        Alle Infografiken als hochauflösende PDFs zum Herunterladen und Ausdrucken.{" "}
+        <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben rechts.
+      </p>
+
+      <div className="flex flex-wrap gap-2 mb-6">
+        {genesungCategories.map((cat) => {
+          const Icon = genesungIcons[cat.id];
+          const count = cat.id === "alle" ? genesungItems.length : genesungItems.filter((item) => item.category === cat.id).length;
+          return (
+            <Button
+              key={cat.id}
+              variant={activeFilter === cat.id ? "default" : "outline"}
+              size="sm"
+              onClick={() => {
+                setActiveFilter(cat.id);
+                setTimeout(() => {
+                  gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                }, 100);
+              }}
+              className={`whitespace-nowrap shrink-0 ${activeFilter === cat.id ? "bg-terracotta-mid hover:bg-terracotta-dark text-white" : ""}`}
+            >
+              <Icon className="w-4 h-4 mr-1.5" />
+              {cat.label} ({count})
+            </Button>
+          );
+        })}
+      </div>
+
+      <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+        {filteredItems.map((item, index) => (
+          <Card key={item.title} className={`overflow-hidden border-border/50 hover:shadow-lg transition-all duration-500 group ${filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""}`}>
+            <div className="aspect-[3/4] overflow-hidden bg-muted">
+              <img src={item.img} alt={item.title} className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-700" loading="lazy" width={400} height={223} decoding="async" />
+            </div>
+            <CardContent className="p-4">
+              <h3 className="font-semibold text-foreground mb-1">{item.title}</h3>
+              <p className="text-muted-foreground text-sm mb-3">{item.desc}</p>
+              <a
+                href={item.pdf}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+              >
+                <ExternalLink className="w-4 h-4" />
+                PDF öffnen
+              </a>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+      <div className="text-center mt-8">
+        <Link href="/materialien">
+          <Button variant="outline">
+            Alle Materialien ansehen
+            <ArrowRight className="w-4 h-4 ml-2" />
+          </Button>
+        </Link>
+      </div>
+    </ContentSection>
+  );
+}

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -1,0 +1,87 @@
+import { useRef, useState } from "react";
+import { Link } from "wouter";
+import { ExternalLink, Download, Filter, Activity, Zap, Heart } from "lucide-react";
+import ContentSection from "@/components/ContentSection";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { selbstfuersorgeInfografiken, type SelbstfuersorgeKategorie } from "@/content/selbstfuersorge";
+
+const selbstfuersorgeCategories = [
+  { id: "alle", label: "Alle", icon: Filter, count: selbstfuersorgeInfografiken.length },
+  { id: "erkennen", label: "Erkennen", icon: Activity, count: selbstfuersorgeInfografiken.filter((i) => i.category === "erkennen").length },
+  { id: "techniken", label: "Techniken", icon: Zap, count: selbstfuersorgeInfografiken.filter((i) => i.category === "techniken").length },
+  { id: "ressourcen", label: "Ressourcen", icon: Heart, count: selbstfuersorgeInfografiken.filter((i) => i.category === "ressourcen").length },
+] as const;
+
+export default function SelbstfuersorgeInfografikenSection() {
+  const [activeFilter, setActiveFilter] = useState<SelbstfuersorgeKategorie>("alle");
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const filteredItems = activeFilter === "alle"
+    ? selbstfuersorgeInfografiken
+    : selbstfuersorgeInfografiken.filter((item) => item.category === activeFilter);
+
+  return (
+    <ContentSection
+      title="Materialien zum Download"
+      icon={<Download className="w-6 h-6 text-sage-mid" />}
+      id="materialien-download"
+      preview="Infografiken als hochauflösende PDFs zum Herunterladen und Ausdrucken."
+    >
+      <p className="text-sm text-muted-foreground mb-4">
+        <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben rechts.
+      </p>
+
+      <div className="flex flex-wrap gap-2 mb-6">
+        {selbstfuersorgeCategories.map((cat) => (
+          <Button
+            key={cat.id}
+            variant={activeFilter === cat.id ? "default" : "outline"}
+            size="sm"
+            onClick={() => {
+              setActiveFilter(cat.id);
+              setTimeout(() => {
+                gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+              }, 50);
+            }}
+            className={`whitespace-nowrap shrink-0 ${activeFilter === cat.id ? "bg-sage-dark hover:bg-sage-mid text-white" : ""}`}
+          >
+            <cat.icon className="w-4 h-4 mr-1.5" />
+            {cat.label} ({cat.count})
+          </Button>
+        ))}
+      </div>
+
+      <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {filteredItems.map((item) => (
+          <Card key={item.id} className={`overflow-hidden border-border/50 hover:shadow-md transition-shadow ${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""}`}>
+            <div className="aspect-[3/4] overflow-hidden bg-muted">
+              <img src={item.webp} alt={item.title} className="w-full h-full object-cover object-top" loading="lazy" width={400} height={223} decoding="async" />
+            </div>
+            <CardContent className="p-4">
+              <h3 className="font-medium text-foreground mb-1 text-sm">{item.title}</h3>
+              <p className="text-xs text-muted-foreground mb-3">{item.desc}</p>
+              <a
+                href={item.pdf}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+              >
+                <ExternalLink className="w-4 h-4" /> PDF öffnen
+              </a>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="mt-4 text-center">
+        <Link href="/materialien">
+          <Button variant="outline" size="sm">
+            Alle Materialien anzeigen
+          </Button>
+        </Link>
+      </div>
+    </ContentSection>
+  );
+}

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -1,0 +1,96 @@
+import { type CSSProperties, useRef, useState } from "react";
+import { motion } from "framer-motion";
+import { Link } from "wouter";
+import { BookOpen, Brain, Download, ExternalLink, Filter } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { verstehenInfografiken, type VerstehenKategorie } from "@/content/verstehen";
+
+const verstehenCategories = [
+  { id: "alle", label: "Alle", icon: Filter, count: verstehenInfografiken.length },
+  { id: "grundlagen", label: "Grundlagen", icon: BookOpen, count: verstehenInfografiken.filter((i) => i.category === "grundlagen").length },
+  { id: "neurobiologie", label: "Neurobiologie", icon: Brain, count: verstehenInfografiken.filter((i) => i.category === "neurobiologie").length },
+] as const;
+
+export default function VerstehenInfografikenSection() {
+  const [activeFilter, setActiveFilter] = useState<VerstehenKategorie>("alle");
+  const gridRef = useRef<HTMLDivElement>(null);
+
+  const filteredItems = activeFilter === "alle"
+    ? verstehenInfografiken
+    : verstehenInfografiken.filter((item) => item.category === activeFilter);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      className="mb-12 wave-divider-top"
+      id="materialien"
+      style={{ '--wave-color': 'var(--background)' } as CSSProperties}
+    >
+      <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
+        <Download className="w-8 h-8 text-sage-dark" />
+        Infografiken zum Thema
+      </h2>
+
+      <p className="text-muted-foreground mb-6">
+        Vorschau = Web-Bild. «PDF öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben rechts.
+      </p>
+
+      <div className="flex flex-wrap gap-2 mb-6">
+        {verstehenCategories.map((cat) => (
+          <Button
+            key={cat.id}
+            variant={activeFilter === cat.id ? "default" : "outline"}
+            size="sm"
+            onClick={() => {
+              setActiveFilter(cat.id);
+              setTimeout(() => {
+                gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+              }, 50);
+            }}
+            className={`whitespace-nowrap shrink-0 ${activeFilter === cat.id ? "bg-sage-dark hover:bg-sage-mid text-white" : ""}`}
+          >
+            <cat.icon className="w-4 h-4 mr-1.5" />
+            {cat.label} ({cat.count})
+          </Button>
+        ))}
+      </div>
+
+      <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {filteredItems.map((item) => (
+          <Card key={item.id} className={`${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""} overflow-hidden hover:shadow-lg transition-shadow`}>
+            <button type="button" className="aspect-[3/4] bg-muted cursor-pointer w-full" onClick={() => window.open(item.webpUrl, '_blank')} aria-label={`${item.alt} – Vorschau öffnen`}>
+              <img
+                src={item.webpUrl}
+                alt={item.alt}
+                className="w-full h-full object-cover object-top"
+                loading="lazy"
+                width={400}
+                height={223}
+                decoding="async"
+              />
+            </button>
+            <CardContent className="p-4">
+              <h3 className="font-medium text-foreground mb-1">{item.title}</h3>
+              <p className="text-sm text-muted-foreground mb-3">{item.description}</p>
+              <a href={item.pdfUrl} target="_blank" rel="noopener noreferrer" aria-label={`PDF öffnen: ${item.title} (neuer Tab)`} className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors">
+                <ExternalLink className="w-4 h-4" />
+                PDF öffnen
+              </a>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="mt-6 text-center">
+        <Link href="/materialien">
+          <Button variant="outline">
+            Alle Materialien anzeigen
+          </Button>
+        </Link>
+      </div>
+    </motion.div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Reduce page file size and separate static content from UI logic so content can be edited without touching page code.
- Encapsulate the infographics/download blocks into small, reusable section components to keep pages focused on layout and flow.

### Description

- Extracted static datasets and types into new content modules: `client/src/content/selbstfuersorge.ts`, `client/src/content/verstehen.ts`, and `client/src/content/genesung.ts`, which export the infographic arrays and category/type definitions.
- Implemented focused section components that own filtering state and rendering for the materials blocks: `client/src/sections/SelbstfuersorgeInfografikenSection.tsx`, `client/src/sections/VerstehenInfografikenSection.tsx`, and `client/src/sections/GenesungInfografikenSection.tsx`.
- Updated pages `client/src/pages/Selbstfuersorge.tsx`, `client/src/pages/Verstehen.tsx`, and `client/src/pages/Genesung.tsx` to import and use the new section components and removed the large inline data/UI blocks and unused imports.
- Added TypeScript types for content items and adjusted minor typings in the sections (made `featured` optional and imported `CSSProperties` where needed) to resolve type errors.

### Testing

- Ran the TypeScript check with `pnpm -s tsc --noEmit`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2c6d881e0833298422d22fa245fb0)