### PR TITLE
Add minimal audit scripts for lint, typecheck and test

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "preview": "vite preview --host",
+    "lint": "npm run check",
+    "typecheck": "npm run check",
+    "test": "vitest run --passWithNoTests",
     "check": "tsc --noEmit",
     "format": "prettier --write ."
   },


### PR DESCRIPTION
### Motivation
- The verification audit `_dev/REFACTOR-VERIFICATION-AUDIT-2026-03-24.md` reported missing npm scripts (`lint`, `typecheck`, `test`) as a P1 tooling/process gap, so a minimal fix is required to make standard checks directly runnable.

### Description
- Added three minimal scripts to `package.json`: `lint` -> `npm run check`, `typecheck` -> `npm run check`, and `test` -> `vitest run --passWithNoTests`, with no other code, routing, layout, or content changes.

### Testing
- Executed `npm run lint`, `npm run typecheck`, `npm test`, and `npm run build`; all commands completed successfully (`npm test` found no tests and exited 0), and `npm run build` succeeded while preserving the existing Vite env warnings for `VITE_ANALYTICS_*`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2ce3fb8488332806c2e238a2d1542)