### PR TITLE
feat(client): introduce domain layer primitives

### DIFF
--- a/client/src/components/layout/navigationData.ts
+++ b/client/src/components/layout/navigationData.ts
@@ -1,29 +1,6 @@
-import { BookMarked, BookOpen, Building2, Download, Heart, HelpCircle, MessageCircle, Phone, Shield, Sparkles, Stethoscope, TrendingUp, Users } from "lucide-react";
-import type { LucideIcon } from "lucide-react";
+import { primaryNavigationItems, resourceNavigationItems } from "@/domain/navigation";
 
-export interface NavItem {
-  href: string;
-  label: string;
-  icon: LucideIcon;
-}
+export { type NavigationItem as NavItem } from "@/domain/content-types";
 
-export const navItems: NavItem[] = [
-  { href: "/verstehen", label: "Verstehen", icon: BookOpen },
-  { href: "/unterstuetzen/uebersicht", label: "Unterstützen", icon: Heart },
-  { href: "/kommunizieren", label: "Kommunizieren", icon: MessageCircle },
-  { href: "/grenzen", label: "Grenzen", icon: Shield },
-  { href: "/selbstfuersorge", label: "Selbstfürsorge", icon: Sparkles },
-  { href: "/genesung", label: "Genesung", icon: TrendingUp },
-  { href: "/beratung", label: "Beratung", icon: Users },
-];
-
-export const ressourcenItems: NavItem[] = [
-  { href: "/soforthilfe", label: "Soforthilfe", icon: Phone },
-  { href: "/materialien", label: "Materialien & Handouts", icon: Download },
-  { href: "/beratung", label: "Beratung & Netzwerke", icon: Users },
-  { href: "/fachstelle", label: "Fachstelle & Kontakt", icon: Building2 },
-  { href: "/faq", label: "Häufige Fragen (FAQ)", icon: HelpCircle },
-  { href: "/glossar", label: "Glossar", icon: BookMarked },
-  { href: "/buchempfehlungen", label: "Buchempfehlungen", icon: BookOpen },
-  { href: "/unterstuetzen/therapie#therapieangebote", label: "Therapieangebote Zürich", icon: Stethoscope },
-];
+export const navItems = primaryNavigationItems;
+export const ressourcenItems = resourceNavigationItems;

--- a/client/src/domain/content-types.ts
+++ b/client/src/domain/content-types.ts
@@ -1,0 +1,42 @@
+import type { LucideIcon } from "lucide-react";
+
+export interface NavigationItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+}
+
+export interface SelectableCategory<TId extends string = string> {
+  id: TId;
+  label: string;
+}
+
+export interface ResourceFilter<TValue extends string = string> {
+  value: TValue;
+  label: string;
+}
+
+export interface PageSection {
+  id: string;
+  title: string;
+  description?: string;
+}
+
+export interface ResourceCard {
+  id: string;
+  title: string;
+  description: string;
+  href: string;
+  category: string;
+  type?: string;
+  tags?: string[];
+}
+
+export interface EvidenceSource {
+  title: string;
+  authors?: string;
+  year?: number;
+  source: string;
+  url?: string;
+  note?: string;
+}

