### PR TITLE
Sprache & Differenzierung: Präzisierungen in Verstehen/FAQ/UeberUns

### DIFF
--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -60,7 +60,7 @@ export default function FAQ() {
         },
         {
           question: "Warum verhält sich mein Angehöriger bei anderen «normal»?",
-          answer: "Dieses Phänomen ist typisch und kein Zeichen von Manipulation. Menschen mit Borderline haben oft die grössten Schwierigkeiten in engen Beziehungen, weil dort die Verlassensangst am stärksten aktiviert wird. Bei Fremden oder in oberflächlichen Kontakten ist diese Angst geringer, daher können sie sich besser regulieren. Es ist paradox: Je wichtiger Sie Ihrem Angehörigen sind, desto intensiver können die Symptome sein. Das ist keine bewusste Entscheidung, sondern ein Muster, das in der Therapie bearbeitet wird."
+          answer: "Dieses Phänomen ist häufig und nicht automatisch ein Zeichen von Manipulation. Menschen mit Borderline haben oft die grössten Schwierigkeiten in engen Beziehungen, weil dort die Verlassensangst am stärksten aktiviert wird. Bei Fremden oder in oberflächlichen Kontakten ist diese Angst geringer, daher können sie sich besser regulieren. Es ist paradox: Je wichtiger Sie Ihrem Angehörigen sind, desto intensiver können die Symptome sein. Das ist keine bewusste Entscheidung, sondern ein Muster, das in der Therapie bearbeitet wird."
         }
       ]
     },
