### PR TITLE
Align MedicalPageSchema labels with ICD-11 6D11

### DIFF
--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -99,8 +99,8 @@ export function MedicalPageSchema({ title, description, path }: { title: string;
     "inLanguage": "de",
     "about": {
       "@type": "MedicalCondition",
-      "name": "Borderline-Persönlichkeitsstörung",
-      "alternateName": ["BPS", "Emotional instabile Persönlichkeitsstörung"],
+      "name": "Persönlichkeitsstörung mit Borderline-Muster",
+      "alternateName": ["Borderline-Muster", "Borderline pattern"],
       "code": {
         "@type": "MedicalCode",
         "code": "6D11",


### PR DESCRIPTION
### Motivation
- Align the human-readable diagnosis labels in `MedicalPageSchema` with the already-present ICD-11 code `6D11` so schema semantics are consistent.

### Description
- In `client/src/components/SEO.tsx` updated the `about` block of `MedicalPageSchema` to set `name` to "Persönlichkeitsstörung mit Borderline-Muster" and `alternateName` to [`"Borderline-Muster"`, `"Borderline pattern"`], leaving the `code` (`"6D11"`) and `codingSystem` (`"ICD-11"`) unchanged and limiting changes to that block.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d6c9a85883329ae2dcc3db67d593)