### PR TITLE
docs: add BUG-SCAN-2026-03-26 with 15 findings

### DIFF
--- a/_dev/BUG-SCAN-2026-03-26.md
+++ b/_dev/BUG-SCAN-2026-03-26.md
@@ -1,0 +1,40 @@
+# Bug-Scan (26.03.2026)
+
+Scope: schneller Repo-Scan (Code + bestehende Audit-Artefakte) mit Fokus auf reproduzierbare bzw. klar belegte Probleme.
+
+## Gefundene Bugs (mind. 15)
+
+1. **Stale `sourceRef` in Kontaktdaten: UnterstuetzenTherapie Zeile 379 existiert nicht mehr.**
+   - In `kontakte.ts` wird auf `UnterstuetzenTherapie.tsx:379` verwiesen, die Datei hat aber nur 371 Zeilen.
+2. **Stale `sourceRef` in Kontaktdaten: UnterstuetzenTherapie Zeile 383 existiert nicht mehr.**
+3. **Stale `sourceRef` in Kontaktdaten: UnterstuetzenTherapie Zeile 386 existiert nicht mehr.**
+4. **Stale `sourceRef` in Kontaktdaten: Feedback Zeile 275 existiert nicht mehr.**
+   - `Feedback.tsx` hat nur 137 Zeilen.
+5. **Inhaltliche Inkonsistenz bei Krisen-Call-to-Action (zu absolute Formulierung).**
+   - Soforthilfe-Text enthält eine absolute Handlungsanweisung („auch gegen den Willen ...“), ohne klare juristisch-klinische Bedingung.
+6. **Fehlender globaler Regionalitäts-Hinweis (CH/ZH) trotz lokaler Notfallkontakte.**
+   - Risiko: Nutzer außerhalb CH/ZH können Kontakte falsch verwenden.
+7. **Volatile Kontaktdaten ohne flächendeckenden, sichtbaren Verifizierungsstempel.**
+   - `LastVerifiedBadge` ist punktuell vorhanden, aber nicht systematisch an allen Telefonnummern/Zeiten.
+8. **Inkonsistente Quellenführung bei medizinischen Aussagen.**
+   - Evidenzversprechen auf „Über uns“, aber auf manchen Kernseiten fehlen direkte Quellenblöcke.
+9. **`MedicalPageSchema` aktualisiert sich nicht korrekt bei Änderungen von `title`/`description`.**
+   - `useEffect` hängt nur von `path` ab; bei Textänderung ohne Pfadwechsel bleibt JSON-LD stale.
+10. **SEO Canonical/OG Basisdomain hart auf Netlify-Domain verdrahtet.**
+    - Bei eigener Produktionsdomain drohen falsche Canonicals/OpenGraph-URLs.
+11. **Schema `lastReviewed` ist statisch und driftet mit der Zeit.**
+    - In `SEO.tsx` auf festen Wert gesetzt (`2026-03-09`).
+12. **Möglicher Timer-Leak im Dialog-Composition-Kontext.**
+    - `endTimerRef` wird gesetzt, aber beim Unmount nicht explizit gecleart.
+13. **Möglicher Timer-Leak in `useComposition` (zwei Timer ohne Unmount-Cleanup).**
+    - Bei schnellem Mount/Unmount können Timer weiterlaufen.
+14. **Daten-Mapping-Risiko in `Selbsthilfegruppen`: Stand-by-You-Telefon kommt aus `INFO_SELBSTHILFE_CH`.**
+    - ID/Label deuten auf „Selbsthilfe Schweiz“, werden aber als „Stand by You HelpLine“ verwendet.
+15. **Doppelte URL-Entry-Points für dieselbe Seite (`/beratung` und `/selbsthilfegruppen`) mit nur einem SEO-Path.**
+    - SEO-Komponente setzt auf `/beratung`; auf `/selbsthilfegruppen` ist Canonical nicht automatisch selbsterklärend.
+
+## Verwendete Checks
+
+- TypeScript-Check (`pnpm -s check`) lief sauber durch.
+- Zusatzskript prüfte `sourceRef`-Zeilen gegen reale Dateilängen und fand 4 harte Treffer.
+- Zusatzsichtung für SEO/Schema und IME/Timer-Handling in UI-Hooks.


### PR DESCRIPTION
### Motivation
- Add a concise, reproducible bug-scan artifact to capture and hand off a prioritized list of repository issues discovered during audits and quick scans (`_dev/BUG-SCAN-2026-03-26.md`).

### Description
- Added `_dev/BUG-SCAN-2026-03-26.md` documenting 15 concrete findings (data consistency stale `sourceRef` entries, SEO/schema risks, content/regionality concerns, possible timer leaks in IME/dialog hooks, duplicate routes/SEO entry-points and related mapping issues) as an actionable backlog.

### Testing
- Ran the TypeScript check via `pnpm -s check`, which completed successfully. 
- Executed a custom Python check that validates `sourceRef` line references in `client/src/data/kontakte.ts` against actual file lengths and reported 4 stale references (included in the report).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c489541230833295c9aea1f248f375)