### PR TITLE
Analytics: Optionales Env-Handling in client/index.html beheben

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -116,19 +116,18 @@
       </div>
     </noscript>
     <script type="module" src="/src/main.tsx"></script>
-    <script>
-      // Umami Analytics – nur laden wenn Env-Variablen beim Build gesetzt wurden
-      (function() {
-        var endpoint = "%VITE_ANALYTICS_ENDPOINT%";
-        var websiteId = "%VITE_ANALYTICS_WEBSITE_ID%";
-        if (endpoint.indexOf("VITE_") === -1 && websiteId.indexOf("VITE_") === -1) {
-          var s = document.createElement("script");
-          s.defer = true;
-          s.src = endpoint + "/umami";
-          s.setAttribute("data-website-id", websiteId);
-          document.head.appendChild(s);
-        }
-      })();
+    <script type="module">
+      // Umami Analytics – nur laden wenn optionale Env-Variablen gesetzt sind
+      const endpoint = import.meta.env.VITE_ANALYTICS_ENDPOINT?.trim();
+      const websiteId = import.meta.env.VITE_ANALYTICS_WEBSITE_ID?.trim();
+
+      if (endpoint && websiteId) {
+        const s = document.createElement("script");
+        s.defer = true;
+        s.src = `${endpoint}/umami`;
+        s.setAttribute("data-website-id", websiteId);
+        document.head.appendChild(s);
+      }
     </script>
   </body>
 


### PR DESCRIPTION
### Motivation
- Entfernen von Build-Warnungen, wenn die optionalen Analytics-Variablen nicht gesetzt sind, ohne Analytics-Logik neu zu gestalten. 
- Sicherstellen, dass die Anwendung release-ready bleibt und optionales Umami nur geladen wird, wenn beide Env-Werte vorhanden sind.

### Description
- Ersetzte die `%VITE_ANALYTICS_*%` HTML-Platzhalter in `client/index.html` durch ein `type="module"`-Script, das `import.meta.env.VITE_ANALYTICS_ENDPOINT` und `import.meta.env.VITE_ANALYTICS_WEBSITE_ID` verwendet. 
- Implementiert einen sicheren Minimal-Fallback: das Umami-Skript wird nur injiziert, wenn sowohl `endpoint` als auch `websiteId` nicht-empty sind. 
- Keine funktionalen, inhaltlichen oder strukturellen Änderungen an der App vorgenommen; nur minimaler Release-Hardening-Fix an der Bootstrap-Datei. 
- Geänderte Datei: `client/index.html` (kleine, risikoarme Anpassung im Footer-Skript).

### Testing
- Vorheriger Build-Test: `env -u VITE_ANALYTICS_ENDPOINT -u VITE_ANALYTICS_WEBSITE_ID pnpm build` zeigte Vite-Warnungen zu den `%VITE_*%`-Platzhaltern, Build selbst war aber erfolgreich. (vor Änderung)
- Nach Änderung: `env -u VITE_ANALYTICS_ENDPOINT -u VITE_ANALYTICS_WEBSITE_ID pnpm build` lief erfolgreich **ohne** Analytics-Env-Warnungen. (erfolgreich)
- Type-Check: `pnpm check` wurde ausgeführt und ist erfolgreich. (erfolgreich)
- Production smoke: gebautes `dist` gestartet mit `PORT=4173 NODE_ENV=production node dist/index.js` und mittels `curl` die Routen `/`, `/verstehen`, `/unterstuetzen/therapie`, `/materialien`, `/soforthilfe`, `/suche` geprüft; alle Ziele sind erreichbar (direkt 200 oder 301→200 bei kanonischen Trailing-Slash-Redirects). (erfolgreich)
- Ergebnis aller automatisierten Prüfungen: bestanden.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2dcfa6a5483329c7db6438dc0667c)