### PR TITLE
Top‑Zone harmonisiert und kleine Grid-/Layout‑Feinheiten geglättet

### DIFF
--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -93,40 +93,42 @@ export function Breadcrumbs() {
   const backLabel = parent?.label || "Startseite";
 
   return (
-    <nav className="container py-3" aria-label="Breadcrumb">
-      <div className="flex items-center justify-between">
-        {/* Zurück-Pfeil (Mobile: prominent, Desktop: dezent) */}
-        <Link
-          href={backHref}
-          className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors group sm:hidden"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          <span>{backLabel}</span>
-        </Link>
+    <div className="border-b border-border/40 bg-background/60">
+      <nav className="container py-3" aria-label="Breadcrumb">
+        <div className="flex items-center justify-between">
+          {/* Zurück-Pfeil (Mobile: prominent, Desktop: dezent) */}
+          <Link
+            href={backHref}
+            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors group sm:hidden"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            <span>{backLabel}</span>
+          </Link>
 
-        {/* Desktop Breadcrumb-Pfad */}
-        <ol className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground">
-          <li>
-            <Link href="/" className="flex items-center gap-1 hover:text-foreground transition-colors">
-              <Home className="w-4 h-4" />
-              <span>Startseite</span>
-            </Link>
-          </li>
-          {parent && (
-            <li className="flex items-center gap-2">
-              <ChevronRight className="w-4 h-4 text-muted-foreground/50" />
-              <Link href={parent.href} className="hover:text-foreground transition-colors">
-                {parent.label}
+          {/* Desktop Breadcrumb-Pfad */}
+          <ol className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground">
+            <li>
+              <Link href="/" className="flex items-center gap-1 hover:text-foreground transition-colors">
+                <Home className="w-4 h-4" />
+                <span>Startseite</span>
               </Link>
             </li>
-          )}
-          <li className="flex items-center gap-2">
-            <ChevronRight className="w-4 h-4 text-muted-foreground/50" />
-            <span className="text-foreground font-medium">{pageName}</span>
-          </li>
-        </ol>
-      </div>
-    </nav>
+            {parent && (
+              <li className="flex items-center gap-2">
+                <ChevronRight className="w-4 h-4 text-muted-foreground/50" />
+                <Link href={parent.href} className="hover:text-foreground transition-colors">
+                  {parent.label}
+                </Link>
+              </li>
+            )}
+            <li className="flex items-center gap-2">
+              <ChevronRight className="w-4 h-4 text-muted-foreground/50" />
+              <span className="text-foreground font-medium">{pageName}</span>
+            </li>
+          </ol>
+        </div>
+      </nav>
+    </div>
   );
 }
 

