### PR TITLE
Fix Materialien category count copy to match taxonomy (6 → 7)

### DIFF
--- a/client/src/pages/Materialien.tsx
+++ b/client/src/pages/Materialien.tsx
@@ -418,7 +418,7 @@ export default function Materialien() {
                     Alle 31 Materialien verfügbar
                   </h2>
                   <p className="text-muted-foreground">
-                    Sämtliche Materialien stehen zum Herunterladen bereit – sortiert nach 6 Kategorien: Verstehen · Unterstützen · Kommunizieren · Grenzen · Selbstfürsorge · Soforthilfe
+                    Sämtliche Materialien stehen zum Herunterladen bereit – sortiert nach 7 Kategorien: Verstehen · Unterstützen · Kommunizieren · Grenzen · Selbstfürsorge · Genesung · Soforthilfe
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Correct a factual content drift where the Materialien page text claimed "6 Kategorien" while the actual category taxonomy includes 7 entries (missing explicit "Genesung"), which was flagged during the release-readiness validation.

### Description
- Update copy in `client/src/pages/Materialien.tsx` to read "7 Kategorien" and include "Genesung" in the listed categories; no structural, routing, or design changes were made.

### Testing
- Ran `npm run check` (TypeScript) which completed successfully.
- Ran `npm run test` (Vitest) which exited successfully with no tests found.
- Ran `npm run build` which completed successfully (build emitted warnings about missing analytics env vars but no errors).
- Also ran `npm run check && npm run build` as a combined validation which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2db4884b88332b275ebcb92b2d6f8)