--- a/client/src/domain/navigation.ts
+++ b/client/src/domain/navigation.ts
@@ -1,0 +1,37 @@
+import {
+  BookMarked,
+  BookOpen,
+  Building2,
+  Download,
+  Heart,
+  HelpCircle,
+  MessageCircle,
+  Phone,
+  Shield,
+  Sparkles,
+  Stethoscope,
+  TrendingUp,
+  Users,
+} from "lucide-react";
+import type { NavigationItem } from "@/domain/content-types";
+
+export const primaryNavigationItems: NavigationItem[] = [
+  { href: "/verstehen", label: "Verstehen", icon: BookOpen },
+  { href: "/unterstuetzen/uebersicht", label: "Unterstützen", icon: Heart },
+  { href: "/kommunizieren", label: "Kommunizieren", icon: MessageCircle },
+  { href: "/grenzen", label: "Grenzen", icon: Shield },
+  { href: "/selbstfuersorge", label: "Selbstfürsorge", icon: Sparkles },
+  { href: "/genesung", label: "Genesung", icon: TrendingUp },
+  { href: "/beratung", label: "Beratung", icon: Users },
+];
+
+export const resourceNavigationItems: NavigationItem[] = [
+  { href: "/soforthilfe", label: "Soforthilfe", icon: Phone },
+  { href: "/materialien", label: "Materialien & Handouts", icon: Download },
+  { href: "/beratung", label: "Beratung & Netzwerke", icon: Users },
+  { href: "/fachstelle", label: "Fachstelle & Kontakt", icon: Building2 },
+  { href: "/faq", label: "Häufige Fragen (FAQ)", icon: HelpCircle },
+  { href: "/glossar", label: "Glossar", icon: BookMarked },
+  { href: "/buchempfehlungen", label: "Buchempfehlungen", icon: BookOpen },
+  { href: "/unterstuetzen/therapie#therapieangebote", label: "Therapieangebote Zürich", icon: Stethoscope },
+];

--- a/client/src/domain/resources.ts
+++ b/client/src/domain/resources.ts
@@ -1,0 +1,32 @@
+import type { ResourceFilter, SelectableCategory } from "@/domain/content-types";
+
+export type MainResourceCategoryId =
+  | "alle"
+  | "verstehen"
+  | "kommunizieren"
+  | "unterstuetzen"
+  | "grenzen"
+  | "selbstfuersorge"
+  | "genesung"
+  | "soforthilfe";
+
+export const mainResourceCategories: SelectableCategory<MainResourceCategoryId>[] = [
+  { id: "alle", label: "Alle" },
+  { id: "verstehen", label: "Verstehen" },
+  { id: "kommunizieren", label: "Kommunizieren" },
+  { id: "unterstuetzen", label: "Unterstützen" },
+  { id: "grenzen", label: "Grenzen" },
+  { id: "selbstfuersorge", label: "Selbstfürsorge" },
+  { id: "genesung", label: "Genesung" },
+  { id: "soforthilfe", label: "Soforthilfe" },
+];
+
+export type ResourceTypeId = "alle" | "infografik" | "checkliste" | "arbeitsblatt" | "notfallhilfe";
+
+export const resourceTypeFilters: ResourceFilter<ResourceTypeId>[] = [
+  { value: "alle", label: "Alle Typen" },
+  { value: "infografik", label: "Infografik" },
+  { value: "checkliste", label: "Checkliste" },
+  { value: "arbeitsblatt", label: "Arbeitsblatt" },
+  { value: "notfallhilfe", label: "Notfallhilfe" },
+];


### PR DESCRIPTION
### Motivation

- Centralize reusable frontend domain concepts (navigation, resource categories, shared content types) to avoid duplication across pages.
- Provide shared TypeScript interfaces to improve consistency and type-safety for page sections, resource cards and evidence metadata.
- Prepare a single source of truth for navigation and resource filters so multiple components/pages can consume the same definitions.

### Description

- Add `client/src/domain/content-types.ts` which defines shared interfaces and helper types such as `NavigationItem`, `PageSection`, `ResourceCard`, `EvidenceSource`, `SelectableCategory` and `ResourceFilter`.
- Add `client/src/domain/navigation.ts` which exports `primaryNavigationItems` and `resourceNavigationItems` arrays with labels, icons and `href` targets.
- Add `client/src/domain/resources.ts` which exports `mainResourceCategories` and `resourceTypeFilters` along with related ID types for reuse across pages.
- Update `client/src/components/layout/navigationData.ts` to import navigation arrays from the new domain layer and re-export the `NavigationItem` type as `NavItem` while preserving the existing `navItems`/`ressourcenItems` API.

### Testing

- Ran TypeScript check with `pnpm -s tsc --noEmit` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ca66bb9c8332af0fcc13de492edf)