@@ -81,7 +81,7 @@ export default function FAQ() {
         },
         {
           question: "Wie gehe ich mit dem Schwarz-Weiss-Denken um?",
-          answer: "Das «Splitting» (Idealisierung und Abwertung) ist ein Kernmerkmal von Borderline. In einem Moment sind Sie der beste Mensch der Welt, im nächsten der schlimmste. Wichtig: Nehmen Sie weder die Idealisierung noch die Abwertung persönlich. Beide sind Verzerrungen. Bleiben Sie konsistent in Ihrem Verhalten, auch wenn die Bewertung schwankt. Sagen Sie zum Beispiel: «Ich bin derselbe Mensch wie gestern. Ich liebe dich, auch wenn du gerade wütend auf mich bist.» Mit der Zeit und Therapie lernen Betroffene, Grautöne zu sehen."
+          answer: "Das «Splitting» (Idealisierung und Abwertung) ist ein häufiges Merkmal bei Borderline, aber nicht bei allen Betroffenen gleich ausgeprägt. In einem Moment sind Sie der beste Mensch der Welt, im nächsten der schlimmste. Wichtig: Nehmen Sie weder die Idealisierung noch die Abwertung persönlich. Beides kann Ausdruck von innerer Anspannung und Beziehungssorge sein. Bleiben Sie konsistent in Ihrem Verhalten, auch wenn die Bewertung schwankt. Sagen Sie zum Beispiel: «Ich bin derselbe Mensch wie gestern. Ich liebe dich, auch wenn du gerade wütend auf mich bist.» Mit der Zeit und Therapie lernen Betroffene, Grautöne zu sehen."
         },
         {
           question: "Soll ich lügen, um Konflikte zu vermeiden?",
@@ -127,7 +127,7 @@ export default function FAQ() {
         },
         {
           question: "Welche Therapie ist am besten?",
-          answer: "Für Borderline gibt es mehrere evidenzbasierte Therapien: DBT (Dialektisch-Behaviorale Therapie) ist am besten erforscht und besonders wirksam bei Selbstverletzung und Suizidalität. MBT (Mentalisierungsbasierte Therapie) fokussiert auf das Verstehen eigener und fremder Gedanken/Gefühle. Schematherapie arbeitet an frühen Prägungen und Beziehungsmustern. TFP (Übertragungsfokussierte Therapie) nutzt die therapeutische Beziehung zur Veränderung. Alle sind wirksam – wichtiger als die Methode ist oft die Passung zwischen Therapeut und Patient.",
+          answer: "Für Borderline gibt es mehrere evidenzbasierte Therapien: DBT (Dialektisch-Behaviorale Therapie) ist sehr gut erforscht und häufig besonders wirksam bei Selbstverletzung und Suizidalität. MBT (Mentalisierungsbasierte Therapie) fokussiert auf das Verstehen eigener und fremder Gedanken/Gefühle. Schematherapie arbeitet an frühen Prägungen und Beziehungsmustern. TFP (Übertragungsfokussierte Therapie) nutzt die therapeutische Beziehung zur Veränderung. Alle können wirksam sein – wichtiger als die Methode ist oft die Passung zwischen Therapeut und Patient.",
           links: [{ text: "Therapieformen erklärt", url: "/unterstuetzen/therapie" }]
         },
         {
@@ -151,7 +151,7 @@ export default function FAQ() {
         },
         {
           question: "Wie gehe ich mit Eifersucht und Kontrolle um?",
-          answer: "Eifersucht bei Borderline wurzelt oft in Verlassensangst, nicht in Misstrauen. Verstehen Sie das, ohne es zu akzeptieren. Setzen Sie klare Grenzen: «Ich werde mein Handy nicht zeigen. Ich habe nichts zu verbergen, aber ich brauche Privatsphäre.» Geben Sie nicht nach, um Ruhe zu haben – das verstärkt das Muster. Gleichzeitig: Seien Sie transparent, wo es Ihnen möglich ist, ohne sich zu verbiegen. Ermutigen Sie Ihren Angehörigen, die Eifersucht in der Therapie zu bearbeiten."
+          answer: "Eifersucht bei Borderline wurzelt aus Angehörigensicht häufig in Verlassensangst, nicht nur in Misstrauen. Verstehen Sie das, ohne es zu akzeptieren. Setzen Sie klare Grenzen: «Ich werde mein Handy nicht zeigen. Ich habe nichts zu verbergen, aber ich brauche Privatsphäre.» Geben Sie nicht nach, um Ruhe zu haben – das verstärkt das Muster. Gleichzeitig: Seien Sie transparent, wo es Ihnen möglich ist, ohne sich zu verbiegen. Ermutigen Sie Ihren Angehörigen, die Eifersucht in der Therapie zu bearbeiten."
         },
         {
           question: "Kann ich noch ein normales Leben führen?",
@@ -160,7 +160,7 @@ export default function FAQ() {
         },
         {
           question: "Wann wird es besser?",
-          answer: "Das ist für viele Angehörige die schwierigste Frage. Die ehrliche Antwort lautet: Der Verlauf bleibt begrenzt vorhersehbar. Manche Betroffene zeigen nach Monaten deutliche Fortschritte, bei anderen dauert es deutlich länger. Was Sie beeinflussen können, sind Ihr eigenes Verhalten, Ihre Grenzen und Ihre Selbstfürsorge. Was Sie nicht steuern können, ist der Zeitpunkt oder das Tempo der Veränderung Ihres Angehörigen. Hilfreich ist meist, auf Entwicklungen über längere Zeit zu achten statt auf einzelne Tage oder Krisen."
+          answer: "Das ist für viele Angehörige die schwierigste Frage. Die ehrliche Antwort lautet: Der Verlauf bleibt begrenzt vorhersehbar. Manche Betroffene zeigen nach Monaten deutliche Fortschritte, bei anderen dauert es deutlich länger – und nicht alle Verläufe sind gleich. Was Sie beeinflussen können, sind Ihr eigenes Verhalten, Ihre Grenzen und Ihre Selbstfürsorge. Was Sie nicht steuern können, ist der Zeitpunkt oder das Tempo der Veränderung Ihres Angehörigen. Hilfreich ist meist, auf Entwicklungen über längere Zeit zu achten statt auf einzelne Tage oder Krisen."
         }
       ]
     }

--- a/client/src/pages/UeberUns.tsx
+++ b/client/src/pages/UeberUns.tsx
@@ -55,11 +55,11 @@ export default function UeberUns() {
                 </p>
                 
                 <p className="leading-relaxed mb-4">
-                  Der Begriff «Eiertanz» aus dem Standardwerk von Paul T. Mason und Randi Kreger beschreibt dieses Gefühl treffend: das ständige Auf-der-Hut-Sein, die Angst vor dem nächsten Ausbruch, das Gefühl, auf Eierschalen zu laufen.
+                  Der Begriff «Eiertanz» aus dem Standardwerk von Paul T. Mason und Randi Kreger wird hier als Angehörigenmetapher verwendet: Er beschreibt das ständige Auf-der-Hut-Sein und die Angst vor dem nächsten Konflikt. Gleichzeitig ist wichtig: Solche Dynamiken sind nicht bei allen Betroffenen gleich und stehen häufig mit innerer Not in Zusammenhang.
                 </p>
                 
                 <p className="leading-relaxed">
-                  Diese Website möchte Angehörigen evidenzbasierte Werkzeuge an die Hand geben – nicht um die Erkrankung zu «heilen», sondern um den Alltag besser zu bewältigen, die Beziehung zu stärken und dabei auf sich selbst zu achten.
+                  Diese Website möchte Angehörigen evidenzbasierte Werkzeuge an die Hand geben – nicht um die Erkrankung zu «heilen», sondern um den Alltag besser zu bewältigen, die Beziehung zu stärken und dabei auf sich selbst zu achten. Viele belastende Muster sind behandelbar und können sich mit der Zeit verändern.
                 </p>
               </div>
             </ContentSection>
@@ -135,7 +135,7 @@ export default function UeberUns() {
                   {
                     title: "Stop Walking on Eggshells",
                     author: "Paul T. Mason & Randi Kreger",
-                    description: "Das Standardwerk für Angehörige, Grundlage für den Namen dieser Website."
+                    description: "Ein bekanntes Angehörigenbuch, das die Perspektive von Familien in belastenden Situationen beschreibt."
                   },
                   {
                     title: "Ich hasse dich – verlass mich nicht",

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -105,7 +105,7 @@ export default function Verstehen() {
               preview="Für eine Diagnose müssen mindestens 5 von 9 Kriterien erfüllt sein."
             >
               <p className="text-muted-foreground leading-relaxed mb-6">
-                Für eine Diagnose müssen mindestens <strong>5 von 9 Kriterien</strong> erfüllt sein. Die Liste kann helfen, typische Muster besser zu verstehen, ersetzt aber keine fachliche Abklärung. Entscheidend ist immer das Gesamtbild über längere Zeit und in verschiedenen Lebensbereichen.
+                Für eine Diagnose müssen mindestens <strong>5 von 9 Kriterien</strong> erfüllt sein. Die Liste kann helfen, häufige Muster besser zu verstehen, ersetzt aber keine fachliche Abklärung. Entscheidend ist immer das Gesamtbild über längere Zeit und in verschiedenen Lebensbereichen.
               </p>
               
               <div className="space-y-3">
@@ -300,7 +300,7 @@ export default function Verstehen() {
                       Amygdala – Das Alarmzentrum
                     </h3>
                     <p className="text-muted-foreground text-sm leading-relaxed mb-2">
-                      Die Amygdala ist bei Borderline <strong>überaktiv</strong>. Sie reagiert stärker und schneller auf emotionale Reize – besonders auf Gesichtsausdrücke, die als bedrohlich interpretiert werden könnten.
+                      Die Amygdala kann bei Borderline <strong>überaktiv</strong> sein. Sie reagiert stärker und schneller auf emotionale Reize – besonders auf Gesichtsausdrücke, die als bedrohlich interpretiert werden könnten.
                     </p>
                     <div className="bg-terracotta-wash rounded-lg p-3">
                       <p className="text-xs text-foreground">
@@ -317,7 +317,7 @@ export default function Verstehen() {
                       Hippocampus – Das Gedächtniszentrum
                     </h3>
                     <p className="text-muted-foreground text-sm leading-relaxed mb-2">
-                      Der Hippocampus ist bei vielen Betroffenen <strong>verkleinert</strong>. Er ist zuständig für Gedächtnis und das Einordnen von Erfahrungen in einen Kontext.
+                      Der Hippocampus kann bei manchen Betroffenen <strong>verkleinert</strong> sein. Er ist zuständig für Gedächtnis und das Einordnen von Erfahrungen in einen Kontext.
                     </p>
                     <div className="bg-sage-wash rounded-lg p-3">
                       <p className="text-xs text-foreground">
@@ -334,7 +334,7 @@ export default function Verstehen() {
                       Präfrontaler Kortex – Die Kontrollinstanz
                     </h3>
                     <p className="text-muted-foreground text-sm leading-relaxed mb-2">
-                      Der präfrontale Kortex ist für rationales Denken, Impulskontrolle und <Link to="/glossar?q=Emotionale+Dysregulation" className="underline decoration-sage-mid/40 underline-offset-2 hover:decoration-sage-mid transition-colors">Emotionsregulation</Link> zuständig. Bei Borderline ist die <strong>Verbindung zur Amygdala geschwächt</strong>.
+                      Der präfrontale Kortex ist für rationales Denken, Impulskontrolle und <Link to="/glossar?q=Emotionale+Dysregulation" className="underline decoration-sage-mid/40 underline-offset-2 hover:decoration-sage-mid transition-colors">Emotionsregulation</Link> zuständig. Bei Borderline kann die <strong>Verbindung zur Amygdala geschwächt</strong> sein.
                     </p>
                     <div className="bg-slate-wash rounded-lg p-3">
                       <p className="text-xs text-foreground">
@@ -427,7 +427,7 @@ export default function Verstehen() {
             >
               <div className="prose prose-lg max-w-none">
                 <p className="text-muted-foreground leading-relaxed mb-6">
-                  Viele Angehörige berichten von einem wiederkehrenden Muster. Dieses Muster zu kennen, hilft Ihnen, nicht jede Phase persönlich zu nehmen – und sich auf die nächste vorzubereiten.
+                  Viele Angehörige berichten von einem wiederkehrenden Muster. Aus Angehörigenperspektive kann es hilfreich sein, dieses Muster zu kennen, um nicht jede Phase persönlich zu nehmen – und sich auf die nächste vorzubereiten.
                 </p>
                 
                 <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
@@ -453,7 +453,7 @@ export default function Verstehen() {
                 <Card className="mt-6 border-l-4 border-l-sage-mid bg-sage-wash/30">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      <strong>Wichtig:</strong> Dieser Zyklus ist kein Schicksal. Mit Therapie und Unterstützung können die Phasen weniger intensiv werden und die stabilen Zeiten länger dauern.
+                      <strong>Wichtig:</strong> Dieser Zyklus ist kein Schicksal und zeigt sich nicht bei allen Betroffenen gleich. Mit Therapie und Unterstützung können die Phasen häufig weniger intensiv werden und die stabilen Zeiten länger dauern.
                     </p>
                   </CardContent>
                 </Card>
@@ -473,7 +473,7 @@ export default function Verstehen() {
             >
               <div className="prose prose-lg max-w-none">
                 <p className="text-muted-foreground leading-relaxed mb-6">
-                  Wenn Sie verstehen, dass das Verhalten Ihres Angehörigen nicht gegen Sie gerichtet ist, sondern Ausdruck einer Erkrankung, können Sie anders reagieren. Sie können:
+                  Wenn Sie verstehen, dass das Verhalten Ihres Angehörigen aus Angehörigensicht oft nicht gegen Sie gerichtet wirkt, sondern häufig Ausdruck innerer Not und einer Erkrankung ist, können Sie anders reagieren. Sie können:
                 </p>
                 
                 <div className="grid sm:grid-cols-2 gap-4">


### PR DESCRIPTION
### Motivation
- Umsetzung des Audits `_dev/CONTENT-LOGIC-VALIDATION-AUDIT-2026-03-24.md` zur Reduktion kategorischer Sprache und Minimierung von Stigma-Risiken ohne Redesign.
- Ziel war, verallgemeinernde Aussagen zu präzisieren, Angehörigen- und Betroffenenperspektiven klar zu markieren sowie Kreger-/Mason-nahe Frames kontextualisiert abzumildern.
- Änderungen sollten minimal-invasiv bleiben und die psychoedukative Verständlichkeit für Angehörige erhalten.

### Description
- Dateien geändert: `client/src/pages/Verstehen.tsx`, `client/src/pages/FAQ.tsx`, `client/src/pages/UeberUns.tsx` und kleinere textliche Anpassungen in diesen Komponenten vorgenommen.
- Formulierungen wurden von kategorisch auf probabilistisch/qualifizierend umgestellt (z. B. Ergänzungen wie „häufig“, „kann“, „bei manchen Betroffenen“, „nicht bei allen“). 
- Angehörigenperspektive explizit markiert (z. B. 4‑Phasen‑Zyklus, Beschreibungen von Reaktionsmustern) und Betroffenen-/Recovery‑Gegenrahmung ergänzt (z. B. Hinweis auf Behandelbarkeit/Recovery). 
- Emotional stark aufgeladene Mason/Kreger‑Frames wurden kontextualisiert statt entfernt (z. B. „Eiertanz“ als Angehörigenmetapher), sowie einige normative Quellenformulierungen abgeschwächt.

### Testing
- Automatischer Typcheck ausgeführt mit `npm run check` (führt `tsc --noEmit` aus) und erfolgreich abgeschlossen.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2d929eb088332be2003ae68effc1e)