### PR TITLE
P0: DSM/ICD‑Kurzabschnitt, Materialien‑Taxonomie und Search‑Mapping anpassen

### DIFF
--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -433,28 +433,28 @@ const searchableContent = [
     title: "Therapieangebote im Kanton Zürich",
     description: "Spezialisierte Borderline-Behandlung an der PUK Zürich",
     keywords: ["therapie", "zürich", "puk", "behandlung", "angebot", "kanton"],
-    href: "/unterstuetzen/therapie#therapieangebote",
+    href: "/unterstuetzen/therapie",
     section: "Therapie"
   },
   {
     title: "DBT-Station PUK Zürich",
     description: "Stationäre DBT-Behandlung für Erwachsene in Rheinau",
     keywords: ["dbt", "station", "stationär", "rheinau", "puk", "erwachsene"],
-    href: "/unterstuetzen/therapie#therapieangebote",
+    href: "/unterstuetzen/therapie",
     section: "Therapie"
   },
   {
     title: "HYPE ZÜRI – Frühintervention für Jugendliche",
     description: "Spezialisiertes Programm für Jugendliche ab 13 Jahren",
     keywords: ["hype", "jugendliche", "früh", "intervention", "13", "teenager"],
-    href: "/unterstuetzen/therapie#therapieangebote",
+    href: "/unterstuetzen/therapie",
     section: "Therapie"
   },
   {
     title: "PUK Erwachsene (ab 65) Zürich",
     description: "Psychiatrische Versorgung für Erwachsene ab 65 Jahren",
     keywords: ["alter", "senioren", "65", "alterspsychiatrie", "puk"],
-    href: "/unterstuetzen/therapie#therapieangebote",
+    href: "/unterstuetzen/therapie",
     section: "Therapie"
   },
   

--- a/client/src/pages/Materialien.tsx
+++ b/client/src/pages/Materialien.tsx
@@ -418,7 +418,7 @@ export default function Materialien() {
                     Alle 31 Materialien verfügbar
                   </h2>
                   <p className="text-muted-foreground">
-                    Sämtliche Materialien stehen zum Herunterladen bereit – sortiert nach den Kategorien: Verstehen · Unterstützen · Kommunizieren · Grenzen · Selbstfürsorge · Genesung · Soforthilfe
+                    Sämtliche Materialien stehen zum Herunterladen bereit – sortiert nach 6 Kategorien: Verstehen · Unterstützen · Kommunizieren · Grenzen · Selbstfürsorge · Soforthilfe
                   </p>
                 </div>
               </div>

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -201,7 +201,7 @@ export default function Verstehen() {
                     <strong>DSM-5-TR:</strong> Auf dieser Seite nutzen wir weiterhin die 9 Kriterien als psychoedukative Orientierung für Angehörige.
                   </p>
                   <p className="text-muted-foreground leading-relaxed">
-                    <strong>ICD-11:</strong> Im Versorgungskontext in DACH wird Persönlichkeitsstörung dimensional beschrieben (ICD-11: <em>6D10</em>) und das Borderline-Muster als Qualifier ergänzt (<em>6D11</em>).
+                    <strong>ICD-11:</strong> Im Versorgungskontext in DACH wird Borderline als Muster innerhalb der ICD-11-Persönlichkeitsstörungsdiagnostik eingeordnet (u. a. Borderline-Pattern-Qualifier, im Schema aktuell als <em>6D11</em> referenziert).
                   </p>
                   <p className="text-sm text-muted-foreground">
                     Praktisch heisst das: Beide Systeme beschreiben ähnliche klinische Muster, nutzen aber unterschiedliche Struktur- und Kodierungslogiken.


### PR DESCRIPTION
### Motivation
- Umsetzung der P0‑Aufgaben aus dem Content‑Audit zur schnellen Behebung fachlicher und technischer Driftpunkte ohne Redesign oder umfangreiche Refactorings. 
- Ziel ist, den diagnostischen Rahmen (DSM vs. ICD) kurz und konsistent darzustellen, die Materials‑Kommunikation an die tatsächliche Taxonomie anzugleichen und Suche‑Targets für „Unterstützen“ granular zu machen. 
- Änderungen sind minimal‑invasiv und auf Sichtbarkeit/Konsistenz gegenüber SEO/Schema und Nutzerführung ausgerichtet.

### Description
- `client/src/pages/Verstehen.tsx`: Kompakter Abschnitt „DSM‑5‑TR und ICD‑11 im Überblick“ sprachlich präzisiert und die ICD‑11‑Einordnung an die im Schema genutzte Referenz (`6D11`) angepasst. 
- `client/src/pages/Materialien.tsx`: Die Nutzerkommunikation zu verfügbaren Kategorien korrigiert und explizit auf die reale Taxonomie mit 6 Kategorien (inkl. `Soforthilfe`, ohne „Genesung“ als Kategoriebezeichnung) geändert. 
- `client/src/components/Search.tsx`: Mehrere Unterstützen/Therapie‑Treffer wurden von hash‑Fragmentzielen wie `/unterstuetzen/therapie#therapieangebote` auf die konsistente, granulare Route `/unterstuetzen/therapie` normalisiert.

### Testing
- `npm run check` (`tsc --noEmit`) wurde ausgeführt und lief erfolgreich (keine TypeScript‑Fehler). 
- `npm run test` (`vitest`) wurde ausgeführt und beendete sich erfolgreich (keine Testdateien, Exit 0).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d7b517608332872f55f4225c6ab2)