--- a/client/src/components/interactive/Schnelleinstieg.tsx
+++ b/client/src/components/interactive/Schnelleinstieg.tsx
@@ -60,7 +60,7 @@ export default function Schnelleinstieg() {
           </p>
         </div>
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 max-w-3xl mx-auto">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 md:gap-4 max-w-4xl mx-auto">
           {needs.map((need) => {
             const Icon = need.icon;
             return (

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -221,7 +221,7 @@ export default function Grenzen() {
                 ].map((item, index) => {
                   const Icon = item.icon;
                   return (
-                    <Card key={index} className={`border-border/50 hover:shadow-md transition-all duration-500 ${index === 0 ? "sm:col-span-2" : ""}`} style={{ borderTopWidth: '4px', borderTopColor: item.color }}>
+                    <Card key={index} className="border-border/50 hover:shadow-md transition-all duration-500" style={{ borderTopWidth: '4px', borderTopColor: item.color }}>
                       <CardContent className="p-5">
                         <div className="flex items-start gap-4 mb-3">
                           <div 
@@ -539,8 +539,8 @@ export default function Grenzen() {
               </div>
               
               <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {filteredItems.map((item, index) => (
-                  <Card key={item.title} className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""}`}>
+                {filteredItems.map((item) => (
+                  <Card key={item.title} className="h-full overflow-hidden hover:shadow-lg transition-all duration-500 group">
                     <div className="relative aspect-[3/4] bg-muted overflow-hidden">
                       <img 
                         src={item.url} 

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -578,7 +578,7 @@ export default function Kommunizieren() {
                 <span><strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben rechts.</span>
               </p>
               {/* Filter-Tabs */}
-              <div className="flex gap-2 overflow-x-auto pb-3 mb-6 scrollbar-none -mx-1 px-1">
+              <div className="flex gap-2 overflow-x-auto pb-3 mb-6 scrollbar-none -mx-4 px-4 md:mx-0 md:px-0 md:flex-wrap md:overflow-visible">
                 {kommSubcategories.map((cat) => {
                   const Icon = cat.icon;
                   const count = cat.id === "alle"
@@ -605,9 +605,9 @@ export default function Kommunizieren() {
                 })}
               </div>
               
-              <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-                {filteredItems.map((item, index) => (
-                  <Card key={item.title} className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""}`}>
+              <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-stretch mb-6">
+                {filteredItems.map((item) => (
+                  <Card key={item.title} className="h-full overflow-hidden hover:shadow-lg transition-all duration-500 group">
                     <div className="aspect-[4/3] bg-muted">
                       <img src={item.url} alt={item.title} className="w-full h-full object-cover object-top" loading="lazy" width={400} height={223} decoding="async" />
                     </div>


### PR DESCRIPTION
### Motivation
- Beseitige eine sichtbare Inkonsistenz in der Breiten-/Kantenlogik der Top‑Zone (Header / Hinweisleiste / Breadcrumb) und gleiche horizontale Fluchtlinien an.  
- Leichte Flächennutzungsverbesserungen auf großen Viewports für bestimmte Kachel‑Module ohne Redesign.  
- Beruhige vereinzelte mixed‑Grids und mobile Chip‑Scroller, die zu unruhiger Wahrnehmung führten, mit minimalinvasiven Utility‑Fixes.

### Description
- Harmonisiert die Breadcrumb‑Zone, indem die Navigation in eine dezente vollbreite Strip‑Zone gelegt wird und weiterhin `container` für Innenabstände verwendet wird (`client/src/components/UXEnhancements.tsx`).
- Erhöht die maximale Breite des `Schnelleinstieg`‑Grids von `max-w-3xl` auf `max-w-4xl` zur besseren Flächenausnutzung auf großen Desktops (`client/src/components/interactive/Schnelleinstieg.tsx`).
- Entfernt bedingte `sm:col-span-2` Hervorhebungen im „Arten von Grenzen“ Grid, sodass alle Karten gleichmäßiger spalten (`client/src/pages/Grenzen.tsx`).
- Entfernt die bedingte Hero‑Spalte im Materialien‑Grid und setzt Karten auf `h-full`, um Sprünge bei Filterwechseln zu vermeiden und Box‑Heights zu stabilisieren (`client/src/pages/Grenzen.tsx`).
- Gleicht die mobile Filter/Chip‑Scroller‑Logik in `/kommunizieren` an das bereits etablierte Edge‑to‑Edge‑Pattern an (`-mx-4 px-4 md:mx-0 md:px-0 md:flex-wrap md:overflow-visible`) und vereinheitlicht damit das Verhalten mit `/materialien` (`client/src/pages/Kommunizieren.tsx`).
- Verbessert Kartenraster‑Konsistenz in `/kommunizieren` durch `items-stretch` auf dem Grid und `h-full` auf Cards, und entfernt die einzelne `sm:col-span-2` Hervorhebung, damit die Kacheln visuell ruhiger ausgerichtet sind (`client/src/pages/Kommunizieren.tsx`).

### Testing
- `npm run check` (`tsc --noEmit`) wurde ausgeführt und lief erfolgreich (Exit 0).  
- `npm run test` (Vitest) wurde ausgeführt, fand keine Testdateien und beendete sich mit Exit 0 (kein Fehler).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d135b5288332911b917baf2af0a5)