### PR TITLE
docs: add release approval recommendation (2026-03-24)

### DIFF
--- a/_dev/RELEASE-EMPFEHLUNG-2026-03-24.md
+++ b/_dev/RELEASE-EMPFEHLUNG-2026-03-24.md
@@ -1,0 +1,20 @@
+# Freigabeempfehlung (2026-03-24)
+
+**Release freigeben.**
+
+Der aktuelle Stand ist inhaltlich, sprachlich, technisch und strukturell konsistent. Die letzten release-relevanten Punkte wurden minimal-invasiv bereinigt, inklusive der Analytics-Initialisierung. Es wurde kein echter Blocker mehr gefunden.
+
+## Bekannte kleine Restnotiz
+
+- einzelne kanonische Trailing-Slash-Redirects auf Deep-Links
+- technisch unkritisch
+- kein Release-Blocker
+- optionales Feintuning in einer späteren Iteration möglich
+
+## Für die nächste Iteration vorgemerkt
+
+- optionales Routing-/Canonical-Feintuning
+- Aufbau echter automatisierter Tests
+- weiterer redaktioneller CH-/DACH-Feinschliff nur bei Bedarf
+
+Damit ist das Projekt aus aktueller Sicht **freigabereit**.


### PR DESCRIPTION
### Motivation
- Capture the current release approval status and record the remaining non-blocking items and next-iteration follow-ups in the repository as a permanent reference.

### Description
- Add ` _dev/RELEASE-EMPFEHLUNG-2026-03-24.md` containing the release recommendation, known minor notes, and planned follow-up items, and commit the file to the repo.

### Testing
- No automated tests were applicable for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2de3ddb2c8332a622a432454d3c2e)