### PR TITLE
Centralize content, add materials & search index, improve mobile floating UI and SEO

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { ScrollToTopButton, Breadcrumbs } from "@/components/UXEnhancements";
 import { HeaderNav } from "@/components/layout/HeaderNav";
 import { navItems, ressourcenItems } from "@/components/layout/navigationData";
+import { getMobileFloatingMode } from "@/domain/floating-ui";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -14,6 +15,7 @@ interface LayoutProps {
 export default function Layout({ children }: LayoutProps) {
   const [location] = useLocation();
   const [searchOpen, setSearchOpen] = useState(false);
+  const floatingMode = getMobileFloatingMode(location);
 
   // Keyboard shortcut for search (Ctrl/Cmd + K) + ESC closes dropdown
   useEffect(() => {
@@ -41,7 +43,9 @@ export default function Layout({ children }: LayoutProps) {
 
       <div className="border-b border-border/40 bg-sage-wash/40">
         <div className="container py-1.5 text-xs text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="font-medium text-foreground">Notfallkontakte: Schweiz (Kanton Zürich)</span>
+          <span className="font-medium text-foreground">
+            Notfallkontakte: Schweiz (Kanton Zürich)
+          </span>
           <span className="hidden sm:inline">•</span>
           <span>Für andere Regionen bitte lokale Notrufnummern nutzen.</span>
         </div>
@@ -63,7 +67,7 @@ export default function Layout({ children }: LayoutProps) {
             <div className="lg:col-span-1">
               <Link href="/" className="flex items-center gap-2 mb-4">
                 <img
-                  src="https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/NqViLFGTREhdSTsm.webp"
+                  src="/favicon-192.png"
                   alt="Startseite"
                   className="w-10 h-10 rounded-full"
                   width={40}
@@ -76,15 +80,18 @@ export default function Layout({ children }: LayoutProps) {
                 </span>
               </Link>
               <p className="text-muted-foreground text-sm leading-relaxed">
-                Evidenzbasierte Unterstützung für Angehörige von Menschen mit Borderline-Persönlichkeitsstörung.
+                Psychoedukatives Informationsangebot für Angehörige von Menschen
+                mit Borderline-Muster.
               </p>
             </div>
 
             {/* Navigation */}
             <div>
-              <h3 className="font-semibold text-foreground mb-4 text-base">Themen</h3>
+              <h3 className="font-semibold text-foreground mb-4 text-base">
+                Themen
+              </h3>
               <ul className="space-y-1">
-                {navItems.map((item) => (
+                {navItems.map(item => (
                   <li key={item.href}>
                     <Link
                       href={item.href}
@@ -99,9 +106,11 @@ export default function Layout({ children }: LayoutProps) {
 
             {/* Resources */}
             <div>
-              <h3 className="font-semibold text-foreground mb-4 text-base">Ressourcen</h3>
+              <h3 className="font-semibold text-foreground mb-4 text-base">
+                Ressourcen
+              </h3>
               <ul className="space-y-1">
-                {ressourcenItems.map((item) => (
+                {ressourcenItems.map(item => (
                   <li key={item.href}>
                     <Link
                       href={item.href}
@@ -116,9 +125,13 @@ export default function Layout({ children }: LayoutProps) {
 
             {/* Hinweis */}
             <div>
-              <h3 className="font-semibold text-foreground mb-4 text-base">Hinweis</h3>
+              <h3 className="font-semibold text-foreground mb-4 text-base">
+                Hinweis
+              </h3>
               <p className="text-muted-foreground text-sm leading-relaxed">
-                Diese Website ersetzt keine professionelle Beratung oder Therapie. Bei akuten Krisen wenden Sie sich bitte an die Notfallnummern.
+                Diese Website ersetzt keine professionelle Beratung oder
+                Therapie. Bei akuten Krisen wenden Sie sich bitte an die
+                Notfallnummern.
               </p>
             </div>
           </div>
@@ -126,31 +139,49 @@ export default function Layout({ children }: LayoutProps) {
           {/* Absender-Einordnung */}
           <div className="border-t border-border/50 mt-8 pt-8">
             <p className="text-sm text-foreground leading-relaxed">
-              Für Angehörige – Fachstelle Angehörigenarbeit, Psychiatrische Universitätsklinik Zürich (PUK) – Ch. Egger
+              Herausgegeben von der Fachstelle Angehörigenarbeit der
+              Psychiatrischen Universitätsklinik Zürich (PUK).
             </p>
             <p className="text-xs text-muted-foreground mt-1 leading-relaxed">
-              Unabhängiges Informationsangebot der Fachstelle Angehörigenarbeit. Nicht offizieller Kommunikationskanal der PUK Zürich.
+              Redaktionell eigenständiges Informationsangebot der Fachstelle
+              Angehörigenarbeit innerhalb der PUK Zürich.
             </p>
           </div>
 
           <div className="border-t border-border/50 mt-6 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
             <p className="text-muted-foreground text-sm">
-              © 2026 Borderline · Hilfe für Angehörige. Alle Rechte vorbehalten.
+              © 2026 Borderline · Hilfe für Angehörige. Alle Rechte
+              vorbehalten.
             </p>
             <div className="flex flex-wrap gap-x-4 gap-y-1">
-              <Link href="/fachstelle" className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]">
+              <Link
+                href="/fachstelle"
+                className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]"
+              >
                 Fachstelle
               </Link>
-              <Link href="/ueber-uns" className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]">
+              <Link
+                href="/ueber-uns"
+                className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]"
+              >
                 Über uns
               </Link>
-              <Link href="/impressum" className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]">
+              <Link
+                href="/impressum"
+                className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]"
+              >
                 Impressum
               </Link>
-              <Link href="/datenschutz" className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]">
+              <Link
+                href="/datenschutz"
+                className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]"
+              >
                 Datenschutz
               </Link>
-              <Link href="/feedback" className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]">
+              <Link
+                href="/feedback"
+                className="text-muted-foreground hover:text-foreground text-sm transition-colors inline-flex items-center min-h-[44px]"
+              >
                 Feedback
               </Link>
             </div>
@@ -161,15 +192,23 @@ export default function Layout({ children }: LayoutProps) {
       {/* Fixed Emergency Button (Mobile) – Pill mit Label */}
       {/* Position: bottom-20 damit der ScrollToTop-Button (bottom-4) nicht überlappt */}
       {/* Auf /soforthilfe selbst wird der Button ausgeblendet */}
-      {location !== "/soforthilfe" && (
-        <Link href="/soforthilfe" className="sm:hidden fixed z-50" style={{ bottom: 'calc(4.5rem + env(safe-area-inset-bottom, 0px))', right: '1rem' }} aria-label="Soforthilfe – Notfallnummern und Krisenberatung">
+      {floatingMode === "crisis" && location !== "/soforthilfe" && (
+        <Link
+          href="/soforthilfe"
+          className="sm:hidden fixed z-50"
+          style={{
+            bottom: "calc(4.5rem + env(safe-area-inset-bottom, 0px))",
+            right: "1rem",
+          }}
+          aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
+        >
           <Button
             variant="default"
             className="h-12 px-4 rounded-full bg-alert hover:bg-alert/85 text-white shadow-lg gap-2 text-sm font-semibold"
             tabIndex={-1}
           >
             <Phone className="w-4 h-4" />
-            Hilfe
+            Soforthilfe
           </Button>
         </Link>
       )}
@@ -180,7 +219,7 @@ export default function Layout({ children }: LayoutProps) {
           <Search isOpen={searchOpen} onClose={() => setSearchOpen(false)} />
         </Suspense>
       )}
-      
+
       {/* Zurück nach oben Button */}
       <ScrollToTopButton />
     </div>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -189,8 +189,7 @@ export default function Layout({ children }: LayoutProps) {
         </div>
       </footer>
 
-      {/* Fixed Emergency Button (Mobile) – Pill mit Label */}
-      {/* Position: bottom-20 damit der ScrollToTop-Button (bottom-4) nicht überlappt */}
+      {/* Mobile Soforthilfe-FAB: zentral über floatingMode priorisiert (crisis) */}
       {/* Auf /soforthilfe selbst wird der Button ausgeblendet */}
       {floatingMode === "crisis" && location !== "/soforthilfe" && (
         <Link

--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -9,10 +9,16 @@ interface SEOProps {
 }
 
 const SITE_NAME = "Borderline · Hilfe für Angehörige";
-const BASE_DESCRIPTION = "Evidenzbasierte Unterstützung für Angehörige von Menschen mit Borderline-Persönlichkeitsstörung.";
+const BASE_DESCRIPTION =
+  "Evidenzbasierte Unterstützung für Angehörige von Menschen mit Borderline-Muster (Borderline-Persönlichkeitsstörung).";
 const DEFAULT_SITE_URL = "https://borderline-angehoerige.netlify.app";
-const SITE_URL = (import.meta.env.VITE_SITE_URL || DEFAULT_SITE_URL).replace(/\/+$/, "");
-const MEDICAL_LAST_REVIEWED = import.meta.env.VITE_MEDICAL_LAST_REVIEWED || new Date().toISOString().slice(0, 10);
+const SITE_URL = (import.meta.env.VITE_SITE_URL || DEFAULT_SITE_URL).replace(
+  /\/+$/,
+  ""
+);
+const MEDICAL_LAST_REVIEWED =
+  import.meta.env.VITE_MEDICAL_LAST_REVIEWED ||
+  new Date().toISOString().slice(0, 10);
 
 const getSiteUrl = () => {
   if (typeof window !== "undefined" && window.location?.origin) {
@@ -21,8 +27,16 @@ const getSiteUrl = () => {
   return SITE_URL;
 };
 
-export default function SEO({ title, description, path = "/", type = "website", canonicalPath }: SEOProps) {
-  const fullTitle = title ? `${title} – ${SITE_NAME}` : `${SITE_NAME} – Evidenzbasierte Unterstützung`;
+export default function SEO({
+  title,
+  description,
+  path = "/",
+  type = "website",
+  canonicalPath,
+}: SEOProps) {
+  const fullTitle = title
+    ? `${title} – ${SITE_NAME}`
+    : `${SITE_NAME} – Evidenzbasierte Unterstützung`;
   const metaDescription = description || BASE_DESCRIPTION;
 
   useEffect(() => {
@@ -57,7 +71,9 @@ export default function SEO({ title, description, path = "/", type = "website", 
     updateMeta("twitter:image", ogImage);
 
     // Update canonical link
-    let canonical = document.querySelector('link[rel="canonical"]') as HTMLLinkElement;
+    let canonical = document.querySelector(
+      'link[rel="canonical"]'
+    ) as HTMLLinkElement;
     if (!canonical) {
       canonical = document.createElement("link");
       canonical.rel = "canonical";
@@ -74,19 +90,19 @@ export function WebsiteSchema() {
   const schema = {
     "@context": "https://schema.org",
     "@type": "WebSite",
-    "name": SITE_NAME,
-    "alternateName": "Borderline Angehörige",
-    "url": SITE_URL,
-    "description": BASE_DESCRIPTION,
-    "publisher": {
+    name: SITE_NAME,
+    alternateName: "Borderline Angehörige",
+    url: SITE_URL,
+    description: BASE_DESCRIPTION,
+    publisher: {
       "@type": "Organization",
-      "name": SITE_NAME,
-      "logo": {
+      name: SITE_NAME,
+      logo: {
         "@type": "ImageObject",
-        "url": `${SITE_URL}/og-image.jpg`
-      }
+        url: `${SITE_URL}/og-image.jpg`,
+      },
     },
-    "inLanguage": "de-CH"
+    inLanguage: "de-CH",
   };
 
   useEffect(() => {
@@ -98,41 +114,51 @@ export function WebsiteSchema() {
       document.head.appendChild(el);
     }
     el.textContent = JSON.stringify(schema);
-    return () => { el?.remove(); };
+    return () => {
+      el?.remove();
+    };
   }, []);
 
   return null;
 }
 
 // Schema.org MedicalWebPage for health-related pages
-export function MedicalPageSchema({ title, description, path }: { title: string; description: string; path: string }) {
+export function MedicalPageSchema({
+  title,
+  description,
+  path,
+}: {
+  title: string;
+  description: string;
+  path: string;
+}) {
   const siteUrl = getSiteUrl();
   const schema = {
     "@context": "https://schema.org",
     "@type": "MedicalWebPage",
-    "name": title,
-    "description": description,
-    "url": `${siteUrl}${path}`,
-    "inLanguage": "de",
-    "about": {
+    name: title,
+    description: description,
+    url: `${siteUrl}${path}`,
+    inLanguage: "de",
+    about: {
       "@type": "MedicalCondition",
-      "name": "Persönlichkeitsstörung mit Borderline-Muster",
-      "alternateName": ["Borderline-Muster", "Borderline pattern"],
-      "code": {
+      name: "Persönlichkeitsstörung mit Borderline-Muster",
+      alternateName: ["Borderline-Muster", "Borderline pattern"],
+      code: {
         "@type": "MedicalCode",
-        "code": "6D11",
-        "codingSystem": "ICD-11"
-      }
+        code: "6D11",
+        codingSystem: "ICD-11",
+      },
     },
-    "audience": {
+    audience: {
       "@type": "PeopleAudience",
-      "audienceType": "Angehörige von Menschen mit Borderline-Persönlichkeitsstörung"
+      audienceType: "Angehörige von Menschen mit Borderline-Muster",
     },
-    "lastReviewed": MEDICAL_LAST_REVIEWED,
-    "medicalAudience": {
+    lastReviewed: MEDICAL_LAST_REVIEWED,
+    medicalAudience: {
       "@type": "MedicalAudience",
-      "audienceType": "Caregiver"
-    }
+      audienceType: "Caregiver",
+    },
   };
 
   useEffect(() => {
@@ -144,23 +170,29 @@ export function MedicalPageSchema({ title, description, path }: { title: string;
       document.head.appendChild(el);
     }
     el.textContent = JSON.stringify(schema);
-    return () => { el?.remove(); };
+    return () => {
+      el?.remove();
+    };
   }, [description, path, siteUrl, title]);
 
   return null;
 }
 
 // BreadcrumbList schema
-export function BreadcrumbSchema({ items }: { items: { name: string; url: string }[] }) {
+export function BreadcrumbSchema({
+  items,
+}: {
+  items: { name: string; url: string }[];
+}) {
   const schema = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
-    "itemListElement": items.map((item, i) => ({
+    itemListElement: items.map((item, i) => ({
       "@type": "ListItem",
-      "position": i + 1,
-      "name": item.name,
-      "item": item.url
-    }))
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
   };
 
   useEffect(() => {
@@ -173,25 +205,31 @@ export function BreadcrumbSchema({ items }: { items: { name: string; url: string
       document.head.appendChild(el);
     }
     el.textContent = JSON.stringify(schema);
-    return () => { el?.remove(); };
+    return () => {
+      el?.remove();
+    };
   }, [items]);
 
   return null;
 }
 
 // FAQ schema for FAQ page
-export function FAQSchema({ questions }: { questions: { question: string; answer: string }[] }) {
+export function FAQSchema({
+  questions,
+}: {
+  questions: { question: string; answer: string }[];
+}) {
   const schema = {
     "@context": "https://schema.org",
     "@type": "FAQPage",
-    "mainEntity": questions.map(q => ({
+    mainEntity: questions.map(q => ({
       "@type": "Question",
-      "name": q.question,
-      "acceptedAnswer": {
+      name: q.question,
+      acceptedAnswer: {
         "@type": "Answer",
-        "text": q.answer
-      }
-    }))
+        text: q.answer,
+      },
+    })),
   };
 
   useEffect(() => {
@@ -203,7 +241,9 @@ export function FAQSchema({ questions }: { questions: { question: string; answer
       document.head.appendChild(el);
     }
     el.textContent = JSON.stringify(schema);
-    return () => { el?.remove(); };
+    return () => {
+      el?.remove();
+    };
   }, [questions]);
 
   return null;

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -2,618 +2,9 @@ import { useState, useEffect, useRef } from "react";
 import { Search as SearchIcon, X, ArrowRight } from "lucide-react";
 import { Link } from "wouter";
 import { motion, AnimatePresence } from "framer-motion";
-import { kontaktById } from "@/data/kontakte";
-
-const rot144 = kontaktById("ROT_144")!;
-const gruen143 = kontaktById("GRUEN_143")!;
-const rot117 = kontaktById("ROT_117")!;
+import { searchableContent, type SearchEntry } from "@/content/searchIndex";
 
 // Suchbare Inhalte der Website
-const searchableContent = [
-  // Verstehen
-  {
-    title: "Was ist Borderline?",
-    description: "Borderline aus Sicht von Angehörigen verstehen: Beziehungsmuster, Überflutung und Belastungsdynamik",
-    keywords: ["borderline", "bps", "persönlichkeitsstörung", "diagnose", "symptome", "emotionale instabilität", "verlassensangst", "impulsivität", "selbstbild"],
-    href: "/verstehen",
-    section: "Verstehen"
-  },
-  {
-    title: "Emotionale Dysregulation",
-    description: "Warum Emotionen bei Borderline so intensiv sind und schnell wechseln",
-    keywords: ["emotionen", "gefühle", "dysregulation", "intensität", "stimmungsschwankungen", "wut", "angst", "trauer"],
-    href: "/verstehen",
-    section: "Verstehen"
-  },
-  {
-    title: "Schwarz-Weiss-Denken",
-    description: "Die Tendenz, Menschen und Situationen als entweder ganz gut oder ganz schlecht zu sehen",
-    keywords: ["schwarz-weiss", "splitting", "idealisierung", "entwertung", "alles oder nichts"],
-    href: "/verstehen",
-    section: "Verstehen"
-  },
-  {
-    title: "Verlassensangst",
-    description: "Intensive Angst vor Zurückweisung oder Verlassenwerden",
-    keywords: ["verlassensangst", "trennungsangst", "zurückweisung", "klammern", "abhängigkeit"],
-    href: "/verstehen",
-    section: "Verstehen"
-  },
-  
-  // Unterstützen
-  {
-    title: "Wie kann ich helfen?",
-    description: "Die eigene Rolle klären und Unterstützung tragfähig mit Selbstschutz verbinden",
-    keywords: ["helfen", "unterstützen", "rolle", "balance", "begleiten"],
-    href: "/unterstuetzen/uebersicht",
-    section: "Unterstützen"
-  },
-  {
-    title: "Im Alltag unterstützen",
-    description: "Im Alltag Orientierung, Verlässlichkeit und begrenzte Verfügbarkeit gestalten",
-    keywords: ["alltag", "stabilität", "routine", "aktivitäten", "präsenz", "verfügbarkeit"],
-    href: "/unterstuetzen/alltag",
-    section: "Unterstützen"
-  },
-  {
-    title: "Therapie begleiten",
-    description: "Therapie realistisch begleiten und mit Rückschlägen oder Überforderung umgehen",
-    keywords: ["therapie", "dbt", "dialektisch-behaviorale therapie", "skills", "fortschritte", "rückschläge", "behandlung"],
-    href: "/unterstuetzen/therapie",
-    section: "Unterstützen"
-  },
-  {
-    title: "In der Krise unterstützen",
-    description: "Krisen erkennen, deeskalieren und Sicherheit gewährleisten",
-    keywords: ["krise", "eskalation", "deeskalation", "sicherheit", "notfall", "akut"],
-    href: "/unterstuetzen/krise",
-    section: "Unterstützen"
-  },
-  
-  // Kommunizieren
-  {
-    title: "Validierung",
-    description: "Gefühle und Erleben ernst nehmen, ohne jedem Vorwurf oder Verhalten zuzustimmen",
-    keywords: ["validierung", "validieren", "anerkennen", "gefühle", "zuhören", "verstehen"],
-    href: "/kommunizieren",
-    section: "Kommunizieren"
-  },
-  {
-    title: "Die 6 Stufen der Validierung",
-    description: "Von aufmerksamem Zuhören bis zu echter Augenhöhe: eine hilfreiche Orientierung für Gespräche",
-    keywords: ["stufen", "validierung", "aufmerksam", "spiegeln", "augenhöhe", "linehan"],
-    href: "/kommunizieren",
-    section: "Kommunizieren"
-  },
-  {
-    title: "SET-Kommunikation",
-    description: "Ein bekannter Gesprächsrahmen aus der Angehörigenliteratur für schwierige Situationen",
-    keywords: ["set", "support", "empathy", "truth", "kommunikation", "gespräch", "technik"],
-    href: "/kommunizieren",
-    section: "Kommunizieren"
-  },
-  {
-    title: "Ich-Botschaften",
-    description: "Eigene Gefühle und Bedürfnisse ausdrücken ohne Vorwürfe",
-    keywords: ["ich-botschaften", "bedürfnisse", "gefühle", "kommunikation", "vorwürfe"],
-    href: "/kommunizieren",
-    section: "Kommunizieren"
-  },
-  
-  // Grenzen
-  {
-    title: "Warum Grenzen wichtig sind",
-    description: "Grenzen sind keine Mauern – sie sind Leitplanken für beide Seiten",
-    keywords: ["grenzen", "wichtig", "schutz", "selbstschutz", "respekt"],
-    href: "/grenzen",
-    section: "Grenzen setzen"
-  },
-  {
-    title: "Arten von Grenzen",
-    description: "Zeitliche, emotionale, physische und finanzielle Grenzen setzen",
-    keywords: ["zeitlich", "emotional", "physisch", "finanziell", "grenzen", "arten"],
-    href: "/grenzen",
-    section: "Grenzen setzen"
-  },
-  {
-    title: "Grenzen kommunizieren",
-    description: "Wie Sie Grenzen klar, ruhig und ohne unnötige Eskalation formulieren",
-    keywords: ["kommunizieren", "formulieren", "aussprechen", "grenzen", "klar"],
-    href: "/grenzen",
-    section: "Grenzen setzen"
-  },
-  {
-    title: "Grenzen durchhalten",
-    description: "Konsequent bleiben auch wenn es schwer fällt",
-    keywords: ["durchhalten", "konsequent", "konsistent", "grenzen", "bleiben"],
-    href: "/grenzen",
-    section: "Grenzen setzen"
-  },
-  
-  // Selbstfürsorge
-  {
-    title: "Warnsignale für Überlastung",
-    description: "Emotionale, körperliche und soziale Anzeichen erkennen",
-    keywords: ["warnsignale", "überlastung", "burnout", "erschöpfung", "stress", "anzeichen"],
-    href: "/selbstfuersorge",
-    section: "Selbstfürsorge"
-  },
-  {
-    title: "Selbstfürsorge-Strategien",
-    description: "Orientierung, Entlastung und alltagstaugliche Schritte für Ihre eigene Stabilität",
-    keywords: ["selbstfürsorge", "strategien", "stabilität", "entlastung", "alltag", "achtsamkeit"],
-    href: "/selbstfuersorge",
-    section: "Selbstfürsorge"
-  },
-  {
-    title: "Atem und Beruhigung",
-    description: "Einfache Möglichkeiten, den Körper in angespannten Momenten wieder zu beruhigen",
-    keywords: ["atem", "atmen", "beruhigung", "entspannung", "stress", "sofort"],
-    href: "/selbstfuersorge",
-    section: "Selbstfürsorge"
-  },
-  {
-    title: "Professionelle Unterstützung",
-    description: "Wann und wo Sie selbst Hilfe holen sollten",
-    keywords: ["professionell", "hilfe", "therapie", "beratung", "angehörigenberatung", "psychologe"],
-    href: "/selbstfuersorge",
-    section: "Selbstfürsorge"
-  },
-  
-  // Notfall
-  {
-    title: "Notfallnummern Schweiz",
-    description: `${rot144.nummer} ${rot144.label}, ${gruen143.nummer} ${gruen143.label}, ${rot117.nummer} ${rot117.label}`,
-    keywords: ["notfall", "notruf", "144", "143", "117", "telefon", "hilfe", "akut"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-  {
-    title: "Psychiatrische Notdienste",
-    description: "Regionale psychiatrische Notaufnahmen in der Schweiz",
-    keywords: ["psychiatrie", "notdienst", "notaufnahme", "klinik", "zürich", "bern", "basel"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-  {
-    title: "Krisenplan erstellen",
-    description: "Einen persönlichen Krisenplan gemeinsam vorbereiten",
-    keywords: ["krisenplan", "vorbereitung", "notfall", "plan", "sicherheit"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-  
-  // Genesung
-  {
-    title: "Genesung ist möglich",
-    description: "Was Langzeitstudien über Remission, Besserung und realistische Hoffnung zeigen",
-    keywords: ["genesung", "remission", "recovery", "hoffnung", "prognose", "besserung", "heilung"],
-    href: "/genesung",
-    section: "Genesung"
-  },
-  {
-    title: "Remission vs. Recovery",
-    description: "Was die Begriffe bedeuten und wie sie sich unterscheiden",
-    keywords: ["remission", "recovery", "genesung", "unterschied", "definition"],
-    href: "/genesung",
-    section: "Genesung"
-  },
-  {
-    title: "Faktoren für Genesung",
-    description: "Was die Forschung über positive Verläufe zeigt",
-    keywords: ["faktoren", "genesung", "therapie", "beziehungen", "zeit", "forschung"],
-    href: "/genesung",
-    section: "Genesung"
-  },
-  
-  // Materialien
-  {
-    title: "Infografiken & Handouts",
-    description: "Herunterladbare Materialien zu allen Themen",
-    keywords: ["infografik", "handout", "download", "pdf", "material", "drucken"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "Der Leuchtturm: Ihre Rolle als Angehörige/r",
-    description: "Infografik: Orientierung, Verlässlichkeit und Selbstschutz in der Angehörigenrolle",
-    keywords: ["leuchtturm", "rolle", "stabil", "orientierung", "metapher", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "Der Eisberg: Was hinter Wut liegen kann",
-    description: "Infografik: Hinter sichtbarer Wut liegen oft Schmerz, Angst oder Scham",
-    keywords: ["eisberg", "wut", "trauer", "gefühle", "verborgen", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "Die Spaltung verstehen",
-    description: "Infografik: Wie starke Idealisierung und Entwertung in Krisen entstehen können",
-    keywords: ["spaltung", "pendel", "idealisierung", "entwertung", "ehrlich", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "U.M.W.E.G.© – Das Gesamtsystem",
-    description: "Ältere Infografik zur Gesprächsorientierung in akuten Krisensituationen",
-    keywords: ["umweg", "krise", "kommunikation", "empathie", "geduld", "system", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "Die U.M.W.-Formel: So sprechen Sie in der Krise",
-    description: "Ältere Infografik mit Schritt-für-Schritt-Orientierung für akute Krisengespräche",
-    keywords: ["umweg", "formel", "amygdala", "hippocampus", "cortex", "gehirn", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "U.M.W.E.G.© Praxis + Exit-Strategie",
-    description: "Ältere Infografik mit Gesprächsbeispiel sowie Orientierung zu Grenzen und Konsequenzen",
-    keywords: ["umweg", "praxis", "exit", "lmk", "konsequenzen", "dialog", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "Die U.M.W.-Formel in der Praxis",
-    description: "Ältere Infografik mit möglichen Formulierungen für akute Krisensituationen",
-    keywords: ["umweg", "formel", "praxis", "krise", "team", "dein", "dir", "wir", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  {
-    title: "Die 5 Leitlinien für den Alltag",
-    description: "Infografik: Orientierung für einen ruhigeren und klareren Alltag",
-    keywords: ["leitlinien", "alltag", "hektik", "routinen", "ruhe", "team", "grenzen", "infografik"],
-    href: "/materialien",
-    section: "Materialien"
-  },
-  
-  // Selbsttest
-  {
-    title: "Selbsttest: Finden Sie Ihren Weg",
-    description: "Kurze Orientierung, welche Bereiche der Website im Moment am ehesten helfen könnten",
-    keywords: ["selbsttest", "test", "orientierung", "fragen", "empfehlung"],
-    href: "/selbsttest",
-    section: "Selbsttest"
-  },
-  
-  // Selbsthilfegruppen
-  {
-    title: "Beratung & Netzwerke",
-    description: "Professionelle Beratung, Selbsthilfegruppen und Netzwerke für Angehörige",
-    keywords: ["beratung", "selbsthilfe", "selbsthilfegruppe", "netzwerk", "gruppe", "austausch", "angehörige"],
-    href: "/beratung",
-    section: "Beratung & Netzwerke"
-  },
-  {
-    title: "Stand by You Schweiz",
-    description: "Netzwerk für Angehörige von Menschen mit psychischen Erkrankungen (ehemals VASK)",
-    keywords: ["stand by you", "vask", "angehörige", "netzwerk", "beratung", "schweiz", "podcast"],
-    href: "/beratung",
-    section: "Beratung & Netzwerke"
-  },
-  {
-    title: "Selbsthilfe Schweiz",
-    description: "Datenbank für Selbsthilfegruppen in der ganzen Schweiz",
-    keywords: ["selbsthilfe schweiz", "datenbank", "gruppen", "regional", "zürich", "bern", "winterthur"],
-    href: "/beratung",
-    section: "Beratung & Netzwerke"
-  },
-  {
-    title: "Pro Mente Sana",
-    description: "Beratung für psychisch Betroffene und Angehörige",
-    keywords: ["pro mente sana", "beratung", "telefon", "email", "kostenlos"],
-    href: "/beratung",
-    section: "Beratung & Netzwerke"
-  },
-  {
-    title: "Fachstelle Angehörigenarbeit PUK Zürich",
-    description: "Kostenlose, vertrauliche Beratung für Angehörige im Kanton Zürich",
-    keywords: ["fachstelle", "angehörigenarbeit", "puk", "zürich", "beratung", "kostenlos"],
-    href: "/beratung",
-    section: "Beratung & Netzwerke"
-  },
-  
-  // Spezifische Begriffe
-  {
-    title: "DBT (Dialektisch-Behaviorale Therapie)",
-    description: "Ein zentraler und gut erforschter Therapieansatz bei Borderline",
-    keywords: ["dbt", "dialektisch", "behavioral", "therapie", "linehan", "skills"],
-    href: "/unterstuetzen/therapie",
-    section: "Unterstützen"
-  },
-  {
-    title: "PUK Zürich Notfall",
-    description: "Psychiatrische Notdienste für Kinder, Erwachsene und Menschen ab 65",
-    keywords: ["puk", "notfall", "psychiatrie", "zürich", "kinder", "erwachsene", "senioren", "kiz"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-  {
-    title: "McLean-Studie & CLPS-Studie",
-    description: "Langzeitstudien zur Remission bei Borderline",
-    keywords: ["mclean", "clps", "studie", "forschung", "zanarini", "gunderson", "langzeit"],
-    href: "/genesung",
-    section: "Genesung"
-  },
-  
-  // Glossar
-  {
-    title: "Glossar – Fachbegriffe erklärt",
-    description: "Fachbegriffe rund um Borderline für Angehörige verständlich und knapp erklärt",
-    keywords: ["glossar", "fachbegriffe", "lexikon", "erklärung", "definition", "begriffe"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  {
-    title: "Splitting",
-    description: "Schwarz-Weiss-Denken bei Borderline – Glossar-Eintrag",
-    keywords: ["splitting", "schwarz-weiss", "idealisierung", "entwertung", "glossar"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  {
-    title: "Mentalisierung",
-    description: "Die Fähigkeit, Verhalten als Ausdruck von Gedanken und Gefühlen zu verstehen",
-    keywords: ["mentalisierung", "mentalisieren", "verstehen", "gedanken", "gefühle", "glossar"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  {
-    title: "Dissoziation",
-    description: "Zustand der Abgetrenntheit von sich selbst oder der Umgebung",
-    keywords: ["dissoziation", "dissoziieren", "abgetrennt", "unwirklich", "glossar"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  {
-    title: "Co-Abhängigkeit",
-    description: "Wenn das eigene Wohlbefinden vom Zustand des anderen abhängt",
-    keywords: ["co-abhängigkeit", "abhängigkeit", "muster", "angehörige", "glossar"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  {
-    title: "Enabling",
-    description: "Unbeabsichtigtes Ermöglichen von problematischem Verhalten",
-    keywords: ["enabling", "ermöglichen", "verstärken", "konsequenzen", "glossar"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  {
-    title: "DEARMAN",
-    description: "DBT-Struktur für klare Bitten und Grenzen in schwierigen Gesprächen",
-    keywords: ["dearman", "kommunikation", "dbt", "technik", "glossar"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  {
-    title: "Leuchtturm-Prinzip",
-    description: "Metapher für die Rolle von Angehörigen – stabil sein, ohne zu steuern",
-    keywords: ["leuchtturm", "prinzip", "metapher", "rolle", "angehörige", "glossar"],
-    href: "/glossar",
-    section: "Glossar"
-  },
-  
-  // Buchempfehlungen
-  {
-    title: "Buchempfehlungen für Angehörige",
-    description: "Kuratierte deutschsprachige Bücher für Partner, Eltern und Kinder",
-    keywords: ["buch", "bücher", "buchempfehlung", "lesen", "ratgeber", "literatur"],
-    href: "/buchempfehlungen",
-    section: "Buchempfehlungen"
-  },
-  {
-    title: "Schluss mit dem Eiertanz (Buch)",
-    description: "Das Standardwerk von Mason & Kreger für Angehörige",
-    keywords: ["eiertanz", "mason", "kreger", "buch", "partner", "angehörige"],
-    href: "/buchempfehlungen",
-    section: "Buchempfehlungen"
-  },
-  {
-    title: "Ich hasse dich – verlass mich nicht",
-    description: "Klassiker zum Verständnis von Borderline",
-    keywords: ["ich hasse dich", "verlass mich nicht", "kreisman", "straus", "buch"],
-    href: "/buchempfehlungen",
-    section: "Buchempfehlungen"
-  },
-  {
-    title: "Kinderbücher über psychische Erkrankungen",
-    description: "Bücher, die Kindern helfen, psychische Erkrankungen zu verstehen",
-    keywords: ["kinderbuch", "kinder", "erklären", "mama", "papa", "psychisch"],
-    href: "/buchempfehlungen",
-    section: "Buchempfehlungen"
-  },
-  
-  // Therapieangebote (jetzt in Unterstützen/Therapie integriert)
-  {
-    title: "Therapieangebote im Kanton Zürich",
-    description: "Spezialisierte Borderline-Behandlung an der PUK Zürich",
-    keywords: ["therapie", "zürich", "puk", "behandlung", "angebot", "kanton"],
-    href: "/unterstuetzen/therapie",
-    section: "Therapie"
-  },
-  {
-    title: "DBT-Station PUK Zürich",
-    description: "Stationäre DBT-Behandlung für Erwachsene in Rheinau",
-    keywords: ["dbt", "station", "stationär", "rheinau", "puk", "erwachsene"],
-    href: "/unterstuetzen/therapie",
-    section: "Therapie"
-  },
-  {
-    title: "HYPE ZÜRI – Frühintervention für Jugendliche",
-    description: "Spezialisiertes Programm für Jugendliche ab 13 Jahren",
-    keywords: ["hype", "jugendliche", "früh", "intervention", "13", "teenager"],
-    href: "/unterstuetzen/therapie",
-    section: "Therapie"
-  },
-  {
-    title: "PUK Erwachsene (ab 65) Zürich",
-    description: "Psychiatrische Versorgung für Erwachsene ab 65 Jahren",
-    keywords: ["alter", "senioren", "65", "alterspsychiatrie", "puk"],
-    href: "/unterstuetzen/therapie",
-    section: "Therapie"
-  },
-  
-  // FAQ
-  {
-    title: "Häufig gestellte Fragen (FAQ)",
-    description: "Häufige Fragen von Angehörigen mit ruhigen und differenzierten Antworten",
-    keywords: ["faq", "fragen", "antworten", "häufig", "gestellt"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  {
-    title: "Soll ich die Diagnose ansprechen?",
-    description: "FAQ: Wann und wie über die Borderline-Diagnose sprechen",
-    keywords: ["diagnose", "ansprechen", "gespräch", "faq"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  {
-    title: "Ist Borderline heilbar?",
-    description: "FAQ: Prognose und Genesungschancen bei Borderline",
-    keywords: ["heilbar", "heilung", "prognose", "chancen", "faq"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  {
-    title: "Wann ist eine Einweisung nötig?",
-    description: "FAQ: Kriterien für psychiatrische Einweisung",
-    keywords: ["einweisung", "klinik", "stationär", "wann", "nötig", "faq"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  {
-    title: "Darf ich meinen Angehörigen verlassen?",
-    description: "FAQ: Trennung bei psychischer Erkrankung des Partners",
-    keywords: ["verlassen", "trennung", "beziehung", "ende", "darf", "faq"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  {
-    title: "Mein Angehöriger will keine Therapie",
-    description: "FAQ: Was tun, wenn Betroffene Behandlung ablehnen",
-    keywords: ["therapie", "ablehnen", "will nicht", "verweigert", "faq"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  {
-    title: "Bin ich co-abhängig?",
-    description: "FAQ: Warnsignale für Co-Abhängigkeit erkennen",
-    keywords: ["co-abhängig", "abhängigkeit", "warnsignale", "muster", "faq"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  {
-    title: "Wie schütze ich meine Kinder?",
-    description: "FAQ: Kinder vor den Auswirkungen schützen",
-    keywords: ["kinder", "schützen", "schutz", "familie", "faq"],
-    href: "/faq",
-    section: "FAQ"
-  },
-  
-  // Orientierung und Beispiele
-  {
-    title: "5-4-3-2-1 Grounding",
-    description: "Schrittweise Orientierung über die fünf Sinne, um im gegenwärtigen Moment anzukommen",
-    keywords: ["grounding", "5-4-3-2-1", "achtsamkeit", "sinne", "beruhigung", "gegenwart", "erdung"],
-    href: "/selbstfuersorge",
-    section: "Selbstfürsorge"
-  },
-  {
-    title: "DEAR-Formulierungen",
-    description: "Orientierung für klare und respektvolle Formulierungen in schwierigen Gesprächen",
-    keywords: ["dear", "dearman", "satzbaukasten", "kommunikation", "formulierung", "übung"],
-    href: "/grenzen",
-    section: "Grenzen setzen"
-  },
-  {
-    title: "Mythen und Einordnungen",
-    description: "Häufige Missverständnisse über Borderline ruhig und differenziert eingeordnet",
-    keywords: ["mythos", "fakt", "vorurteil", "aufklärung", "einordnung"],
-    href: "/verstehen",
-    section: "Verstehen"
-  },
-  {
-    title: "Spiegeln und antworten",
-    description: "Beispiele für hilfreiche und weniger hilfreiche Reaktionen in belastenden Situationen",
-    keywords: ["spiegeln", "validierung", "empathie", "reformulieren", "beispiele"],
-    href: "/kommunizieren",
-    section: "Kommunizieren"
-  },
-  {
-    title: "Belastung einordnen",
-    description: "Ruhige Orientierung zu Warnsignalen von Überforderung und Selbstfürsorge",
-    keywords: ["selbstfürsorge", "belastung", "wohlbefinden", "überlastung", "warnsignale"],
-    href: "/selbstfuersorge",
-    section: "Selbstfürsorge"
-  },
-  {
-    title: "Validierungsstufenleiter",
-    description: "Die sechs Stufen der Validierung ruhig erklärt, mit Beispielen und Stolpersteinen",
-    keywords: ["validierung", "stufen", "leiter", "linehan", "beispiele", "kommunikation"],
-    href: "/kommunizieren",
-    section: "Kommunizieren"
-  },
-
-  // Unterstützen-Unterseiten
-  {
-    title: "Im Alltag unterstützen",
-    description: "Stabilität bieten, Skills unterstützen, gemeinsame Aktivitäten – praktische Tipps für den Alltag",
-    keywords: ["alltag", "stabilität", "routine", "skills", "unterstützen", "praktisch", "tipps"],
-    href: "/unterstuetzen/alltag",
-    section: "Unterstützen"
-  },
-  {
-    title: "Therapie begleiten",
-    description: "DBT und andere Therapien verstehen, Fortschritte würdigen, mit Rückschlägen umgehen",
-    keywords: ["therapie", "dbt", "begleiten", "fortschritte", "rückschläge", "behandlung", "skills"],
-    href: "/unterstuetzen/therapie",
-    section: "Unterstützen"
-  },
-  {
-    title: "In der Krise unterstützen",
-    description: "Krisen erkennen, deeskalieren und Sicherheit gewährleisten – konkrete Handlungsschritte",
-    keywords: ["krise", "deeskalation", "sicherheit", "notfall", "akut", "handeln"],
-    href: "/unterstuetzen/krise",
-    section: "Unterstützen"
-  },
-
-  // Krisenszenarien (Notfall-Seite)
-  {
-    title: "Suiziddrohung – Was tun?",
-    description: "Schritt-für-Schritt-Anleitung bei Suiziddrohungen",
-    keywords: ["suizid", "drohung", "selbstmord", "will nicht mehr", "umbringen"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-  {
-    title: "Selbstverletzung – Was tun?",
-    description: "Anleitung bei Ritzen, Brennen oder anderen Selbstverletzungen",
-    keywords: ["selbstverletzung", "ritzen", "schneiden", "brennen", "svv"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-  {
-    title: "Aggressive Eskalation – Was tun?",
-    description: "Deeskalation bei Schreien, Drohen oder Gewalt",
-    keywords: ["aggression", "eskalation", "gewalt", "schreien", "drohen", "wut"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-  {
-    title: "Emotionale Erpressung – Was tun?",
-    description: "Umgang mit Drohungen, Schuldvorwürfen und starkem Beziehungsdruck",
-    keywords: ["erpressung", "manipulation", "schuld", "drohung", "wenn du gehst"],
-    href: "/soforthilfe",
-    section: "Krisenressourcen"
-  },
-];
-
 interface SearchProps {
   isOpen: boolean;
   onClose: () => void;
@@ -621,7 +12,7 @@ interface SearchProps {
 
 export default function Search({ isOpen, onClose }: SearchProps) {
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<typeof searchableContent>([]);
+  const [results, setResults] = useState<SearchEntry[]>([]);
   const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
@@ -650,25 +41,25 @@ export default function Search({ isOpen, onClose }: SearchProps) {
   useEffect(() => {
     if (isOpen) {
       const scrollY = window.scrollY;
-      document.body.style.position = 'fixed';
+      document.body.style.position = "fixed";
       document.body.style.top = `-${scrollY}px`;
-      document.body.style.width = '100%';
-      document.body.style.overflow = 'hidden';
+      document.body.style.width = "100%";
+      document.body.style.overflow = "hidden";
     } else {
       const scrollY = document.body.style.top;
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      document.body.style.overflow = '';
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
+      document.body.style.overflow = "";
       if (scrollY) {
-        window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+        window.scrollTo(0, parseInt(scrollY || "0", 10) * -1);
       }
     }
     return () => {
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      document.body.style.overflow = '';
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
+      document.body.style.overflow = "";
     };
   }, [isOpen]);
 
@@ -679,16 +70,21 @@ export default function Search({ isOpen, onClose }: SearchProps) {
       return;
     }
 
-    const searchTerms = query.toLowerCase().split(" ").filter(t => t.length > 1);
-    
+    const searchTerms = query
+      .toLowerCase()
+      .split(" ")
+      .filter(t => t.length > 1);
+
     const matches = searchableContent.filter(item => {
       const searchText = [
         item.title,
         item.description,
         ...item.keywords,
-        item.section
-      ].join(" ").toLowerCase();
-      
+        item.section,
+      ]
+        .join(" ")
+        .toLowerCase();
+
       return searchTerms.every(term => searchText.includes(term));
     });
 
@@ -697,8 +93,9 @@ export default function Search({ isOpen, onClose }: SearchProps) {
       const aTitle = a.title.toLowerCase();
       const bTitle = b.title.toLowerCase();
       const queryLower = query.toLowerCase();
-      
-      if (aTitle.includes(queryLower) && !bTitle.includes(queryLower)) return -1;
+
+      if (aTitle.includes(queryLower) && !bTitle.includes(queryLower))
+        return -1;
       if (!aTitle.includes(queryLower) && bTitle.includes(queryLower)) return 1;
       return 0;
     });
@@ -723,7 +120,9 @@ export default function Search({ isOpen, onClose }: SearchProps) {
       setActiveIndex(prev => (prev > 0 ? prev - 1 : results.length - 1));
     } else if (e.key === "Enter" && activeIndex >= 0) {
       e.preventDefault();
-      const link = resultsRef.current?.querySelectorAll("a")[activeIndex] as HTMLAnchorElement | undefined;
+      const link = resultsRef.current?.querySelectorAll("a")[activeIndex] as
+        | HTMLAnchorElement
+        | undefined;
       link?.click();
     }
   };
@@ -758,7 +157,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                   ref={inputRef}
                   type="text"
                   value={query}
-                  onChange={(e) => setQuery(e.target.value)}
+                  onChange={e => setQuery(e.target.value)}
                   onKeyDown={handleInputKeyDown}
                   placeholder="Suchen Sie nach Themen, z.B. 'Validierung', 'Grenzen setzen', 'Notfall'..."
                   className="flex-1 bg-transparent text-foreground placeholder:text-muted-foreground focus:outline-none text-base"
@@ -766,7 +165,11 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                   aria-label="Website durchsuchen"
                   aria-expanded={results.length > 0}
                   aria-controls="search-results"
-                  aria-activedescendant={activeIndex >= 0 ? `search-result-${activeIndex}` : undefined}
+                  aria-activedescendant={
+                    activeIndex >= 0
+                      ? `search-result-${activeIndex}`
+                      : undefined
+                  }
                 />
                 {query && (
                   <button
@@ -788,7 +191,13 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                       Geben Sie mindestens 2 Zeichen ein, um zu suchen
                     </p>
                     <div className="mt-4 flex flex-wrap justify-center gap-2">
-                      {["Validierung", "Grenzen", "Krise", "Selbstfürsorge", "DBT"].map(term => (
+                      {[
+                        "Validierung",
+                        "Grenzen",
+                        "Krise",
+                        "Selbstfürsorge",
+                        "DBT",
+                      ].map(term => (
                         <button
                           type="button"
                           key={term}
@@ -807,11 +216,17 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                       Keine Ergebnisse für "{query}"
                     </p>
                     <p className="text-sm text-muted-foreground mt-2">
-                      Versuchen Sie andere Suchbegriffe oder schauen Sie in der Navigation
+                      Versuchen Sie andere Suchbegriffe oder schauen Sie in der
+                      Navigation
                     </p>
                   </div>
                 ) : (
-                  <div className="py-2" ref={resultsRef} role="listbox" id="search-results">
+                  <div
+                    className="py-2"
+                    ref={resultsRef}
+                    role="listbox"
+                    id="search-results"
+                  >
                     {results.map((result, index) => (
                       <Link
                         key={`${result.href}-${index}`}
@@ -846,16 +261,22 @@ export default function Search({ isOpen, onClose }: SearchProps) {
               <div className="px-4 py-3 border-t border-border bg-muted/30 flex items-center justify-between text-xs text-muted-foreground">
                 <span className="flex items-center gap-2">
                   <span>
-                    <kbd className="px-1.5 py-0.5 bg-background border border-border rounded text-[10px]">↑↓</kbd>
-                    {" "}navigieren
+                    <kbd className="px-1.5 py-0.5 bg-background border border-border rounded text-[10px]">
+                      ↑↓
+                    </kbd>{" "}
+                    navigieren
                   </span>
                   <span>
-                    <kbd className="px-1.5 py-0.5 bg-background border border-border rounded text-[10px]">ESC</kbd>
-                    {" "}schliessen
+                    <kbd className="px-1.5 py-0.5 bg-background border border-border rounded text-[10px]">
+                      ESC
+                    </kbd>{" "}
+                    schliessen
                   </span>
                 </span>
                 {results.length > 0 && (
-                  <span>{results.length} Ergebnis{results.length !== 1 ? "se" : ""}</span>
+                  <span>
+                    {results.length} Ergebnis{results.length !== 1 ? "se" : ""}
+                  </span>
                 )}
               </div>
             </div>

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -1,11 +1,23 @@
 import { useState, useEffect, useRef, useCallback } from "react";
-import { ChevronUp, ChevronRight, ChevronLeft, Home, List, X, ArrowLeft } from "lucide-react";
+import {
+  ChevronUp,
+  ChevronRight,
+  ChevronLeft,
+  Home,
+  List,
+  X,
+  ArrowLeft,
+} from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { motion, AnimatePresence } from "framer-motion";
+import { getMobileFloatingMode } from "@/domain/floating-ui";
 
 // Zurück-nach-oben-Button
 export function ScrollToTopButton() {
   const [visible, setVisible] = useState(false);
+  const [location] = useLocation();
+  const floatingMode = getMobileFloatingMode(location);
+  const hideOnMobile = floatingMode !== "default";
 
   useEffect(() => {
     const toggleVisibility = () => {
@@ -19,7 +31,7 @@ export function ScrollToTopButton() {
   const scrollToTop = () => {
     window.scrollTo({
       top: 0,
-      behavior: "smooth"
+      behavior: "smooth",
     });
   };
 
@@ -32,8 +44,8 @@ export function ScrollToTopButton() {
           exit={{ opacity: 0, scale: 0.8, y: 20 }}
           transition={{ duration: 0.4, ease: "easeOut" }}
           onClick={scrollToTop}
-          className="fixed left-4 sm:left-auto sm:right-4 z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-sage-mid hover:bg-sage-dark text-white shadow-lg flex items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          style={{ bottom: 'calc(1rem + env(safe-area-inset-bottom, 0px))' }}
+          className={`fixed right-4 z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-sage-mid hover:bg-sage-dark text-white shadow-lg items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
+          style={{ bottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
           aria-label="Nach oben scrollen"
         >
           <ChevronUp className="w-6 h-6" />
@@ -67,11 +79,13 @@ const pageNames: Record<string, string> = {
   "/faq": "Häufige Fragen",
   "/glossar": "Glossar",
   "/buchempfehlungen": "Buchempfehlungen",
-  "/feedback": "Feedback"
+  "/feedback": "Feedback",
 };
 
 // Kontextbezogene Elternseite bestimmen
-function getParentInfo(location: string): { href: string; label: string } | null {
+function getParentInfo(
+  location: string
+): { href: string; label: string } | null {
   // Unterstützen-Unterseiten → Elternseite ist Unterstützen
   if (location.startsWith("/unterstuetzen/")) {
     return { href: "/unterstuetzen/uebersicht", label: "Unterstützen" };
@@ -81,11 +95,12 @@ function getParentInfo(location: string): { href: string; label: string } | null
 
 export function Breadcrumbs() {
   const [location] = useLocation();
-  
+
   // Nicht auf der Startseite anzeigen
   if (location === "/") return null;
 
-  const pageName = pageNames[location] || location.split("/").pop()?.replace(/-/g, " ") || "";
+  const pageName =
+    pageNames[location] || location.split("/").pop()?.replace(/-/g, " ") || "";
   const parent = getParentInfo(location);
 
   // Zurück-Ziel bestimmen: Elternseite oder Startseite
@@ -108,7 +123,10 @@ export function Breadcrumbs() {
           {/* Desktop Breadcrumb-Pfad */}
           <ol className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground">
             <li>
-              <Link href="/" className="flex items-center gap-1 hover:text-foreground transition-colors">
+              <Link
+                href="/"
+                className="flex items-center gap-1 hover:text-foreground transition-colors"
+              >
                 <Home className="w-4 h-4" />
                 <span>Startseite</span>
               </Link>
@@ -116,7 +134,10 @@ export function Breadcrumbs() {
             {parent && (
               <li className="flex items-center gap-2">
                 <ChevronRight className="w-4 h-4 text-muted-foreground/50" />
-                <Link href={parent.href} className="hover:text-foreground transition-colors">
+                <Link
+                  href={parent.href}
+                  className="hover:text-foreground transition-colors"
+                >
                   {parent.label}
                 </Link>
               </li>
@@ -143,6 +164,9 @@ export function TableOfContents() {
   const [headings, setHeadings] = useState<TOCItem[]>([]);
   const [activeId, setActiveId] = useState<string>("");
   const [isOpen, setIsOpen] = useState(false);
+  const [showFloatingButton, setShowFloatingButton] = useState(false);
+  const [location] = useLocation();
+  const floatingMode = getMobileFloatingMode(location);
   // Scroll-basierte aktive Markierung (kein IntersectionObserver nötig)
   const activeNavRef = useRef<HTMLButtonElement | null>(null);
 
@@ -152,30 +176,35 @@ export function TableOfContents() {
     const timer = setTimeout(() => {
       const elements = document.querySelectorAll("h2, h3");
       const items: TOCItem[] = [];
-      
+
       elements.forEach((el, index) => {
         // Prüfen ob das Heading innerhalb einer ContentSection liegt
-        const contentSectionWrapper = el.closest('[id]:not(h2):not(h3)');
-        const isInsideContentSection = contentSectionWrapper?.querySelector('[aria-expanded]') !== null;
-        
+        const contentSectionWrapper = el.closest("[id]:not(h2):not(h3)");
+        const isInsideContentSection =
+          contentSectionWrapper?.querySelector("[aria-expanded]") !== null;
+
         let id: string;
-        if (isInsideContentSection && contentSectionWrapper?.id && !contentSectionWrapper.id.startsWith('heading-')) {
+        if (
+          isInsideContentSection &&
+          contentSectionWrapper?.id &&
+          !contentSectionWrapper.id.startsWith("heading-")
+        ) {
           id = contentSectionWrapper.id;
         } else {
           id = el.id || `heading-${index}`;
           if (!el.id) el.id = id;
         }
-        
+
         // Duplikate vermeiden
         if (!items.some(item => item.id === id)) {
           items.push({
             id,
             text: el.textContent || "",
-            level: el.tagName === "H2" ? 2 : 3
+            level: el.tagName === "H2" ? 2 : 3,
           });
         }
       });
-      
+
       setHeadings(items);
       // Ersten Eintrag als aktiv setzen
       if (items.length > 0) {
@@ -199,10 +228,10 @@ export function TableOfContents() {
       headings.forEach(({ id }) => {
         const el = document.getElementById(id);
         if (!el) return;
-        
+
         const rect = el.getBoundingClientRect();
         const distance = rect.top - headerHeight;
-        
+
         // Wähle den letzten Abschnitt, der den Header-Bereich passiert hat (distance <= 100)
         // oder noch knapp darunter ist
         if (distance <= 100 && distance > bestDistance) {
@@ -217,7 +246,10 @@ export function TableOfContents() {
       }
 
       // Wenn wir ganz unten sind, den letzten Eintrag aktivieren
-      if (window.innerHeight + window.scrollY >= document.documentElement.scrollHeight - 100) {
+      if (
+        window.innerHeight + window.scrollY >=
+        document.documentElement.scrollHeight - 100
+      ) {
         bestId = headings[headings.length - 1]?.id || bestId;
       }
 
@@ -237,47 +269,57 @@ export function TableOfContents() {
   // Aktiven Eintrag in der Desktop-Sidebar in den sichtbaren Bereich scrollen
   useEffect(() => {
     if (activeNavRef.current) {
-      activeNavRef.current.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      activeNavRef.current.scrollIntoView({
+        block: "nearest",
+        behavior: "smooth",
+      });
     }
   }, [activeId]);
+
+  useEffect(() => {
+    const onScroll = () => setShowFloatingButton(window.scrollY > 280);
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
 
   // Body-Scroll-Lock für Mobile-Drawer
   useEffect(() => {
     if (isOpen) {
       const scrollY = window.scrollY;
-      document.body.style.position = 'fixed';
+      document.body.style.position = "fixed";
       document.body.style.top = `-${scrollY}px`;
-      document.body.style.width = '100%';
-      document.body.style.overflow = 'hidden';
+      document.body.style.width = "100%";
+      document.body.style.overflow = "hidden";
     } else {
       const scrollY = document.body.style.top;
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      document.body.style.overflow = '';
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
+      document.body.style.overflow = "";
       if (scrollY) {
-        window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+        window.scrollTo(0, parseInt(scrollY || "0", 10) * -1);
       }
     }
     return () => {
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      document.body.style.overflow = '';
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.width = "";
+      document.body.style.overflow = "";
     };
   }, [isOpen]);
 
   const scrollToHeading = useCallback((id: string) => {
     const el = document.getElementById(id);
     if (el) {
-      const isContentSection = el.querySelector('[aria-expanded]') !== null;
+      const isContentSection = el.querySelector("[aria-expanded]") !== null;
 
       if (isContentSection) {
         window.dispatchEvent(
           new CustomEvent("open-section", { detail: { sectionId: id } })
         );
       } else {
-        const header = document.querySelector('header');
+        const header = document.querySelector("header");
         const headerHeight = header?.getBoundingClientRect().height || 80;
         const offset = headerHeight + 20;
         const top = el.getBoundingClientRect().top + window.scrollY - offset;
@@ -292,21 +334,25 @@ export function TableOfContents() {
   if (headings.length < 3) return null;
 
   // Aktiver Eintrag Styling
-  const activeClass = "bg-terracotta-lighter text-terracotta-darker font-semibold border-l-2 border-l-terracotta-mid";
-  const inactiveClass = "text-muted-foreground hover:text-foreground hover:bg-muted/60";
+  const activeClass =
+    "bg-terracotta-lighter text-terracotta-darker font-semibold border-l-2 border-l-terracotta-mid";
+  const inactiveClass =
+    "text-muted-foreground hover:text-foreground hover:bg-muted/60";
 
   return (
     <>
       {/* ─── Mobile: Floating TOC Button ─── */}
-      <motion.button
-        onClick={() => setIsOpen(true)}
-        className="min-[1400px]:hidden fixed left-4 z-40 h-11 px-4 rounded-full bg-background border border-border shadow-lg flex items-center gap-2 text-sm font-medium text-foreground"
-        style={{ bottom: 'calc(1rem + env(safe-area-inset-bottom, 0px))' }}
-        aria-label="Inhaltsverzeichnis öffnen"
-      >
-        <List className="w-4 h-4" />
-        <span>Inhalt</span>
-      </motion.button>
+      {floatingMode === "content" && showFloatingButton && (
+        <motion.button
+          onClick={() => setIsOpen(true)}
+          className="min-[1400px]:hidden fixed right-4 z-40 h-11 px-4 rounded-full bg-background border border-border shadow-lg flex items-center gap-2 text-sm font-medium text-foreground"
+          style={{ bottom: "calc(7.5rem + env(safe-area-inset-bottom, 0px))" }}
+          aria-label="Inhaltsverzeichnis öffnen"
+        >
+          <List className="w-4 h-4" />
+          <span>Inhalt</span>
+        </motion.button>
+      )}
 
       {/* ─── Mobile: Overlay ─── */}
       <AnimatePresence>
@@ -330,7 +376,7 @@ export function TableOfContents() {
             exit={{ y: "100%" }}
             transition={{ duration: 0.2, ease: "easeOut" }}
             className="min-[1400px]:hidden fixed left-0 right-0 bottom-0 max-h-[70vh] bg-background z-50 rounded-t-2xl shadow-2xl overflow-hidden flex flex-col"
-            style={{ paddingBottom: 'env(safe-area-inset-bottom, 0px)' }}
+            style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
           >
             {/* Drawer Handle */}
             <div className="flex justify-center pt-3 pb-1">
@@ -339,9 +385,15 @@ export function TableOfContents() {
 
             {/* Drawer Header */}
             <div className="flex items-center justify-between px-5 py-3 border-b border-border">
-              <span className="font-semibold text-foreground text-base" role="heading" aria-level={2}>Inhaltsverzeichnis</span>
+              <span
+                className="font-semibold text-foreground text-base"
+                role="heading"
+                aria-level={2}
+              >
+                Inhaltsverzeichnis
+              </span>
               <button
-                type="button" 
+                type="button"
                 onClick={() => setIsOpen(false)}
                 className="w-8 h-8 rounded-full hover:bg-muted flex items-center justify-center"
                 aria-label="Schliessen"
@@ -359,11 +411,9 @@ export function TableOfContents() {
                       type="button"
                       onClick={() => scrollToHeading(id)}
                       aria-label={`Zum Abschnitt: ${text}`}
-                    className={`w-full text-left px-3 py-2.5 rounded-lg text-sm transition-colors ${
-                      level === 3 ? "pl-7" : ""
-                    } ${
-                        activeId === id ? activeClass : inactiveClass
-                      }`}
+                      className={`w-full text-left px-3 py-2.5 rounded-lg text-sm transition-colors ${
+                        level === 3 ? "pl-7" : ""
+                      } ${activeId === id ? activeClass : inactiveClass}`}
                     >
                       {text}
                     </button>
@@ -379,7 +429,13 @@ export function TableOfContents() {
       <div className="hidden min-[1400px]:block fixed left-4 top-1/2 -translate-y-1/2 w-56 z-30 max-h-[70vh]">
         <div className="bg-background/90 backdrop-blur-md rounded-xl border border-border/50 shadow-sm overflow-hidden flex flex-col max-h-[70vh]">
           <div className="px-4 pt-4 pb-2">
-            <span className="font-semibold text-foreground text-sm" role="heading" aria-level={2}>Auf dieser Seite</span>
+            <span
+              className="font-semibold text-foreground text-sm"
+              role="heading"
+              aria-level={2}
+            >
+              Auf dieser Seite
+            </span>
           </div>
           <nav className="overflow-y-auto overscroll-contain px-2 pb-3 flex-1">
             <ul className="space-y-0.5">
@@ -392,9 +448,7 @@ export function TableOfContents() {
                     aria-label={`Zum Abschnitt: ${text}`}
                     className={`w-full text-left px-2.5 py-1.5 rounded-md text-xs transition-colors line-clamp-2 ${
                       level === 3 ? "pl-5" : ""
-                    } ${
-                      activeId === id ? activeClass : inactiveClass
-                    }`}
+                    } ${activeId === id ? activeClass : inactiveClass}`}
                   >
                     {text}
                   </button>

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -37,7 +37,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
         <div className="flex items-center justify-between gap-2 lg:gap-4 h-16 md:h-20">
           <Link href="/" className="flex items-center gap-2 group shrink-0">
             <img
-              src="https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/NqViLFGTREhdSTsm.webp"
+              src="/favicon-192.png"
               alt="Startseite"
               className="w-8 h-8 md:w-10 md:h-10 rounded-full"
               width={40}
@@ -51,7 +51,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
           </Link>
 
           <nav className="hidden lg:flex items-center gap-0.5 xl:gap-1 shrink-0">
-            {navItems.map((item) => {
+            {navItems.map(item => {
               const isActive = location.startsWith(item.href);
               return (
                 <Link
@@ -95,7 +95,10 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               <SearchIcon className="w-5 h-5" />
             </button>
 
-            <Link href="/soforthilfe" aria-label="Soforthilfe – Notfallnummern und Krisenberatung">
+            <Link
+              href="/soforthilfe"
+              aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
+            >
               <Button
                 variant="default"
                 size="sm"
@@ -113,7 +116,11 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               className="lg:hidden p-2.5 -m-0.5 rounded-lg hover:bg-muted transition-colors"
               aria-label={mobileMenuOpen ? "Menü schliessen" : "Menü öffnen"}
             >
-              {mobileMenuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+              {mobileMenuOpen ? (
+                <X className="w-6 h-6" />
+              ) : (
+                <Menu className="w-6 h-6" />
+              )}
             </button>
           </div>
         </div>

--- a/client/src/content/grenzen.ts
+++ b/client/src/content/grenzen.ts
@@ -1,0 +1,59 @@
+import { AlertTriangle, Filter, Heart, Shield } from "lucide-react";
+
+export const grenzenSubcategories = [
+  { id: "alle", label: "Alle", icon: Filter },
+  { id: "erkennen", label: "Erkennen", icon: AlertTriangle },
+  { id: "kommunizieren", label: "Kommunizieren", icon: Heart },
+  { id: "handeln", label: "Handeln", icon: Shield },
+];
+
+export const grenzenItems = [
+  {
+    title: "Die DEAR-Technik",
+    description: "4 Schritte für respektvolle Grenzsetzung",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/yBSkvBJGSeNvxINq.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DDkqUiaNJwizEtPv.pdf",
+    category: "kommunizieren",
+  },
+  {
+    title: "Spiegeln statt Aufsaugen",
+    description: "Mitfühlen ohne Übernehmen",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/rbDvjxTUWJMXQCPj.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/jJFieYXEiIxbrazO.pdf",
+    category: "kommunizieren",
+  },
+  {
+    title: "Die 4 Arten von Grenzen",
+    description: "Physisch, emotional, zeitlich, materiell",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/otBFiwevLwWQsinR.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/KiiZJfLHYOlNVTsn.pdf",
+    category: "erkennen",
+  },
+  {
+    title: "Grenzen erkennen",
+    description: "5 Warnsignale Ihres Körpers",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/pPRcjWVKERfSWUPL.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/FftUeWuOzmxjrUEi.pdf",
+    category: "erkennen",
+  },
+  {
+    title: "L.M.K. (Lebe Mit Konsequenzen)",
+    description: "Wenn Grenzen nicht respektiert werden",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/izBLuzTFtMDeQYoc.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/eyhngTnxXoekiWwJ.pdf",
+    category: "handeln",
+  },
+  {
+    title: "Spickzettel Grenzen",
+    description: "A4 mit den wichtigsten Sätzen",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/avGqFKFuKFfFYANu.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/obwIZiRPiVPphIUX.pdf",
+    category: "handeln",
+  },
+];

--- a/client/src/content/kommunizieren.ts
+++ b/client/src/content/kommunizieren.ts
@@ -1,0 +1,53 @@
+import { Filter, Heart, MessageCircle, ShieldAlert } from "lucide-react";
+
+export const kommSubcategories = [
+  { id: "alle", label: "Alle", icon: Filter },
+  { id: "techniken", label: "Techniken", icon: Heart },
+  { id: "konflikte", label: "Konflikte", icon: ShieldAlert },
+  { id: "praxis", label: "Praxis", icon: MessageCircle },
+];
+
+export const kommItems = [
+  {
+    title: "Wenn Gespräche kippen: 3 Schritte",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/kWTjVSZAwAXAymgw.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/eEpcTcWSbYQpNzJv.pdf",
+    category: "techniken",
+  },
+  {
+    title: "Grenzen setzen, ohne zu eskalieren",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/QrgVLpdeorAWgKvg.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YyBYayMoMIGwTZtM.pdf",
+    category: "konflikte",
+  },
+  {
+    title: "Pause statt Streit",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VCooXJsQnRmSZGul.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/fGgpuKMuDfzJYgrc.pdf",
+    category: "konflikte",
+  },
+  {
+    title: "Zuhören ohne Zustimmen",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/eeZIHGmfprWnoPPf.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/toeDsBefZFNbxXYc.pdf",
+    category: "techniken",
+  },
+  {
+    title: "Beispiel-Dialog",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YZGoCcmXszaQGVtV.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WZdsgoAKaJwvMCjp.pdf",
+    category: "praxis",
+  },
+  {
+    title: "Spickzettel Krisenkommunikation (A4)",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tgVHTaXVryVEuEss.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YvXkEbRmwIcCFtsj.pdf",
+    category: "praxis",
+  },
+];

--- a/client/src/content/materials.ts
+++ b/client/src/content/materials.ts
@@ -1,0 +1,252 @@
+export type Material = {
+  id: string;
+  title: string;
+  description: string;
+  category:
+    | "verstehen"
+    | "unterstuetzen"
+    | "kommunizieren"
+    | "grenzen"
+    | "selbstfuersorge"
+    | "genesung"
+    | "soforthilfe";
+  kind:
+    | "Infografik"
+    | "Spickzettel"
+    | "Checkliste"
+    | "Notfallkarte"
+    | "Notfallplan";
+  url: string;
+  downloadUrl?: string;
+  pdfUrl?: string;
+  previewUrl?: string;
+  isHtml?: boolean;
+  priority?: "core" | "secondary";
+};
+
+export const materials: Material[] = [
+  {
+    id: "notfallkarte-zuerich",
+    title: "Notfallkarte Zürich – Psychische Krise",
+    description:
+      "Alle wichtigen Nummern für Angehörige auf einer A4-Seite. Für akute Orientierung, wenn rasches Handeln nötig ist.",
+    category: "soforthilfe",
+    kind: "Notfallkarte",
+    url: "/notfallkarte.html",
+    previewUrl: "/notfallkarte-preview.webp",
+    downloadUrl: "/notfallkarte.html",
+    pdfUrl: "/Notfallkarte-Zuerich-Psychische-Krise.pdf",
+    isHtml: true,
+    priority: "core",
+  },
+  {
+    id: "notfallplan-krise",
+    title: "Notfallplan Krise – Suizidgedanken & Selbstverletzung",
+    description:
+      "Knappe 4-Schritte-Anleitung für Angehörige bei Suizidgedanken oder Selbstverletzung.",
+    category: "soforthilfe",
+    kind: "Notfallplan",
+    url: "/notfallplan-krise-v03-preview.webp",
+    downloadUrl: "/notfallplan-krise-v03.pdf",
+    priority: "core",
+  },
+  {
+    id: "leuchtturm",
+    title: "Der Leuchtturm – Ihre Rolle als Angehörige/r",
+    description:
+      "Orientierung zur Angehörigenrolle: stabil bleiben, ohne das Schiff steuern zu wollen.",
+    category: "verstehen",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GbFCyQhEWIKomzXw.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DNGijMOYFghXAsLm.pdf",
+    priority: "core",
+  },
+  {
+    id: "eisberg",
+    title: "Der Eisberg – Wut ist oft die Spitze",
+    description:
+      "Wut, Schmerz, Angst und Scham als Beziehungsgeschehen verständlicher einordnen.",
+    category: "verstehen",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MLLwefeyaKvtThbK.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RNKtfQQMvhlSyiIp.pdf",
+    priority: "core",
+  },
+  {
+    id: "rolle-klaeren",
+    title: "Ihre Rolle klären – Was Sie sein können (und was nicht)",
+    description:
+      "Klarheit über hilfreiche Unterstützung, Verantwortung und die Grenzen der Angehörigenrolle.",
+    category: "unterstuetzen",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WUiQpUWjKIjpSRDC.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/JMOjSacqrnDcAkoB.pdf",
+    priority: "core",
+  },
+  {
+    id: "krisenkommunikation",
+    title: "Spickzettel Krisenkommunikation (A4)",
+    description:
+      "Kurze Formulierungen für akute Spannungszustände, wenn klare Sprache mehr hilft als lange Erklärungen.",
+    category: "kommunizieren",
+    kind: "Spickzettel",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tgVHTaXVryVEuEss.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YvXkEbRmwIcCFtsj.pdf",
+    priority: "core",
+  },
+  {
+    id: "grenzen-spickzettel",
+    title: "Spickzettel Grenzen – Die wichtigsten Sätze",
+    description:
+      "Knappe Formulierungen für klare, respektvolle Grenzsetzung im Alltag und in belasteten Gesprächen.",
+    category: "grenzen",
+    kind: "Spickzettel",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/avGqFKFuKFfFYANu.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/obwIZiRPiVPphIUX.pdf",
+    priority: "core",
+  },
+  {
+    id: "warnsignale",
+    title: "Warnsignale der Überlastung",
+    description:
+      "Orientierung für Angehörige, wenn Erschöpfung, Alarmbereitschaft oder Rückzug zu viel Raum einnehmen.",
+    category: "selbstfuersorge",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OEUNVdTyojBBYTic.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VdAxPxngFzgNImxg.pdf",
+    priority: "core",
+  },
+  {
+    id: "schuld-verantwortung",
+    title: "Schuld, Verantwortung und was dazwischen liegt",
+    description:
+      "Hilft, Schuldgefühle bei Angehörigen zu entlasten und Verantwortung differenzierter zu sehen.",
+    category: "selbstfuersorge",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/TgzrtmiUbRscTBlg.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/jPuhxPHHtFSjOTly.pdf",
+    priority: "secondary",
+  },
+  {
+    id: "spaltung",
+    title: "Spaltung – das Pendel zwischen Extremen",
+    description:
+      "Einordnung von Idealisierung, Entwertung und dem erschwerten Zugang zu Grautönen unter Stress.",
+    category: "verstehen",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WRORriPmZftmvKTL.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RtdVgflJuCNAhEKk.pdf",
+    priority: "secondary",
+  },
+  {
+    id: "alarm-modus",
+    title: "Alarm-Modus vs. Denk-Modus",
+    description:
+      "Warum logische Klärung unter starker Anspannung oft nicht erreichbar ist und zuerst Beruhigung hilft.",
+    category: "verstehen",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/sSUJoOUTiuWgrkiZ.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tlKAOpYHdCNAtovE.pdf",
+    priority: "secondary",
+  },
+  {
+    id: "wenn-worte-treffen",
+    title: "Wenn Worte treffen – 5 häufige Schuldzuweisungen",
+    description:
+      "Typische anklagende Sätze einordnen und eigene Reaktionen ruhiger und klarer gestalten.",
+    category: "kommunizieren",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/azZbLPyPkSupQskI.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/hEXKCmWYeiyUnwXr.pdf",
+    priority: "secondary",
+  },
+  {
+    id: "dear",
+    title: "Die DEAR-Technik – Grenzen setzen ohne Vorwürfe",
+    description:
+      "DBT-orientierte Struktur für klare Bitten und Grenzsetzungen ohne unnötige Eskalation.",
+    category: "grenzen",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/yBSkvBJGSeNvxINq.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DDkqUiaNJwizEtPv.pdf",
+    priority: "secondary",
+  },
+  {
+    id: "radikale-akzeptanz",
+    title: "Radikale Akzeptanz – Aufhören zu kämpfen, anfangen zu handeln",
+    description:
+      "Hilft Angehörigen, Realität anzuerkennen, ohne aufzugeben oder alles gutzuheissen.",
+    category: "selbstfuersorge",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OmxdguWaaXAkElDp.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/SkBpjnDHfNmPbmnd.pdf",
+    priority: "secondary",
+  },
+  {
+    id: "genesung-zahlen",
+    title: "Genesung in Zahlen – Was die Forschung zeigt",
+    description:
+      "Langfristige Hoffnung mit realistischen Daten: Besserung ist möglich, aber selten linear.",
+    category: "genesung",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tyFTHNjsUagqrXiS.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MunlHDCNqnsOhBFn.pdf",
+    priority: "secondary",
+  },
+  {
+    id: "kinder",
+    title: "Wenn Mama oder Papa grosse Gefühle hat",
+    description:
+      "Altersgerechte Erklärung für Kinder und Hinweise zum Schutz von Kindern im belasteten Familiensystem.",
+    category: "verstehen",
+    kind: "Infografik",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/PrnKdbomSunLKPVv.webp",
+    downloadUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/birikKPATMlHGPWf.pdf",
+    priority: "secondary",
+  },
+];
+
+export const quickStarts = [
+  {
+    id: "soforthilfe",
+    title: "Akute Krise",
+    text: "Wenn rasche Orientierung und Notfallnummern nötig sind.",
+    color: "var(--color-alert)",
+    bg: "var(--color-alert-wash)",
+  },
+  {
+    id: "verstehen",
+    title: "Ich brauche Orientierung",
+    text: "Wenn Sie Dynamiken besser einordnen möchten.",
+    color: "var(--color-sage-mid)",
+    bg: "var(--color-sage-wash)",
+  },
+  {
+    id: "kommunizieren",
+    title: "Schwierige Gespräche",
+    text: "Wenn Worte schnell kippen oder verletzen.",
+    color: "var(--color-slate-blue)",
+    bg: "var(--color-slate-wash)",
+  },
+  {
+    id: "selbstfuersorge",
+    title: "Ich bin selbst am Limit",
+    text: "Wenn Erschöpfung, Schuld oder Daueranspannung dominieren.",
+    color: "var(--color-terracotta-mid)",
+    bg: "var(--color-terracotta-wash)",
+  },
+];

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -1,0 +1,1079 @@
+export type SearchEntry = {
+  title: string;
+  description: string;
+  keywords: string[];
+  href: string;
+  section: string;
+};
+
+export const searchableContent = [
+  // Verstehen
+  {
+    title: "Was ist Borderline?",
+    description:
+      "Borderline aus Sicht von Angehörigen verstehen: Beziehungsmuster, Überflutung und Belastungsdynamik",
+    keywords: [
+      "borderline",
+      "bps",
+      "persönlichkeitsstörung",
+      "diagnose",
+      "symptome",
+      "emotionale instabilität",
+      "verlassensangst",
+      "impulsivität",
+      "selbstbild",
+    ],
+    href: "/verstehen",
+    section: "Verstehen",
+  },
+  {
+    title: "Emotionale Dysregulation",
+    description:
+      "Warum Emotionen bei Borderline so intensiv sind und schnell wechseln",
+    keywords: [
+      "emotionen",
+      "gefühle",
+      "dysregulation",
+      "intensität",
+      "stimmungsschwankungen",
+      "wut",
+      "angst",
+      "trauer",
+    ],
+    href: "/verstehen",
+    section: "Verstehen",
+  },
+  {
+    title: "Schwarz-Weiss-Denken",
+    description:
+      "Die Tendenz, Menschen und Situationen als entweder ganz gut oder ganz schlecht zu sehen",
+    keywords: [
+      "schwarz-weiss",
+      "splitting",
+      "idealisierung",
+      "entwertung",
+      "alles oder nichts",
+    ],
+    href: "/verstehen",
+    section: "Verstehen",
+  },
+  {
+    title: "Verlassensangst",
+    description: "Intensive Angst vor Zurückweisung oder Verlassenwerden",
+    keywords: [
+      "verlassensangst",
+      "trennungsangst",
+      "zurückweisung",
+      "klammern",
+      "abhängigkeit",
+    ],
+    href: "/verstehen",
+    section: "Verstehen",
+  },
+
+  // Unterstützen
+  {
+    title: "Wie kann ich helfen?",
+    description:
+      "Die eigene Rolle klären und Unterstützung tragfähig mit Selbstschutz verbinden",
+    keywords: ["helfen", "unterstützen", "rolle", "balance", "begleiten"],
+    href: "/unterstuetzen/uebersicht",
+    section: "Unterstützen",
+  },
+  {
+    title: "Im Alltag unterstützen",
+    description:
+      "Im Alltag Orientierung, Verlässlichkeit und begrenzte Verfügbarkeit gestalten",
+    keywords: [
+      "alltag",
+      "stabilität",
+      "routine",
+      "aktivitäten",
+      "präsenz",
+      "verfügbarkeit",
+    ],
+    href: "/unterstuetzen/alltag",
+    section: "Unterstützen",
+  },
+  {
+    title: "Therapie begleiten",
+    description:
+      "Therapie realistisch begleiten und mit Rückschlägen oder Überforderung umgehen",
+    keywords: [
+      "therapie",
+      "dbt",
+      "dialektisch-behaviorale therapie",
+      "skills",
+      "fortschritte",
+      "rückschläge",
+      "behandlung",
+    ],
+    href: "/unterstuetzen/therapie",
+    section: "Unterstützen",
+  },
+  {
+    title: "In der Krise unterstützen",
+    description: "Krisen erkennen, deeskalieren und Sicherheit gewährleisten",
+    keywords: [
+      "krise",
+      "eskalation",
+      "deeskalation",
+      "sicherheit",
+      "notfall",
+      "akut",
+    ],
+    href: "/unterstuetzen/krise",
+    section: "Unterstützen",
+  },
+
+  // Kommunizieren
+  {
+    title: "Validierung",
+    description:
+      "Gefühle und Erleben ernst nehmen, ohne jedem Vorwurf oder Verhalten zuzustimmen",
+    keywords: [
+      "validierung",
+      "validieren",
+      "anerkennen",
+      "gefühle",
+      "zuhören",
+      "verstehen",
+    ],
+    href: "/kommunizieren",
+    section: "Kommunizieren",
+  },
+  {
+    title: "Die 6 Stufen der Validierung",
+    description:
+      "Von aufmerksamem Zuhören bis zu echter Augenhöhe: eine hilfreiche Orientierung für Gespräche",
+    keywords: [
+      "stufen",
+      "validierung",
+      "aufmerksam",
+      "spiegeln",
+      "augenhöhe",
+      "linehan",
+    ],
+    href: "/kommunizieren",
+    section: "Kommunizieren",
+  },
+  {
+    title: "SET-Kommunikation",
+    description:
+      "Ein bekannter Gesprächsrahmen aus der Angehörigenliteratur für schwierige Situationen",
+    keywords: [
+      "set",
+      "support",
+      "empathy",
+      "truth",
+      "kommunikation",
+      "gespräch",
+      "technik",
+    ],
+    href: "/kommunizieren",
+    section: "Kommunizieren",
+  },
+  {
+    title: "Ich-Botschaften",
+    description: "Eigene Gefühle und Bedürfnisse ausdrücken ohne Vorwürfe",
+    keywords: [
+      "ich-botschaften",
+      "bedürfnisse",
+      "gefühle",
+      "kommunikation",
+      "vorwürfe",
+    ],
+    href: "/kommunizieren",
+    section: "Kommunizieren",
+  },
+
+  // Grenzen
+  {
+    title: "Warum Grenzen wichtig sind",
+    description:
+      "Grenzen sind keine Mauern – sie sind Leitplanken für beide Seiten",
+    keywords: ["grenzen", "wichtig", "schutz", "selbstschutz", "respekt"],
+    href: "/grenzen",
+    section: "Grenzen setzen",
+  },
+  {
+    title: "Arten von Grenzen",
+    description:
+      "Zeitliche, emotionale, physische und finanzielle Grenzen setzen",
+    keywords: [
+      "zeitlich",
+      "emotional",
+      "physisch",
+      "finanziell",
+      "grenzen",
+      "arten",
+    ],
+    href: "/grenzen",
+    section: "Grenzen setzen",
+  },
+  {
+    title: "Grenzen kommunizieren",
+    description:
+      "Wie Sie Grenzen klar, ruhig und ohne unnötige Eskalation formulieren",
+    keywords: [
+      "kommunizieren",
+      "formulieren",
+      "aussprechen",
+      "grenzen",
+      "klar",
+    ],
+    href: "/grenzen",
+    section: "Grenzen setzen",
+  },
+  {
+    title: "Grenzen durchhalten",
+    description: "Konsequent bleiben auch wenn es schwer fällt",
+    keywords: ["durchhalten", "konsequent", "konsistent", "grenzen", "bleiben"],
+    href: "/grenzen",
+    section: "Grenzen setzen",
+  },
+
+  // Selbstfürsorge
+  {
+    title: "Warnsignale für Überlastung",
+    description: "Emotionale, körperliche und soziale Anzeichen erkennen",
+    keywords: [
+      "warnsignale",
+      "überlastung",
+      "burnout",
+      "erschöpfung",
+      "stress",
+      "anzeichen",
+    ],
+    href: "/selbstfuersorge",
+    section: "Selbstfürsorge",
+  },
+  {
+    title: "Selbstfürsorge-Strategien",
+    description:
+      "Orientierung, Entlastung und alltagstaugliche Schritte für Ihre eigene Stabilität",
+    keywords: [
+      "selbstfürsorge",
+      "strategien",
+      "stabilität",
+      "entlastung",
+      "alltag",
+      "achtsamkeit",
+    ],
+    href: "/selbstfuersorge",
+    section: "Selbstfürsorge",
+  },
+  {
+    title: "Atem und Beruhigung",
+    description:
+      "Einfache Möglichkeiten, den Körper in angespannten Momenten wieder zu beruhigen",
+    keywords: [
+      "atem",
+      "atmen",
+      "beruhigung",
+      "entspannung",
+      "stress",
+      "sofort",
+    ],
+    href: "/selbstfuersorge",
+    section: "Selbstfürsorge",
+  },
+  {
+    title: "Professionelle Unterstützung",
+    description: "Wann und wo Sie selbst Hilfe holen sollten",
+    keywords: [
+      "professionell",
+      "hilfe",
+      "therapie",
+      "beratung",
+      "angehörigenberatung",
+      "psychologe",
+    ],
+    href: "/selbstfuersorge",
+    section: "Selbstfürsorge",
+  },
+
+  // Notfall
+  {
+    title: "Notfallnummern Schweiz",
+    description: "144 Sanitätsnotruf, 143 Die Dargebotene Hand, 117 Polizei",
+    keywords: [
+      "notfall",
+      "notruf",
+      "144",
+      "143",
+      "117",
+      "telefon",
+      "hilfe",
+      "akut",
+    ],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+  {
+    title: "Psychiatrische Notdienste",
+    description: "Regionale psychiatrische Notaufnahmen in der Schweiz",
+    keywords: [
+      "psychiatrie",
+      "notdienst",
+      "notaufnahme",
+      "klinik",
+      "zürich",
+      "bern",
+      "basel",
+    ],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+  {
+    title: "Krisenplan erstellen",
+    description: "Einen persönlichen Krisenplan gemeinsam vorbereiten",
+    keywords: ["krisenplan", "vorbereitung", "notfall", "plan", "sicherheit"],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+
+  // Genesung
+  {
+    title: "Genesung ist möglich",
+    description:
+      "Was Langzeitstudien über Remission, Besserung und realistische Hoffnung zeigen",
+    keywords: [
+      "genesung",
+      "remission",
+      "recovery",
+      "hoffnung",
+      "prognose",
+      "besserung",
+      "heilung",
+    ],
+    href: "/genesung",
+    section: "Genesung",
+  },
+  {
+    title: "Remission vs. Recovery",
+    description: "Was die Begriffe bedeuten und wie sie sich unterscheiden",
+    keywords: [
+      "remission",
+      "recovery",
+      "genesung",
+      "unterschied",
+      "definition",
+    ],
+    href: "/genesung",
+    section: "Genesung",
+  },
+  {
+    title: "Faktoren für Genesung",
+    description: "Was die Forschung über positive Verläufe zeigt",
+    keywords: [
+      "faktoren",
+      "genesung",
+      "therapie",
+      "beziehungen",
+      "zeit",
+      "forschung",
+    ],
+    href: "/genesung",
+    section: "Genesung",
+  },
+
+  // Materialien
+  {
+    title: "Infografiken & Handouts",
+    description: "Herunterladbare Materialien zu allen Themen",
+    keywords: [
+      "infografik",
+      "handout",
+      "download",
+      "pdf",
+      "material",
+      "drucken",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "Der Leuchtturm: Ihre Rolle als Angehörige/r",
+    description:
+      "Infografik: Orientierung, Verlässlichkeit und Selbstschutz in der Angehörigenrolle",
+    keywords: [
+      "leuchtturm",
+      "rolle",
+      "stabil",
+      "orientierung",
+      "metapher",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "Der Eisberg: Was hinter Wut liegen kann",
+    description:
+      "Infografik: Hinter sichtbarer Wut liegen oft Schmerz, Angst oder Scham",
+    keywords: [
+      "eisberg",
+      "wut",
+      "trauer",
+      "gefühle",
+      "verborgen",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "Die Spaltung verstehen",
+    description:
+      "Infografik: Wie starke Idealisierung und Entwertung in Krisen entstehen können",
+    keywords: [
+      "spaltung",
+      "pendel",
+      "idealisierung",
+      "entwertung",
+      "ehrlich",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "U.M.W.E.G.© – Das Gesamtsystem",
+    description:
+      "Ältere Infografik zur Gesprächsorientierung in akuten Krisensituationen",
+    keywords: [
+      "umweg",
+      "krise",
+      "kommunikation",
+      "empathie",
+      "geduld",
+      "system",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "Die U.M.W.-Formel: So sprechen Sie in der Krise",
+    description:
+      "Ältere Infografik mit Schritt-für-Schritt-Orientierung für akute Krisengespräche",
+    keywords: [
+      "umweg",
+      "formel",
+      "amygdala",
+      "hippocampus",
+      "cortex",
+      "gehirn",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "U.M.W.E.G.© Praxis + Exit-Strategie",
+    description:
+      "Ältere Infografik mit Gesprächsbeispiel sowie Orientierung zu Grenzen und Konsequenzen",
+    keywords: [
+      "umweg",
+      "praxis",
+      "exit",
+      "lmk",
+      "konsequenzen",
+      "dialog",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "Die U.M.W.-Formel in der Praxis",
+    description:
+      "Ältere Infografik mit möglichen Formulierungen für akute Krisensituationen",
+    keywords: [
+      "umweg",
+      "formel",
+      "praxis",
+      "krise",
+      "team",
+      "dein",
+      "dir",
+      "wir",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "Die 5 Leitlinien für den Alltag",
+    description:
+      "Infografik: Orientierung für einen ruhigeren und klareren Alltag",
+    keywords: [
+      "leitlinien",
+      "alltag",
+      "hektik",
+      "routinen",
+      "ruhe",
+      "team",
+      "grenzen",
+      "infografik",
+    ],
+    href: "/materialien",
+    section: "Materialien",
+  },
+
+  // Selbsttest
+  {
+    title: "Selbsttest: Finden Sie Ihren Weg",
+    description:
+      "Kurze Orientierung, welche Bereiche der Website im Moment am ehesten helfen könnten",
+    keywords: ["selbsttest", "test", "orientierung", "fragen", "empfehlung"],
+    href: "/selbsttest",
+    section: "Selbsttest",
+  },
+
+  // Selbsthilfegruppen
+  {
+    title: "Beratung & Netzwerke",
+    description:
+      "Professionelle Beratung, Selbsthilfegruppen und Netzwerke für Angehörige",
+    keywords: [
+      "beratung",
+      "selbsthilfe",
+      "selbsthilfegruppe",
+      "netzwerk",
+      "gruppe",
+      "austausch",
+      "angehörige",
+    ],
+    href: "/beratung",
+    section: "Beratung & Netzwerke",
+  },
+  {
+    title: "Stand by You Schweiz",
+    description:
+      "Netzwerk für Angehörige von Menschen mit psychischen Erkrankungen (ehemals VASK)",
+    keywords: [
+      "stand by you",
+      "vask",
+      "angehörige",
+      "netzwerk",
+      "beratung",
+      "schweiz",
+      "podcast",
+    ],
+    href: "/beratung",
+    section: "Beratung & Netzwerke",
+  },
+  {
+    title: "Selbsthilfe Schweiz",
+    description: "Datenbank für Selbsthilfegruppen in der ganzen Schweiz",
+    keywords: [
+      "selbsthilfe schweiz",
+      "datenbank",
+      "gruppen",
+      "regional",
+      "zürich",
+      "bern",
+      "winterthur",
+    ],
+    href: "/beratung",
+    section: "Beratung & Netzwerke",
+  },
+  {
+    title: "Pro Mente Sana",
+    description: "Beratung für psychisch Betroffene und Angehörige",
+    keywords: ["pro mente sana", "beratung", "telefon", "email", "kostenlos"],
+    href: "/beratung",
+    section: "Beratung & Netzwerke",
+  },
+  {
+    title: "Fachstelle Angehörigenarbeit PUK Zürich",
+    description:
+      "Kostenlose, vertrauliche Beratung für Angehörige im Kanton Zürich",
+    keywords: [
+      "fachstelle",
+      "angehörigenarbeit",
+      "puk",
+      "zürich",
+      "beratung",
+      "kostenlos",
+    ],
+    href: "/beratung",
+    section: "Beratung & Netzwerke",
+  },
+
+  // Spezifische Begriffe
+  {
+    title: "DBT (Dialektisch-Behaviorale Therapie)",
+    description:
+      "Ein zentraler und gut erforschter Therapieansatz bei Borderline",
+    keywords: [
+      "dbt",
+      "dialektisch",
+      "behavioral",
+      "therapie",
+      "linehan",
+      "skills",
+    ],
+    href: "/unterstuetzen/therapie",
+    section: "Unterstützen",
+  },
+  {
+    title: "PUK Zürich Notfall",
+    description:
+      "Psychiatrische Notdienste für Kinder, Erwachsene und Menschen ab 65",
+    keywords: [
+      "puk",
+      "notfall",
+      "psychiatrie",
+      "zürich",
+      "kinder",
+      "erwachsene",
+      "senioren",
+      "kiz",
+    ],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+  {
+    title: "McLean-Studie & CLPS-Studie",
+    description: "Langzeitstudien zur Remission bei Borderline",
+    keywords: [
+      "mclean",
+      "clps",
+      "studie",
+      "forschung",
+      "zanarini",
+      "gunderson",
+      "langzeit",
+    ],
+    href: "/genesung",
+    section: "Genesung",
+  },
+
+  // Glossar
+  {
+    title: "Glossar – Fachbegriffe erklärt",
+    description:
+      "Fachbegriffe rund um Borderline für Angehörige verständlich und knapp erklärt",
+    keywords: [
+      "glossar",
+      "fachbegriffe",
+      "lexikon",
+      "erklärung",
+      "definition",
+      "begriffe",
+    ],
+    href: "/glossar",
+    section: "Glossar",
+  },
+  {
+    title: "Splitting",
+    description: "Schwarz-Weiss-Denken bei Borderline – Glossar-Eintrag",
+    keywords: [
+      "splitting",
+      "schwarz-weiss",
+      "idealisierung",
+      "entwertung",
+      "glossar",
+    ],
+    href: "/glossar",
+    section: "Glossar",
+  },
+  {
+    title: "Mentalisierung",
+    description:
+      "Die Fähigkeit, Verhalten als Ausdruck von Gedanken und Gefühlen zu verstehen",
+    keywords: [
+      "mentalisierung",
+      "mentalisieren",
+      "verstehen",
+      "gedanken",
+      "gefühle",
+      "glossar",
+    ],
+    href: "/glossar",
+    section: "Glossar",
+  },
+  {
+    title: "Dissoziation",
+    description: "Zustand der Abgetrenntheit von sich selbst oder der Umgebung",
+    keywords: [
+      "dissoziation",
+      "dissoziieren",
+      "abgetrennt",
+      "unwirklich",
+      "glossar",
+    ],
+    href: "/glossar",
+    section: "Glossar",
+  },
+  {
+    title: "Co-Abhängigkeit",
+    description: "Wenn das eigene Wohlbefinden vom Zustand des anderen abhängt",
+    keywords: [
+      "co-abhängigkeit",
+      "abhängigkeit",
+      "muster",
+      "angehörige",
+      "glossar",
+    ],
+    href: "/glossar",
+    section: "Glossar",
+  },
+  {
+    title: "Enabling",
+    description: "Unbeabsichtigtes Ermöglichen von problematischem Verhalten",
+    keywords: [
+      "enabling",
+      "ermöglichen",
+      "verstärken",
+      "konsequenzen",
+      "glossar",
+    ],
+    href: "/glossar",
+    section: "Glossar",
+  },
+  {
+    title: "DEARMAN",
+    description:
+      "DBT-Struktur für klare Bitten und Grenzen in schwierigen Gesprächen",
+    keywords: ["dearman", "kommunikation", "dbt", "technik", "glossar"],
+    href: "/glossar",
+    section: "Glossar",
+  },
+  {
+    title: "Leuchtturm-Prinzip",
+    description:
+      "Metapher für die Rolle von Angehörigen – stabil sein, ohne zu steuern",
+    keywords: [
+      "leuchtturm",
+      "prinzip",
+      "metapher",
+      "rolle",
+      "angehörige",
+      "glossar",
+    ],
+    href: "/glossar",
+    section: "Glossar",
+  },
+
+  // Buchempfehlungen
+  {
+    title: "Buchempfehlungen für Angehörige",
+    description:
+      "Kuratierte deutschsprachige Bücher für Partner, Eltern und Kinder",
+    keywords: [
+      "buch",
+      "bücher",
+      "buchempfehlung",
+      "lesen",
+      "ratgeber",
+      "literatur",
+    ],
+    href: "/buchempfehlungen",
+    section: "Buchempfehlungen",
+  },
+  {
+    title: "Schluss mit dem Eiertanz (Buch)",
+    description: "Das Standardwerk von Mason & Kreger für Angehörige",
+    keywords: ["eiertanz", "mason", "kreger", "buch", "partner", "angehörige"],
+    href: "/buchempfehlungen",
+    section: "Buchempfehlungen",
+  },
+  {
+    title: "Ich hasse dich – verlass mich nicht",
+    description: "Klassiker zum Verständnis von Borderline",
+    keywords: [
+      "ich hasse dich",
+      "verlass mich nicht",
+      "kreisman",
+      "straus",
+      "buch",
+    ],
+    href: "/buchempfehlungen",
+    section: "Buchempfehlungen",
+  },
+  {
+    title: "Kinderbücher über psychische Erkrankungen",
+    description:
+      "Bücher, die Kindern helfen, psychische Erkrankungen zu verstehen",
+    keywords: ["kinderbuch", "kinder", "erklären", "mama", "papa", "psychisch"],
+    href: "/buchempfehlungen",
+    section: "Buchempfehlungen",
+  },
+
+  // Therapieangebote (jetzt in Unterstützen/Therapie integriert)
+  {
+    title: "Therapieangebote im Kanton Zürich",
+    description: "Spezialisierte Borderline-Behandlung an der PUK Zürich",
+    keywords: ["therapie", "zürich", "puk", "behandlung", "angebot", "kanton"],
+    href: "/unterstuetzen/therapie",
+    section: "Therapie",
+  },
+  {
+    title: "DBT-Station PUK Zürich",
+    description: "Stationäre DBT-Behandlung für Erwachsene in Rheinau",
+    keywords: ["dbt", "station", "stationär", "rheinau", "puk", "erwachsene"],
+    href: "/unterstuetzen/therapie",
+    section: "Therapie",
+  },
+  {
+    title: "HYPE ZÜRI – Frühintervention für Jugendliche",
+    description: "Spezialisiertes Programm für Jugendliche ab 13 Jahren",
+    keywords: ["hype", "jugendliche", "früh", "intervention", "13", "teenager"],
+    href: "/unterstuetzen/therapie",
+    section: "Therapie",
+  },
+  {
+    title: "PUK Erwachsene (ab 65) Zürich",
+    description: "Psychiatrische Versorgung für Erwachsene ab 65 Jahren",
+    keywords: ["alter", "senioren", "65", "alterspsychiatrie", "puk"],
+    href: "/unterstuetzen/therapie",
+    section: "Therapie",
+  },
+
+  // FAQ
+  {
+    title: "Häufig gestellte Fragen (FAQ)",
+    description:
+      "Häufige Fragen von Angehörigen mit ruhigen und differenzierten Antworten",
+    keywords: ["faq", "fragen", "antworten", "häufig", "gestellt"],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Soll ich die Diagnose ansprechen?",
+    description: "FAQ: Wann und wie über die Borderline-Diagnose sprechen",
+    keywords: ["diagnose", "ansprechen", "gespräch", "faq"],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Ist Borderline heilbar?",
+    description: "FAQ: Prognose und Genesungschancen bei Borderline",
+    keywords: ["heilbar", "heilung", "prognose", "chancen", "faq"],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Wann ist eine Einweisung nötig?",
+    description: "FAQ: Kriterien für psychiatrische Einweisung",
+    keywords: ["einweisung", "klinik", "stationär", "wann", "nötig", "faq"],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Darf ich meinen Angehörigen verlassen?",
+    description: "FAQ: Trennung bei psychischer Erkrankung des Partners",
+    keywords: ["verlassen", "trennung", "beziehung", "ende", "darf", "faq"],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Mein Angehöriger will keine Therapie",
+    description: "FAQ: Was tun, wenn Betroffene Behandlung ablehnen",
+    keywords: ["therapie", "ablehnen", "will nicht", "verweigert", "faq"],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Bin ich co-abhängig?",
+    description: "FAQ: Warnsignale für Co-Abhängigkeit erkennen",
+    keywords: ["co-abhängig", "abhängigkeit", "warnsignale", "muster", "faq"],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Wie schütze ich meine Kinder?",
+    description: "FAQ: Kinder vor den Auswirkungen schützen",
+    keywords: ["kinder", "schützen", "schutz", "familie", "faq"],
+    href: "/faq",
+    section: "FAQ",
+  },
+
+  // Orientierung und Beispiele
+  {
+    title: "5-4-3-2-1 Grounding",
+    description:
+      "Schrittweise Orientierung über die fünf Sinne, um im gegenwärtigen Moment anzukommen",
+    keywords: [
+      "grounding",
+      "5-4-3-2-1",
+      "achtsamkeit",
+      "sinne",
+      "beruhigung",
+      "gegenwart",
+      "erdung",
+    ],
+    href: "/selbstfuersorge",
+    section: "Selbstfürsorge",
+  },
+  {
+    title: "DEAR-Formulierungen",
+    description:
+      "Orientierung für klare und respektvolle Formulierungen in schwierigen Gesprächen",
+    keywords: [
+      "dear",
+      "dearman",
+      "satzbaukasten",
+      "kommunikation",
+      "formulierung",
+      "übung",
+    ],
+    href: "/grenzen",
+    section: "Grenzen setzen",
+  },
+  {
+    title: "Mythen und Einordnungen",
+    description:
+      "Häufige Missverständnisse über Borderline ruhig und differenziert eingeordnet",
+    keywords: ["mythos", "fakt", "vorurteil", "aufklärung", "einordnung"],
+    href: "/verstehen",
+    section: "Verstehen",
+  },
+  {
+    title: "Spiegeln und antworten",
+    description:
+      "Beispiele für hilfreiche und weniger hilfreiche Reaktionen in belastenden Situationen",
+    keywords: [
+      "spiegeln",
+      "validierung",
+      "empathie",
+      "reformulieren",
+      "beispiele",
+    ],
+    href: "/kommunizieren",
+    section: "Kommunizieren",
+  },
+  {
+    title: "Belastung einordnen",
+    description:
+      "Ruhige Orientierung zu Warnsignalen von Überforderung und Selbstfürsorge",
+    keywords: [
+      "selbstfürsorge",
+      "belastung",
+      "wohlbefinden",
+      "überlastung",
+      "warnsignale",
+    ],
+    href: "/selbstfuersorge",
+    section: "Selbstfürsorge",
+  },
+  {
+    title: "Validierungsstufenleiter",
+    description:
+      "Die sechs Stufen der Validierung ruhig erklärt, mit Beispielen und Stolpersteinen",
+    keywords: [
+      "validierung",
+      "stufen",
+      "leiter",
+      "linehan",
+      "beispiele",
+      "kommunikation",
+    ],
+    href: "/kommunizieren",
+    section: "Kommunizieren",
+  },
+
+  // Unterstützen-Unterseiten
+  {
+    title: "Im Alltag unterstützen",
+    description:
+      "Stabilität bieten, Skills unterstützen, gemeinsame Aktivitäten – praktische Tipps für den Alltag",
+    keywords: [
+      "alltag",
+      "stabilität",
+      "routine",
+      "skills",
+      "unterstützen",
+      "praktisch",
+      "tipps",
+    ],
+    href: "/unterstuetzen/alltag",
+    section: "Unterstützen",
+  },
+  {
+    title: "Therapie begleiten",
+    description:
+      "DBT und andere Therapien verstehen, Fortschritte würdigen, mit Rückschlägen umgehen",
+    keywords: [
+      "therapie",
+      "dbt",
+      "begleiten",
+      "fortschritte",
+      "rückschläge",
+      "behandlung",
+      "skills",
+    ],
+    href: "/unterstuetzen/therapie",
+    section: "Unterstützen",
+  },
+  {
+    title: "In der Krise unterstützen",
+    description:
+      "Krisen erkennen, deeskalieren und Sicherheit gewährleisten – konkrete Handlungsschritte",
+    keywords: [
+      "krise",
+      "deeskalation",
+      "sicherheit",
+      "notfall",
+      "akut",
+      "handeln",
+    ],
+    href: "/unterstuetzen/krise",
+    section: "Unterstützen",
+  },
+
+  // Krisenszenarien (Notfall-Seite)
+  {
+    title: "Suiziddrohung – Was tun?",
+    description: "Schritt-für-Schritt-Anleitung bei Suiziddrohungen",
+    keywords: [
+      "suizid",
+      "drohung",
+      "selbstmord",
+      "will nicht mehr",
+      "umbringen",
+    ],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+  {
+    title: "Selbstverletzung – Was tun?",
+    description:
+      "Anleitung bei Ritzen, Brennen oder anderen Selbstverletzungen",
+    keywords: ["selbstverletzung", "ritzen", "schneiden", "brennen", "svv"],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+  {
+    title: "Aggressive Eskalation – Was tun?",
+    description: "Deeskalation bei Schreien, Drohen oder Gewalt",
+    keywords: [
+      "aggression",
+      "eskalation",
+      "gewalt",
+      "schreien",
+      "drohen",
+      "wut",
+    ],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+  {
+    title: "Emotionale Erpressung – Was tun?",
+    description:
+      "Umgang mit Drohungen, Schuldvorwürfen und starkem Beziehungsdruck",
+    keywords: [
+      "erpressung",
+      "manipulation",
+      "schuld",
+      "drohung",
+      "wenn du gehst",
+    ],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+];

--- a/client/src/content/unterstuetzen.ts
+++ b/client/src/content/unterstuetzen.ts
@@ -1,0 +1,60 @@
+import { Compass, Filter, Heart, Users } from "lucide-react";
+
+export const unterstuetzenSubcategories = [
+  { id: "alle", label: "Alle", icon: Filter },
+  { id: "grundlagen", label: "Grundlagen", icon: Compass },
+  { id: "haltung", label: "Haltung", icon: Heart },
+  { id: "alltag", label: "Alltag", icon: Users },
+];
+
+export const unterstuetzenItems = [
+  {
+    title: "Im Krisenmodus – Orientierung geben",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/gOumJSiPiJFGkSFy.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/FOZYnweFmVcMXYyr.pdf",
+    category: "grundlagen",
+  },
+  {
+    title: "Ihre Rolle klären",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WUiQpUWjKIjpSRDC.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/JMOjSacqrnDcAkoB.pdf",
+    category: "grundlagen",
+  },
+  {
+    title: "Drei Säulen hilfreicher Unterstützung",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WuCBUdnlHakpSnbY.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/AalrNrybgxuMcRcX.pdf",
+    category: "grundlagen",
+  },
+  {
+    title: "Konsistenz-Prinzip",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MCMaGcrhifsekEqb.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/vfDYZzjEwJsEhzch.pdf",
+    category: "haltung",
+  },
+  {
+    title: "Beziehungs-Achtsamkeit",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/toOMoXhzHiaZUlBg.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/oPRapPNKMLHWEior.pdf",
+    category: "haltung",
+  },
+  {
+    title: "6 Leitlinien für Angehörige",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OfOPUMQpHXrpSPgw.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/IIcvvdvSlDcXqwbL.pdf",
+    category: "alltag",
+  },
+  {
+    title: "4 Alltags-Tipps",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/cwhMoIHSUeEWpyWo.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/ipyRcgPjVrRKYqyd.pdf",
+    category: "alltag",
+  },
+];

--- a/client/src/domain/floating-ui.ts
+++ b/client/src/domain/floating-ui.ts
@@ -1,0 +1,22 @@
+export type MobileFloatingMode = "crisis" | "content" | "default";
+
+const CRISIS_ROUTES = ["/soforthilfe", "/unterstuetzen/krise"];
+const CONTENT_ROUTES = [
+  "/verstehen",
+  "/unterstuetzen/uebersicht",
+  "/selbstfuersorge",
+  "/materialien",
+  "/genesung",
+  "/kommunizieren",
+  "/grenzen",
+];
+
+export function getMobileFloatingMode(location: string): MobileFloatingMode {
+  if (CRISIS_ROUTES.some(route => location.startsWith(route))) {
+    return "crisis";
+  }
+  if (CONTENT_ROUTES.some(route => location.startsWith(route))) {
+    return "content";
+  }
+  return "default";
+}

--- a/client/src/domain/navigation.ts
+++ b/client/src/domain/navigation.ts
@@ -10,8 +10,6 @@ import {
   Shield,
   Sparkles,
   Stethoscope,
-  TrendingUp,
-  Users,
 } from "lucide-react";
 import type { NavigationItem } from "@/domain/content-types";
 
@@ -21,17 +19,19 @@ export const primaryNavigationItems: NavigationItem[] = [
   { href: "/kommunizieren", label: "Kommunizieren", icon: MessageCircle },
   { href: "/grenzen", label: "Grenzen", icon: Shield },
   { href: "/selbstfuersorge", label: "Selbstfürsorge", icon: Sparkles },
-  { href: "/genesung", label: "Genesung", icon: TrendingUp },
-  { href: "/beratung", label: "Beratung", icon: Users },
 ];
 
 export const resourceNavigationItems: NavigationItem[] = [
-  { href: "/soforthilfe", label: "Soforthilfe", icon: Phone },
   { href: "/materialien", label: "Materialien & Handouts", icon: Download },
-  { href: "/beratung", label: "Beratung & Netzwerke", icon: Users },
+  { href: "/beratung", label: "Beratung & Netzwerke", icon: Heart },
   { href: "/fachstelle", label: "Fachstelle & Kontakt", icon: Building2 },
   { href: "/faq", label: "Häufige Fragen (FAQ)", icon: HelpCircle },
   { href: "/glossar", label: "Glossar", icon: BookMarked },
   { href: "/buchempfehlungen", label: "Buchempfehlungen", icon: BookOpen },
-  { href: "/unterstuetzen/therapie#therapieangebote", label: "Therapieangebote Zürich", icon: Stethoscope },
+  {
+    href: "/unterstuetzen/therapie#therapieangebote",
+    label: "Therapieangebote Zürich",
+    icon: Stethoscope,
+  },
+  { href: "/soforthilfe", label: "Soforthilfe", icon: Phone },
 ];

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -22,6 +22,7 @@ import {
 import { Link } from "wouter";
 import ContentSection from "@/components/ContentSection";
 import { TableOfContents } from "@/components/UXEnhancements";
+import { genesungItems as genesungMaterialItems } from "@/content/genesung";
 
 const genesungCategories = [
   { id: "alle", label: "Alle", icon: Filter },
@@ -29,43 +30,7 @@ const genesungCategories = [
   { id: "handeln", label: "Handeln", icon: HandHeart },
 ];
 
-const genesungItems = [
-  {
-    title: "Genesung in Zahlen",
-    desc: "Langzeitdaten und Orientierungswerte",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tyFTHNjsUagqrXiS.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MunlHDCNqnsOhBFn.pdf",
-    category: "verstehen",
-  },
-  {
-    title: "Das Fortschritt-Paradox",
-    desc: "Warum Rückschritte den Weg nicht entwerten",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DPkqytVYFcreeBlC.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/UFLdEEGIDxKdRUZO.pdf",
-    category: "verstehen",
-  },
-  {
-    title: "Remission vs. Heilung",
-    desc: "Was Besserung im Alltag wirklich bedeuten kann",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/HPRsNmCUFirjnraj.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/KMjqRDjDjWVZpjhJ.pdf",
-    category: "verstehen",
-  },
-  {
-    title: "5 Faktoren, die Genesung fördern",
-    desc: "Welche Bedingungen Entwicklung eher begünstigen",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/mFhtxtPMBkCEVPII.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/qgrRYtMKOvwWmuah.pdf",
-    category: "handeln",
-  },
-  {
-    title: "Ihre Rolle im Genesungsprozess",
-    desc: "Was Angehörige beitragen können und was nicht",
-    img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GhgPDkJhqlqJkYzE.webp",
-    pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/CZdiDaadpIWNOBFb.pdf",
-    category: "handeln",
-  },
-];
+const genesungItems = genesungMaterialItems;
 
 function GenesungInfografiken() {
   const [activeFilter, setActiveFilter] = useState("alle");
@@ -74,7 +39,7 @@ function GenesungInfografiken() {
   const filteredItems =
     activeFilter === "alle"
       ? genesungItems
-      : genesungItems.filter((i) => i.category === activeFilter);
+      : genesungItems.filter(i => i.category === activeFilter);
 
   return (
     <ContentSection
@@ -84,15 +49,16 @@ function GenesungInfografiken() {
       preview="Vertiefende Materialien zu Verlauf, Hoffnung, Rückschritten und der Rolle von Angehörigen."
     >
       <p className="text-muted-foreground mb-6">
-        Vorschau = Web-Bild. «PDF öffnen» öffnet die A4-Druckversion im neuen Tab.
+        Vorschau = Web-Bild. «PDF öffnen» öffnet die A4-Druckversion im neuen
+        Tab.
       </p>
 
       <div className="flex flex-wrap gap-2 mb-6">
-        {genesungCategories.map((cat) => {
+        {genesungCategories.map(cat => {
           const count =
             cat.id === "alle"
               ? genesungItems.length
-              : genesungItems.filter((i) => i.category === cat.id).length;
+              : genesungItems.filter(i => i.category === cat.id).length;
           return (
             <Button
               key={cat.id}
@@ -101,11 +67,16 @@ function GenesungInfografiken() {
               onClick={() => {
                 setActiveFilter(cat.id);
                 setTimeout(() => {
-                  gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                  gridRef.current?.scrollIntoView({
+                    behavior: "smooth",
+                    block: "start",
+                  });
                 }, 100);
               }}
               className={`whitespace-nowrap shrink-0 ${
-                activeFilter === cat.id ? "bg-terracotta-mid hover:bg-terracotta-dark text-white" : ""
+                activeFilter === cat.id
+                  ? "bg-terracotta-mid hover:bg-terracotta-dark text-white"
+                  : ""
               }`}
             >
               <cat.icon className="w-4 h-4 mr-1.5" />
@@ -135,7 +106,9 @@ function GenesungInfografiken() {
               />
             </div>
             <CardContent className="p-4">
-              <h3 className="font-semibold text-foreground mb-1">{item.title}</h3>
+              <h3 className="font-semibold text-foreground mb-1">
+                {item.title}
+              </h3>
               <p className="text-muted-foreground text-sm mb-3">{item.desc}</p>
               <a
                 href={item.pdf}
@@ -196,9 +169,11 @@ export default function Genesung() {
             </h1>
 
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Hoffnung ist bei Borderline berechtigt. Gleichzeitig verläuft Entwicklung selten glatt,
-              schnell oder vorhersehbar. Für Angehörige ist deshalb beides wichtig: Zuversicht und
-              eine realistische Sicht auf Zeit, Rückschritte und Grenzen des eigenen Einflusses.
+              Hoffnung ist bei Borderline berechtigt. Gleichzeitig verläuft
+              Entwicklung selten glatt, schnell oder vorhersehbar. Für
+              Angehörige ist deshalb beides wichtig: Zuversicht und eine
+              realistische Sicht auf Zeit, Rückschritte und Grenzen des eigenen
+              Einflusses.
             </p>
           </motion.div>
         </div>
@@ -223,38 +198,48 @@ export default function Genesung() {
                       Was die Forschung zeigt
                     </h2>
                     <p className="text-muted-foreground">
-                      Langzeitstudien sprechen klar gegen das alte Bild einer hoffnungslosen
-                      Entwicklung. Viele Menschen mit Borderline erleben über Jahre deutliche
-                      Besserungen.
+                      Langzeitstudien sprechen klar gegen das alte Bild einer
+                      hoffnungslosen Entwicklung. Viele Menschen mit Borderline
+                      erleben über Jahre deutliche Besserungen.
                     </p>
                   </div>
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mt-8 [&>*:first-child]:md:col-span-2">
                   <div className="text-center p-6 bg-white/60 rounded-xl">
-                    <div className="text-4xl md:text-5xl font-bold text-sage-mid mb-2">85–93%</div>
+                    <div className="text-4xl md:text-5xl font-bold text-sage-mid mb-2">
+                      85–93%
+                    </div>
                     <p className="text-sm text-muted-foreground">
-                      erreichen eine symptomatische Remission innerhalb von etwa 10 Jahren
+                      erreichen eine symptomatische Remission innerhalb von etwa
+                      10 Jahren
                     </p>
                   </div>
                   <div className="text-center p-6 bg-white/60 rounded-xl">
-                    <div className="text-4xl md:text-5xl font-bold text-sage-mid mb-2">50%</div>
+                    <div className="text-4xl md:text-5xl font-bold text-sage-mid mb-2">
+                      50%
+                    </div>
                     <p className="text-sm text-muted-foreground">
-                      erreichen eine umfassendere Genesung mit funktioneller Stabilität
+                      erreichen eine umfassendere Genesung mit funktioneller
+                      Stabilität
                     </p>
                   </div>
                   <div className="text-center p-6 bg-white/60 rounded-xl">
-                    <div className="text-4xl md:text-5xl font-bold text-sage-mid mb-2">Jahre</div>
+                    <div className="text-4xl md:text-5xl font-bold text-sage-mid mb-2">
+                      Jahre
+                    </div>
                     <p className="text-sm text-muted-foreground">
-                      nicht Wochen: Entwicklung braucht meist viel Zeit und mehrere Anläufe
+                      nicht Wochen: Entwicklung braucht meist viel Zeit und
+                      mehrere Anläufe
                     </p>
                   </div>
                 </div>
 
                 <div className="mt-6 pt-6 border-t border-border/30">
                   <p className="text-xs text-muted-foreground">
-                    Quellen: McLean Study of Adult Development (Zanarini et al.); Collaborative
-                    Longitudinal Personality Disorders Study (Gunderson et al.)
+                    Quellen: McLean Study of Adult Development (Zanarini et
+                    al.); Collaborative Longitudinal Personality Disorders Study
+                    (Gunderson et al.)
                   </p>
                 </div>
               </CardContent>
@@ -276,20 +261,26 @@ export default function Genesung() {
               <div className="grid grid-cols-1 md:grid-cols-[7fr_5fr] gap-6">
                 <Card className="h-full border-border/50">
                   <CardContent className="p-6">
-                    <h3 className="text-lg font-semibold text-foreground mb-3">Symptomatische Remission</h3>
+                    <h3 className="text-lg font-semibold text-foreground mb-3">
+                      Symptomatische Remission
+                    </h3>
                     <p className="text-muted-foreground text-sm leading-relaxed">
-                      Die diagnostischen Kriterien werden über längere Zeit nicht mehr erfüllt oder
-                      deutlich schwächer. Das bedeutet häufig weniger Impulsdurchbrüche, weniger
-                      Instabilität und mehr inneren Spielraum.
+                      Die diagnostischen Kriterien werden über längere Zeit
+                      nicht mehr erfüllt oder deutlich schwächer. Das bedeutet
+                      häufig weniger Impulsdurchbrüche, weniger Instabilität und
+                      mehr inneren Spielraum.
                     </p>
                   </CardContent>
                 </Card>
                 <Card className="h-full border-border/50">
                   <CardContent className="p-6">
-                    <h3 className="text-lg font-semibold text-foreground mb-3">Umfassendere Genesung</h3>
+                    <h3 className="text-lg font-semibold text-foreground mb-3">
+                      Umfassendere Genesung
+                    </h3>
                     <p className="text-muted-foreground text-sm leading-relaxed">
-                      Zusätzlich zur Symptomverbesserung kommen alltagsbezogene Stabilität,
-                      Beziehungen, Arbeit oder Ausbildung und mehr Lebensqualität in den Blick.
+                      Zusätzlich zur Symptomverbesserung kommen alltagsbezogene
+                      Stabilität, Beziehungen, Arbeit oder Ausbildung und mehr
+                      Lebensqualität in den Blick.
                     </p>
                   </CardContent>
                 </Card>
@@ -297,8 +288,8 @@ export default function Genesung() {
               <Card className="mt-6 bg-sage-wash/50 border-sage-mid/30">
                 <CardContent className="p-5">
                   <p className="text-foreground leading-relaxed">
-                    Für Angehörige ist entscheidend: Besserung ist oft real, auch wenn nicht alles
-                    konfliktfrei, leicht oder linear wird.
+                    Für Angehörige ist entscheidend: Besserung ist oft real,
+                    auch wenn nicht alles konfliktfrei, leicht oder linear wird.
                   </p>
                 </CardContent>
               </Card>
@@ -312,16 +303,18 @@ export default function Genesung() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Viele Angehörige erleben ein irritierendes Muster: Nach einer ruhigeren Phase kommt
-                  wieder ein Einbruch. Dann fühlt es sich schnell an, als wäre alles umsonst
-                  gewesen. Meist ist das nicht die treffendste Deutung.
+                  Viele Angehörige erleben ein irritierendes Muster: Nach einer
+                  ruhigeren Phase kommt wieder ein Einbruch. Dann fühlt es sich
+                  schnell an, als wäre alles umsonst gewesen. Meist ist das
+                  nicht die treffendste Deutung.
                 </p>
                 <Card className="border-l-4 border-l-terracotta-mid bg-terracotta-wash/30">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Entwicklung bedeutet bei Borderline häufig nicht: Schritt für Schritt nur
-                      vorwärts. Eher: Es gibt Bewegungen, Unterbrüche, Wiederaufnahmen und Phasen, in
-                      denen neue Stabilität erst gelernt werden muss.
+                      Entwicklung bedeutet bei Borderline häufig nicht: Schritt
+                      für Schritt nur vorwärts. Eher: Es gibt Bewegungen,
+                      Unterbrüche, Wiederaufnahmen und Phasen, in denen neue
+                      Stabilität erst gelernt werden muss.
                     </p>
                   </CardContent>
                 </Card>
@@ -331,7 +324,7 @@ export default function Genesung() {
                     "Fortschritte konkret benennen, statt nur global zu hoffen",
                     "Tempo nicht übersteuern, wenn es besser läuft",
                     "für schwierige Phasen einen kleinen Plan bereithalten",
-                  ].map((item) => (
+                  ].map(item => (
                     <Card key={item} className="border-border/50">
                       <CardContent className="p-4">
                         <p className="text-sm text-muted-foreground">{item}</p>
@@ -350,13 +343,16 @@ export default function Genesung() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Angehörige brauchen oft Hoffnung, um nicht zu resignieren. Gleichzeitig kann ein zu
-                  glattes Fortschrittsbild zusätzlichen Druck erzeugen: auf die betroffene Person,
-                  auf die Beziehung und auf Sie selbst.
+                  Angehörige brauchen oft Hoffnung, um nicht zu resignieren.
+                  Gleichzeitig kann ein zu glattes Fortschrittsbild zusätzlichen
+                  Druck erzeugen: auf die betroffene Person, auf die Beziehung
+                  und auf Sie selbst.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   <div className="p-4 rounded-xl bg-terracotta-wash border border-terracotta-mid/20">
-                    <span className="text-lg font-medium text-foreground block mb-2">❌ Weniger hilfreich</span>
+                    <span className="text-lg font-medium text-foreground block mb-2">
+                      ❌ Weniger hilfreich
+                    </span>
                     <ul className="text-sm text-muted-foreground space-y-1.5">
                       <li>Jetzt muss es doch endlich besser werden</li>
                       <li>Ein Rückschritt entwertet alles</li>
@@ -364,10 +360,14 @@ export default function Genesung() {
                     </ul>
                   </div>
                   <div className="p-4 rounded-xl bg-sage-wash border border-sage-mid/20">
-                    <span className="text-lg font-medium text-foreground block mb-2">✓ Tragfähiger</span>
+                    <span className="text-lg font-medium text-foreground block mb-2">
+                      ✓ Tragfähiger
+                    </span>
                     <ul className="text-sm text-muted-foreground space-y-1.5">
                       <li>Besserung ist möglich und oft wahrscheinlich</li>
-                      <li>Rückschritte kommen vor und müssen nicht alles kippen</li>
+                      <li>
+                        Rückschritte kommen vor und müssen nicht alles kippen
+                      </li>
                       <li>Tempo und Zeitpunkt bleiben begrenzt steuerbar</li>
                     </ul>
                   </div>
@@ -383,15 +383,31 @@ export default function Genesung() {
             >
               <div className="grid sm:grid-cols-2 gap-4">
                 {[
-                  { title: "Konsistenz", desc: "berechenbar bleiben, statt in Alarm mitzukippen" },
-                  { title: "realistische Hoffnung", desc: "Zuversicht ohne Druck vermitteln" },
-                  { title: "eigene Grenzen", desc: "die eigene Stabilität nicht opfern" },
-                  { title: "professionelle Hilfe", desc: "Behandlung unterstützen, aber nicht ersetzen" },
-                ].map((item) => (
+                  {
+                    title: "Konsistenz",
+                    desc: "berechenbar bleiben, statt in Alarm mitzukippen",
+                  },
+                  {
+                    title: "realistische Hoffnung",
+                    desc: "Zuversicht ohne Druck vermitteln",
+                  },
+                  {
+                    title: "eigene Grenzen",
+                    desc: "die eigene Stabilität nicht opfern",
+                  },
+                  {
+                    title: "professionelle Hilfe",
+                    desc: "Behandlung unterstützen, aber nicht ersetzen",
+                  },
+                ].map(item => (
                   <Card key={item.title} className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                      <p className="text-sm text-muted-foreground">{item.desc}</p>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        {item.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground">
+                        {item.desc}
+                      </p>
                     </CardContent>
                   </Card>
                 ))}
@@ -443,8 +459,9 @@ export default function Genesung() {
                 Wie können Sie tragfähig begleiten?
               </h2>
               <p className="text-muted-foreground mb-8">
-                Unterstützung heisst nicht, Entwicklung herzustellen. Es heisst oft, Beziehung,
-                Klarheit und Selbstschutz über längere Zeit auszubalancieren.
+                Unterstützung heisst nicht, Entwicklung herzustellen. Es heisst
+                oft, Beziehung, Klarheit und Selbstschutz über längere Zeit
+                auszubalancieren.
               </p>
               <div className="flex flex-wrap justify-center gap-4">
                 <Link href="/unterstuetzen/uebersicht">

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -20,57 +20,7 @@ import {
 import { Link } from "wouter";
 import ContentSection from "@/components/ContentSection";
 
-const grenzenSubcategories = [
-  { id: "alle", label: "Alle", icon: Filter },
-  { id: "erkennen", label: "Erkennen", icon: AlertTriangle },
-  { id: "kommunizieren", label: "Kommunizieren", icon: Heart },
-  { id: "handeln", label: "Handeln", icon: Shield },
-];
-
-const grenzenItems = [
-  {
-    title: "Die DEAR-Technik",
-    description: "4 Schritte für respektvolle Grenzsetzung",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/yBSkvBJGSeNvxINq.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DDkqUiaNJwizEtPv.pdf",
-    category: "kommunizieren",
-  },
-  {
-    title: "Spiegeln statt Aufsaugen",
-    description: "Mitfühlen ohne Übernehmen",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/rbDvjxTUWJMXQCPj.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/jJFieYXEiIxbrazO.pdf",
-    category: "kommunizieren",
-  },
-  {
-    title: "Die 4 Arten von Grenzen",
-    description: "Physisch, emotional, zeitlich, materiell",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/otBFiwevLwWQsinR.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/KiiZJfLHYOlNVTsn.pdf",
-    category: "erkennen",
-  },
-  {
-    title: "Grenzen erkennen",
-    description: "5 Warnsignale Ihres Körpers",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/pPRcjWVKERfSWUPL.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/FftUeWuOzmxjrUEi.pdf",
-    category: "erkennen",
-  },
-  {
-    title: "L.M.K. (Lebe Mit Konsequenzen)",
-    description: "Wenn Grenzen nicht respektiert werden",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/izBLuzTFtMDeQYoc.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/eyhngTnxXoekiWwJ.pdf",
-    category: "handeln",
-  },
-  {
-    title: "Spickzettel Grenzen",
-    description: "A4 mit den wichtigsten Sätzen",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/avGqFKFuKFfFYANu.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/obwIZiRPiVPphIUX.pdf",
-    category: "handeln",
-  },
-];
+import { grenzenSubcategories, grenzenItems } from "@/content/grenzen";
 
 export default function Grenzen() {
   const [activeFilter, setActiveFilter] = useState("alle");
@@ -79,7 +29,7 @@ export default function Grenzen() {
   const filteredItems =
     activeFilter === "alle"
       ? grenzenItems
-      : grenzenItems.filter((i) => i.category === activeFilter);
+      : grenzenItems.filter(i => i.category === activeFilter);
 
   return (
     <Layout>
@@ -101,7 +51,9 @@ export default function Grenzen() {
               <div className="w-12 h-12 rounded-xl bg-terracotta-lighter flex items-center justify-center">
                 <Shield className="w-6 h-6 text-terracotta-mid" />
               </div>
-              <span className="text-sm font-medium text-terracotta-mid">Lesezeit: 12 Minuten</span>
+              <span className="text-sm font-medium text-terracotta-mid">
+                Lesezeit: 12 Minuten
+              </span>
             </div>
 
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
@@ -109,10 +61,11 @@ export default function Grenzen() {
             </h1>
 
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Grenzen sind kein Gegenpol zu Mitgefühl, sondern oft seine Voraussetzung. Sie schützen
-              Ihre Integrität, machen Beziehungen berechenbarer und verhindern, dass Unterstützung in
-              Selbstaufgabe kippt. Gleichzeitig können Grenzen Spannungen auslösen. Genau deshalb
-              brauchen sie Klarheit, Wiederholbarkeit und Konsequenz.
+              Grenzen sind kein Gegenpol zu Mitgefühl, sondern oft seine
+              Voraussetzung. Sie schützen Ihre Integrität, machen Beziehungen
+              berechenbarer und verhindern, dass Unterstützung in Selbstaufgabe
+              kippt. Gleichzeitig können Grenzen Spannungen auslösen. Genau
+              deshalb brauchen sie Klarheit, Wiederholbarkeit und Konsequenz.
             </p>
           </motion.div>
         </div>
@@ -130,26 +83,32 @@ export default function Grenzen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  In belasteten Beziehungen entsteht leicht der Eindruck, Grenzen würden die Lage
-                  verschärfen. Kurzfristig kann das sogar so wirken. Langfristig machen fehlende
-                  Grenzen Beziehungen aber oft chaotischer, unklarer und krisenanfälliger.
+                  In belasteten Beziehungen entsteht leicht der Eindruck,
+                  Grenzen würden die Lage verschärfen. Kurzfristig kann das
+                  sogar so wirken. Langfristig machen fehlende Grenzen
+                  Beziehungen aber oft chaotischer, unklarer und
+                  krisenanfälliger.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Für Sie</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Für Sie
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Grenzen schützen vor Überlastung, Dauererreichbarkeit, Schuldspiralen und dem
-                        Verlust der eigenen Orientierung.
+                        Grenzen schützen vor Überlastung, Dauererreichbarkeit,
+                        Schuldspiralen und dem Verlust der eigenen Orientierung.
                       </p>
                     </CardContent>
                   </Card>
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Für die Beziehung</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Für die Beziehung
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Grenzen schaffen Berechenbarkeit. Sie signalisieren, was Kontakt trägt und was
-                        ihn beschädigt.
+                        Grenzen schaffen Berechenbarkeit. Sie signalisieren, was
+                        Kontakt trägt und was ihn beschädigt.
                       </p>
                     </CardContent>
                   </Card>
@@ -169,10 +128,12 @@ export default function Grenzen() {
                   "Sie fühlen sich dauernd zuständig, beobachtend oder auf Abruf.",
                   "Sie werden gereizt, hart oder ziehen sich innerlich zurück.",
                   "Sie merken, dass Hilfe nur noch aus Schuld oder Panik geschieht.",
-                ].map((item) => (
+                ].map(item => (
                   <Card key={item} className="border-border/50">
                     <CardContent className="p-5">
-                      <p className="text-sm text-muted-foreground leading-relaxed">{item}</p>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {item}
+                      </p>
                     </CardContent>
                   </Card>
                 ))}
@@ -180,8 +141,8 @@ export default function Grenzen() {
               <Card className="mt-4 bg-sand-muted border-sand-mid">
                 <CardContent className="p-5">
                   <p className="text-foreground leading-relaxed">
-                    Grenzen beginnen oft nicht mit dem Satz an den anderen, sondern mit dem ernsten
-                    Wahrnehmen Ihrer eigenen Belastung.
+                    Grenzen beginnen oft nicht mit dem Satz an den anderen,
+                    sondern mit dem ernsten Wahrnehmen Ihrer eigenen Belastung.
                   </p>
                 </CardContent>
               </Card>
@@ -211,11 +172,15 @@ export default function Grenzen() {
                     title: "Materielle Grenzen",
                     text: "Wie weit gehen finanzielle Hilfe, Ausleihen oder praktische Übernahmen?",
                   },
-                ].map((item) => (
+                ].map(item => (
                   <Card key={item.title} className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                      <p className="text-sm text-muted-foreground leading-relaxed">{item.text}</p>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        {item.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {item.text}
+                      </p>
                     </CardContent>
                   </Card>
                 ))}
@@ -238,22 +203,29 @@ export default function Grenzen() {
                       <li>konkret statt abstrakt sind,</li>
                       <li>auf Ihr Handeln bezogen bleiben,</li>
                       <li>nicht mit Vorwürfen überladen werden,</li>
-                      <li>nicht bei jedem Gespräch neu verhandelt werden müssen.</li>
+                      <li>
+                        nicht bei jedem Gespräch neu verhandelt werden müssen.
+                      </li>
                     </ul>
                   </CardContent>
                 </Card>
                 <div className="grid sm:grid-cols-2 gap-4">
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Eher hilfreich</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Eher hilfreich
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        "Ich spreche weiter mit dir, aber nicht, wenn du mich anschreist."
+                        "Ich spreche weiter mit dir, aber nicht, wenn du mich
+                        anschreist."
                       </p>
                     </CardContent>
                   </Card>
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Eher problematisch</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Eher problematisch
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
                         "Du bist unmöglich. So rede ich nie wieder mit dir."
                       </p>
@@ -271,15 +243,16 @@ export default function Grenzen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Grenzen wirken selten, wenn sie nur angekündigt, aber nicht umgesetzt werden.
-                  Genau hier geraten viele Angehörige in Loyalitätskonflikte: Sie wollen klar sein,
-                  fürchten aber Eskalation, Ablehnung oder Schuld.
+                  Grenzen wirken selten, wenn sie nur angekündigt, aber nicht
+                  umgesetzt werden. Genau hier geraten viele Angehörige in
+                  Loyalitätskonflikte: Sie wollen klar sein, fürchten aber
+                  Eskalation, Ablehnung oder Schuld.
                 </p>
                 <Card className="bg-sage-wash/50 border-sage-mid/30">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Konsequenz heisst nicht Härte. Es heisst, dass Ihr Handeln zu dem passt, was
-                      Sie angekündigt haben.
+                      Konsequenz heisst nicht Härte. Es heisst, dass Ihr Handeln
+                      zu dem passt, was Sie angekündigt haben.
                     </p>
                   </CardContent>
                 </Card>
@@ -294,12 +267,27 @@ export default function Grenzen() {
             >
               <div className="space-y-3">
                 {[
-                  { wrong: "Grenzen im Affekt setzen", right: "besser in ruhigen Momenten vorbereiten" },
-                  { wrong: "zu viele Grenzen auf einmal", right: "wenige zentrale Grenzen priorisieren" },
-                  { wrong: "Grenzen als Strafe formulieren", right: "Grenzen als Selbstschutz erklären" },
-                  { wrong: "Grenzen nicht durchhalten", right: "nur ankündigen, was Sie tragen können" },
-                  { wrong: "bei Schuld sofort zurückrudern", right: "Schuldgefühl nicht automatisch als Fehler lesen" },
-                ].map((item) => (
+                  {
+                    wrong: "Grenzen im Affekt setzen",
+                    right: "besser in ruhigen Momenten vorbereiten",
+                  },
+                  {
+                    wrong: "zu viele Grenzen auf einmal",
+                    right: "wenige zentrale Grenzen priorisieren",
+                  },
+                  {
+                    wrong: "Grenzen als Strafe formulieren",
+                    right: "Grenzen als Selbstschutz erklären",
+                  },
+                  {
+                    wrong: "Grenzen nicht durchhalten",
+                    right: "nur ankündigen, was Sie tragen können",
+                  },
+                  {
+                    wrong: "bei Schuld sofort zurückrudern",
+                    right: "Schuldgefühl nicht automatisch als Fehler lesen",
+                  },
+                ].map(item => (
                   <Card key={item.wrong} className="border-border/50">
                     <CardContent className="p-4">
                       <p className="text-sm text-muted-foreground">
@@ -322,31 +310,38 @@ export default function Grenzen() {
               <div className="space-y-4">
                 <Card className="border-l-4 border-l-terracotta-mid bg-terracotta-wash">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Als Partner/in</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Als Partner/in
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      In Partnerschaften fühlen sich Grenzen oft schnell wie Beziehungsgefahr an.
-                      Gerade deshalb sind sie wichtig: Sie unterscheiden zwischen Nähe und
-                      Verschmelzung, Mitgefühl und Selbstaufgabe.
+                      In Partnerschaften fühlen sich Grenzen oft schnell wie
+                      Beziehungsgefahr an. Gerade deshalb sind sie wichtig: Sie
+                      unterscheiden zwischen Nähe und Verschmelzung, Mitgefühl
+                      und Selbstaufgabe.
                     </p>
                   </CardContent>
                 </Card>
                 <Card className="border-l-4 border-l-slate-mid bg-slate-pale">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Als Elternteil</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Als Elternteil
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Eltern erleben Grenzen oft als Widerspruch zu Fürsorge. Bei erwachsenen Kindern
-                      ist Begrenzung aber häufig Teil verantwortlicher Elternschaft, nicht ihr
-                      Gegenstück.
+                      Eltern erleben Grenzen oft als Widerspruch zu Fürsorge.
+                      Bei erwachsenen Kindern ist Begrenzung aber häufig Teil
+                      verantwortlicher Elternschaft, nicht ihr Gegenstück.
                     </p>
                   </CardContent>
                 </Card>
                 <Card className="border-l-4 border-l-sage-mid bg-sage-pale">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Als erwachsenes Kind</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Als erwachsenes Kind
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Wer seinem Elternteil Grenzen setzt, erlebt oft besonders starke Schuld. Ihre
-                      emotionale Gesundheit ist dennoch nicht nachrangig. Sie dürfen Ihr eigenes Leben
-                      schützen.
+                      Wer seinem Elternteil Grenzen setzt, erlebt oft besonders
+                      starke Schuld. Ihre emotionale Gesundheit ist dennoch
+                      nicht nachrangig. Sie dürfen Ihr eigenes Leben schützen.
                     </p>
                   </CardContent>
                 </Card>
@@ -358,7 +353,9 @@ export default function Grenzen() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="mb-12 wave-divider-top"
-              style={{ "--wave-color": "var(--background)" } as React.CSSProperties}
+              style={
+                { "--wave-color": "var(--background)" } as React.CSSProperties
+              }
             >
               <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
                 <Download className="w-8 h-8 text-terracotta-mid" />
@@ -367,18 +364,20 @@ export default function Grenzen() {
               <p className="text-sm text-muted-foreground mb-6 flex items-center gap-2">
                 <Eye className="w-4 h-4 flex-shrink-0" />
                 <span>
-                  <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen»
-                  öffnet die A4-Druckversion im neuen Tab.
+                  <strong className="text-foreground">
+                    Vorschau = Web-Bild.
+                  </strong>{" "}
+                  «PDF öffnen» öffnet die A4-Druckversion im neuen Tab.
                 </span>
               </p>
 
               <div className="flex flex-wrap gap-2 pb-3 mb-6 -mx-1 px-1">
-                {grenzenSubcategories.map((cat) => {
+                {grenzenSubcategories.map(cat => {
                   const Icon = cat.icon;
                   const count =
                     cat.id === "alle"
                       ? grenzenItems.length
-                      : grenzenItems.filter((i) => i.category === cat.id).length;
+                      : grenzenItems.filter(i => i.category === cat.id).length;
                   return (
                     <Button
                       key={cat.id}
@@ -387,27 +386,39 @@ export default function Grenzen() {
                       onClick={() => {
                         setActiveFilter(cat.id);
                         setTimeout(() => {
-                          gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                          gridRef.current?.scrollIntoView({
+                            behavior: "smooth",
+                            block: "start",
+                          });
                         }, 50);
                       }}
                       className={`whitespace-nowrap ${
-                        activeFilter === cat.id ? "bg-terracotta-mid hover:bg-terracotta-dark text-white" : ""
+                        activeFilter === cat.id
+                          ? "bg-terracotta-mid hover:bg-terracotta-dark text-white"
+                          : ""
                       }`}
                     >
                       <Icon className="w-4 h-4 mr-1.5" />
                       {cat.label}
-                      <span className="ml-1.5 text-xs opacity-90">({count})</span>
+                      <span className="ml-1.5 text-xs opacity-90">
+                        ({count})
+                      </span>
                     </Button>
                   );
                 })}
               </div>
 
-              <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div
+                ref={gridRef}
+                className="grid grid-cols-1 sm:grid-cols-2 gap-4"
+              >
                 {filteredItems.map((item, index) => (
                   <Card
                     key={item.title}
                     className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
-                      filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""
+                      filteredItems.length > 1 && index === 0
+                        ? "sm:col-span-2"
+                        : ""
                     }`}
                   >
                     <div className="relative aspect-[3/4] bg-muted overflow-hidden">
@@ -422,7 +433,9 @@ export default function Grenzen() {
                       />
                     </div>
                     <CardContent className="p-3">
-                      <h3 className="font-medium text-sm text-foreground mb-2">{item.title}</h3>
+                      <h3 className="font-medium text-sm text-foreground mb-2">
+                        {item.title}
+                      </h3>
                       <a
                         href={item.pdfUrl}
                         target="_blank"
@@ -453,15 +466,20 @@ export default function Grenzen() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="mb-12 wave-divider-top"
-              style={{ "--wave-color": "var(--background)" } as React.CSSProperties}
+              style={
+                { "--wave-color": "var(--background)" } as React.CSSProperties
+              }
             >
               <Card className="bg-sage-light/30 border-sage">
                 <CardContent className="p-6">
-                  <h3 className="font-semibold text-foreground mb-3">Denken Sie daran</h3>
+                  <h3 className="font-semibold text-foreground mb-3">
+                    Denken Sie daran
+                  </h3>
                   <p className="text-muted-foreground leading-relaxed">
-                    Grenzen fühlen sich anfangs oft unangenehm an. Das bedeutet nicht automatisch,
-                    dass sie falsch sind. In belasteten Beziehungen braucht gute Begrenzung meist
-                    Wiederholung, innere Festigkeit und die Erlaubnis, auch Schuldgefühle zu
+                    Grenzen fühlen sich anfangs oft unangenehm an. Das bedeutet
+                    nicht automatisch, dass sie falsch sind. In belasteten
+                    Beziehungen braucht gute Begrenzung meist Wiederholung,
+                    innere Festigkeit und die Erlaubnis, auch Schuldgefühle zu
                     überstehen.
                   </p>
                 </CardContent>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -9,19 +9,14 @@ import {
   ArrowRight,
   BookOpen,
   Compass,
-  Download,
   Heart,
   MessageCircle,
   Phone,
   Shield,
   Sparkles,
-  Users,
 } from "lucide-react";
 
-const heroImage = "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/XkvykpgJHYsCUUQW.webp";
-const heroImage1280 = "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/smWfBdfAvQptVoCP.webp";
-const heroImage768 = "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VEYeFPLYdBHjfcQo.webp";
-const heroImageMobile = "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/fYVyThTdLUpjIoVU.webp";
+const heroImage = "/og-image.jpg";
 
 const situationPaths = [
   {
@@ -58,45 +53,6 @@ const situationPaths = [
   },
 ];
 
-const mainPaths = [
-  {
-    href: "/verstehen",
-    icon: BookOpen,
-    title: "Verstehen",
-    description: "Borderline aus Sicht von Angehörigen: Beziehungsmuster, Scham, Überflutung und Nähe-Distanz.",
-  },
-  {
-    href: "/unterstuetzen/uebersicht",
-    icon: Heart,
-    title: "Unterstützen",
-    description: "Wie Unterstützung tragfähig bleiben kann, ohne dass Sie alles allein tragen.",
-  },
-  {
-    href: "/kommunizieren",
-    icon: MessageCircle,
-    title: "Kommunizieren",
-    description: "Hilfreiche Sprache in angespannten, verletzlichen oder eskalierenden Momenten.",
-  },
-  {
-    href: "/grenzen",
-    icon: Shield,
-    title: "Grenzen",
-    description: "Klarheit, Selbstschutz und begrenzte Verfügbarkeit ohne unnötige Eskalation.",
-  },
-  {
-    href: "/selbstfuersorge",
-    icon: Sparkles,
-    title: "Selbstfürsorge",
-    description: "Warnsignale der Überlastung, Entlastung und Umgang mit eigener Erschöpfung.",
-  },
-  {
-    href: "/beratung",
-    icon: Users,
-    title: "Beratung",
-    description: "Fachstelle, Netzwerke und konkrete Anlaufstellen für Angehörige in der Schweiz.",
-  },
-];
-
 export default function Home() {
   return (
     <Layout>
@@ -108,28 +64,21 @@ export default function Home() {
       <WebsiteSchema />
       <MedicalPageSchema
         title="Borderline: Orientierung für Angehörige"
-        description="Psychoedukative Unterstützung für Angehörige von Menschen mit Borderline-Persönlichkeitsstörung."
+        description="Psychoedukative Unterstützung für Angehörige von Menschen mit Borderline-Muster."
         path="/"
       />
 
       <section className="relative overflow-hidden">
         <div className="absolute inset-0 z-0">
-          <picture>
-            <source media="(max-width: 640px)" srcSet={heroImageMobile} />
-            <source media="(max-width: 768px)" srcSet={heroImage768} />
-            <source media="(max-width: 1280px)" srcSet={heroImage1280} />
-            <img
-              src={heroImage}
-              alt="Warme Landschaft als Hintergrundbild"
-              className="w-full h-full object-cover opacity-50"
-              srcSet={`${heroImage768} 768w, ${heroImage1280} 1280w, ${heroImage} 1920w`}
-              sizes="100vw"
-              width={1920}
-              height={1071}
-              fetchPriority="high"
-              decoding="async"
-            />
-          </picture>
+          <img
+            src={heroImage}
+            alt="Ruhige Landschaft als Hintergrundbild"
+            className="w-full h-full object-cover opacity-35"
+            width={1200}
+            height={630}
+            fetchPriority="high"
+            decoding="async"
+          />
           <div className="absolute inset-0 bg-gradient-to-b from-background/60 via-background/40 to-background" />
         </div>
 
@@ -149,21 +98,29 @@ export default function Home() {
               </h1>
 
               <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-8 max-w-2xl">
-                Wenn Beziehungen von starker Anspannung, Eskalation, Rückzug, Schuld oder Erschöpfung
-                geprägt sind, hilft nicht noch mehr Druck, sondern bessere Einordnung. Diese Website
-                unterstützt Angehörige dabei, Dynamiken zu verstehen, hilfreicher zu reagieren und
-                sich selbst nicht zu verlieren.
+                Wenn Beziehungen von starker Anspannung, Eskalation, Rückzug,
+                Schuld oder Erschöpfung geprägt sind, hilft nicht noch mehr
+                Druck, sondern bessere Einordnung. Diese Website unterstützt
+                Angehörige dabei, Dynamiken zu verstehen, hilfreicher zu
+                reagieren und sich selbst nicht zu verlieren.
               </p>
 
               <div className="flex flex-col sm:flex-row gap-4">
                 <Link href="/verstehen">
-                  <Button size="lg" className="bg-terracotta hover:bg-terracotta-mid text-white w-full sm:w-auto">
+                  <Button
+                    size="lg"
+                    className="bg-terracotta hover:bg-terracotta-mid text-white w-full sm:w-auto"
+                  >
                     <BookOpen className="w-5 h-5 mr-2" />
                     Borderline besser verstehen
                   </Button>
                 </Link>
                 <Link href="/unterstuetzen/uebersicht">
-                  <Button size="lg" variant="outline" className="w-full sm:w-auto">
+                  <Button
+                    size="lg"
+                    variant="outline"
+                    className="w-full sm:w-auto"
+                  >
                     <Heart className="w-5 h-5 mr-2" />
                     Was hilft in meiner Lage?
                   </Button>
@@ -177,7 +134,9 @@ export default function Home() {
                 >
                   <Phone className="w-4 h-4" />
                   <span>Akute Krise? Soforthilfe</span>
-                  <span className="group-hover:translate-x-1 transition-transform">&rarr;</span>
+                  <span className="group-hover:translate-x-1 transition-transform">
+                    &rarr;
+                  </span>
                 </Link>
               </div>
             </motion.div>
@@ -197,7 +156,8 @@ export default function Home() {
               </p>
             </div>
             <p className="text-muted-foreground text-sm flex-1">
-              Fachlich fundierte Orientierung, Beratung und Materialien für Angehörige.
+              Fachlich fundierte Orientierung, Beratung und Materialien für
+              Angehörige.
             </p>
             <Link
               href="/fachstelle"
@@ -210,7 +170,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="py-10 md:py-14 bg-background">
+      <section className="py-8 md:py-10 bg-background">
         <div className="container">
           <div className="max-w-5xl mx-auto">
             <motion.div
@@ -224,19 +184,23 @@ export default function Home() {
                 Was ist gerade Ihre Lage?
               </h2>
               <p className="text-muted-foreground max-w-2xl">
-                Beginnen Sie dort, wo der Druck im Moment am grössten ist. Die Website ist nicht nur
-                zum Lesen gedacht, sondern als Orientierung in belasteten Beziehungssituationen.
+                Beginnen Sie dort, wo der Druck im Moment am grössten ist. Die
+                Website ist nicht nur zum Lesen gedacht, sondern als
+                Orientierung in belasteten Beziehungssituationen.
               </p>
             </motion.div>
 
             <div className="grid md:grid-cols-2 gap-4">
-              {situationPaths.map((item) => {
+              {situationPaths.map(item => {
                 const Icon = item.icon;
                 return (
                   <Link key={item.href} href={item.href}>
                     <Card
                       className="h-full cursor-pointer border transition-all duration-300 hover:shadow-md hover:-translate-y-0.5"
-                      style={{ borderColor: item.color, backgroundColor: item.bg }}
+                      style={{
+                        borderColor: item.color,
+                        backgroundColor: item.bg,
+                      }}
                     >
                       <CardContent className="p-5">
                         <div
@@ -245,9 +209,16 @@ export default function Home() {
                         >
                           <Icon className="w-5 h-5 text-white" />
                         </div>
-                        <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                        <p className="text-sm text-muted-foreground mb-3">{item.text}</p>
-                        <span className="text-sm font-medium inline-flex items-center gap-1" style={{ color: item.color }}>
+                        <h3 className="font-semibold text-foreground mb-2">
+                          {item.title}
+                        </h3>
+                        <p className="text-sm text-muted-foreground mb-3">
+                          {item.text}
+                        </p>
+                        <span
+                          className="text-sm font-medium inline-flex items-center gap-1"
+                          style={{ color: item.color }}
+                        >
                           Zum passenden Bereich
                           <ArrowRight className="w-4 h-4" />
                         </span>
@@ -270,7 +241,10 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="py-12 md:py-16 bg-cream wave-divider-top" style={{ "--wave-color": "var(--color-cream)" } as React.CSSProperties}>
+      <section
+        className="py-12 md:py-16 bg-cream wave-divider-top"
+        style={{ "--wave-color": "var(--color-cream)" } as React.CSSProperties}
+      >
         <div className="container">
           <div className="max-w-5xl mx-auto">
             <motion.div
@@ -283,101 +257,81 @@ export default function Home() {
               <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-3">
                 Was diese Website besonders abdeckt
               </h2>
-              <div className="grid md:grid-cols-2 gap-4">
-                {[
-                  "Borderline differenziert aus Sicht von Angehörigen verstehen",
-                  "Beziehungsmuster, Eskalation und Rückzug besser einordnen",
-                  "Grenzen, Selbstschutz und Unterstützung zusammendenken",
-                  "Fachliche Hilfe, Materialien und Beratungswege schnell finden",
-                ].map((item) => (
-                  <div key={item} className="flex items-start gap-3 p-4 rounded-xl bg-white border border-border/40">
-                    <span className="text-sage-mid mt-0.5">✓</span>
-                    <span className="text-sm text-muted-foreground">{item}</span>
-                  </div>
-                ))}
+              <div className="space-y-3">
+                <p className="text-muted-foreground">
+                  Klare Einordnung, konkrete Sprache und praktische Entlastung –
+                  fokussiert auf die Situation von Angehörigen.
+                </p>
+                <ul className="grid md:grid-cols-2 gap-3 text-sm text-muted-foreground">
+                  <li className="p-3 rounded-xl bg-white border border-border/40">
+                    ✓ Beziehungsmuster und Eskalationen besser verstehen
+                  </li>
+                  <li className="p-3 rounded-xl bg-white border border-border/40">
+                    ✓ Grenzen, Selbstschutz und Unterstützung zusammen denken
+                  </li>
+                </ul>
               </div>
             </motion.div>
           </div>
         </div>
       </section>
 
-      <section className="py-16 md:py-20 wave-divider-top" style={{ "--wave-color": "var(--background)" } as React.CSSProperties}>
+      <section
+        className="py-10 md:py-12 wave-divider-top"
+        style={{ "--wave-color": "var(--background)" } as React.CSSProperties}
+      >
         <div className="container">
-          <div className="max-w-5xl mx-auto">
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.5, ease: "easeOut" }}
-              className="mb-10"
-            >
-              <h2 className="text-3xl md:text-4xl font-semibold text-foreground mb-4">
-                Die wichtigsten Wege durch die Website
-              </h2>
-              <p className="text-muted-foreground text-lg max-w-2xl">
-                Die Hauptbereiche bauen aufeinander auf. Sie können trotzdem direkt dort einsteigen,
-                wo Ihre aktuelle Lage es braucht.
-              </p>
-            </motion.div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {mainPaths.map((path) => {
-                const Icon = path.icon;
-                return (
-                  <Link key={path.href} href={path.href}>
-                    <Card className="h-full group cursor-pointer transition-all duration-300 hover:shadow-lg hover:-translate-y-1 border-transparent hover:border-border">
-                      <CardContent className="p-6">
-                        <div className="w-14 h-14 rounded-2xl flex items-center justify-center bg-sage-light mb-5">
-                          <Icon className="w-7 h-7 text-sage-darker" />
-                        </div>
-                        <h3 className="font-semibold text-foreground text-xl mb-3">{path.title}</h3>
-                        <p className="text-muted-foreground leading-relaxed mb-4">{path.description}</p>
-                        <span className="text-sm font-medium text-sage-darker flex items-center gap-1">
-                          Mehr dazu
-                          <ArrowRight className="w-4 h-4 transition-transform group-hover:translate-x-1" />
-                        </span>
-                      </CardContent>
-                    </Card>
-                  </Link>
-                );
-              })}
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section className="py-12 md:py-16 bg-sand-muted wave-divider-top" style={{ "--wave-color": "var(--color-sand-muted)" } as React.CSSProperties}>
-        <div className="container">
-          <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-6">
-            <Card className="border-border/50 bg-white">
-              <CardContent className="p-6">
-                <div className="w-12 h-12 rounded-xl bg-terracotta-lighter flex items-center justify-center mb-4">
-                  <Download className="w-6 h-6 text-terracotta-mid" />
-                </div>
-                <h3 className="text-xl font-semibold text-foreground mb-2">Materialien</h3>
-                <p className="text-muted-foreground mb-4">
-                  Kuratierte Handouts, Notfallhilfen und Infografiken für akute, belastete oder
-                  unklare Situationen.
+          <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-4">
+            <Card className="border-border/50">
+              <CardContent className="p-5">
+                <h2 className="text-xl font-semibold text-foreground mb-2">
+                  Kernwege
+                </h2>
+                <p className="text-sm text-muted-foreground mb-3">
+                  Wenn Sie nicht über die Lage-Karten einsteigen möchten:
                 </p>
-                <Link href="/materialien">
-                  <Button variant="outline">Zu den Materialien</Button>
-                </Link>
+                <div className="flex flex-wrap gap-2">
+                  {[
+                    "/verstehen",
+                    "/unterstuetzen/uebersicht",
+                    "/kommunizieren",
+                    "/grenzen",
+                    "/selbstfuersorge",
+                  ].map(href => (
+                    <Link
+                      key={href}
+                      href={href}
+                      className="text-sm px-3 py-1.5 rounded-full bg-muted text-foreground hover:bg-muted/70 transition-colors"
+                    >
+                      {href === "/unterstuetzen/uebersicht"
+                        ? "Unterstützen"
+                        : href.slice(1).charAt(0).toUpperCase() + href.slice(2)}
+                    </Link>
+                  ))}
+                </div>
               </CardContent>
             </Card>
 
-            <Card className="border-border/50 bg-white">
-              <CardContent className="p-6">
-                <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center mb-4">
-                  <Users className="w-6 h-6 text-sage-darker" />
-                </div>
-                <h3 className="text-xl font-semibold text-foreground mb-2">Beratung & Netzwerke</h3>
-                <p className="text-muted-foreground mb-4">
-                  Fachstelle, Selbsthilfe und weitere Anlaufstellen für Angehörige, die nicht alles
-                  allein tragen möchten.
+            <Card className="border-border/50 bg-sand-muted/40">
+              <CardContent className="p-5">
+                <h2 className="text-xl font-semibold text-foreground mb-2">
+                  Materialien und Beratung
+                </h2>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Sekundäre Wege für Vertiefung und konkrete Unterstützung.
                 </p>
-                <Link href="/beratung">
-                  <Button variant="outline">Zu Beratung & Netzwerken</Button>
-                </Link>
+                <div className="flex gap-3">
+                  <Link href="/materialien">
+                    <Button variant="outline" size="sm">
+                      Materialien
+                    </Button>
+                  </Link>
+                  <Link href="/beratung">
+                    <Button variant="outline" size="sm">
+                      Beratung
+                    </Button>
+                  </Link>
+                </div>
               </CardContent>
             </Card>
           </div>
@@ -396,7 +350,11 @@ export default function Home() {
               </p>
             </div>
             <Link href="/soforthilfe">
-              <Button size="lg" variant="secondary" className="bg-white text-alert hover:bg-white/90">
+              <Button
+                size="lg"
+                variant="secondary"
+                className="bg-white text-alert hover:bg-white/90"
+              >
                 <Phone className="w-5 h-5 mr-2" />
                 Soforthilfe öffnen
               </Button>

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -22,51 +22,7 @@ import { TableOfContents } from "@/components/UXEnhancements";
 import ContentSection from "@/components/ContentSection";
 import ValidierungsStufenleiter from "@/components/interactive/ValidierungsStufenleiter";
 
-const kommSubcategories = [
-  { id: "alle", label: "Alle", icon: Filter },
-  { id: "techniken", label: "Techniken", icon: Heart },
-  { id: "konflikte", label: "Konflikte", icon: ShieldAlert },
-  { id: "praxis", label: "Praxis", icon: MessageCircle },
-];
-
-const kommItems = [
-  {
-    title: "Wenn Gespräche kippen: 3 Schritte",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/kWTjVSZAwAXAymgw.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/eEpcTcWSbYQpNzJv.pdf",
-    category: "techniken",
-  },
-  {
-    title: "Grenzen setzen, ohne zu eskalieren",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/QrgVLpdeorAWgKvg.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YyBYayMoMIGwTZtM.pdf",
-    category: "konflikte",
-  },
-  {
-    title: "Pause statt Streit",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VCooXJsQnRmSZGul.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/fGgpuKMuDfzJYgrc.pdf",
-    category: "konflikte",
-  },
-  {
-    title: "Zuhören ohne Zustimmen",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/eeZIHGmfprWnoPPf.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/toeDsBefZFNbxXYc.pdf",
-    category: "techniken",
-  },
-  {
-    title: "Beispiel-Dialog",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YZGoCcmXszaQGVtV.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WZdsgoAKaJwvMCjp.pdf",
-    category: "praxis",
-  },
-  {
-    title: "Spickzettel Krisenkommunikation (A4)",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tgVHTaXVryVEuEss.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YvXkEbRmwIcCFtsj.pdf",
-    category: "praxis",
-  },
-];
+import { kommSubcategories, kommItems } from "@/content/kommunizieren";
 
 export default function Kommunizieren() {
   const [activeFilter, setActiveFilter] = useState("alle");
@@ -75,7 +31,7 @@ export default function Kommunizieren() {
   const filteredItems =
     activeFilter === "alle"
       ? kommItems
-      : kommItems.filter((i) => i.category === activeFilter);
+      : kommItems.filter(i => i.category === activeFilter);
 
   return (
     <Layout>
@@ -98,7 +54,9 @@ export default function Kommunizieren() {
               <div className="w-12 h-12 rounded-xl bg-slate-light flex items-center justify-center">
                 <MessageCircle className="w-6 h-6 text-slate-blue" />
               </div>
-              <span className="text-sm font-medium text-slate-blue">Lesezeit: 14 Minuten</span>
+              <span className="text-sm font-medium text-slate-blue">
+                Lesezeit: 14 Minuten
+              </span>
             </div>
 
             <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
@@ -106,10 +64,11 @@ export default function Kommunizieren() {
             </h1>
 
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Kommunikation löst keine Grunddynamik. Sie kann aber Eskalation bremsen,
-              Missverständnisse begrenzen und Ihre eigene Position klarer machen. Gerade in
-              belasteten Beziehungen ist deshalb nicht nur wichtig, was Sie sagen, sondern wann, in
-              welchem Ton und mit welcher inneren Haltung.
+              Kommunikation löst keine Grunddynamik. Sie kann aber Eskalation
+              bremsen, Missverständnisse begrenzen und Ihre eigene Position
+              klarer machen. Gerade in belasteten Beziehungen ist deshalb nicht
+              nur wichtig, was Sie sagen, sondern wann, in welchem Ton und mit
+              welcher inneren Haltung.
             </p>
           </motion.div>
         </div>
@@ -127,15 +86,17 @@ export default function Kommunizieren() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  In belasteten Beziehungen kippt Kommunikation oft schnell in Verteidigung,
-                  Beschuldigung, Rückzug oder Übererklärung. Dann ist die Frage nicht nur, welcher
-                  Satz "richtig" wäre, sondern ob überhaupt schon ein Moment für Gespräch da ist.
+                  In belasteten Beziehungen kippt Kommunikation oft schnell in
+                  Verteidigung, Beschuldigung, Rückzug oder Übererklärung. Dann
+                  ist die Frage nicht nur, welcher Satz "richtig" wäre, sondern
+                  ob überhaupt schon ein Moment für Gespräch da ist.
                 </p>
                 <Card className="bg-slate-wash border-slate-mid/20">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Hilfreiche Kommunikation ist meist kürzer, langsamer und klarer. Sie versucht
-                      nicht sofort zu überzeugen, sondern zuerst Beziehungsspannung etwas zu senken.
+                      Hilfreiche Kommunikation ist meist kürzer, langsamer und
+                      klarer. Sie versucht nicht sofort zu überzeugen, sondern
+                      zuerst Beziehungsspannung etwas zu senken.
                     </p>
                   </CardContent>
                 </Card>
@@ -152,14 +113,17 @@ export default function Kommunizieren() {
                 <Card className="bg-terracotta-light/10 border-terracotta">
                   <CardContent className="p-6">
                     <p className="text-foreground leading-relaxed text-lg mb-3">
-                      <strong>Validierung</strong> bedeutet, dass Sie das Erleben Ihres Gegenübers
-                      als nachvollziehbar behandeln, ohne jeden Vorwurf, jede Interpretation oder
-                      jedes Verhalten zu bestätigen.
+                      <strong>Validierung</strong> bedeutet, dass Sie das
+                      Erleben Ihres Gegenübers als nachvollziehbar behandeln,
+                      ohne jeden Vorwurf, jede Interpretation oder jedes
+                      Verhalten zu bestätigen.
                     </p>
                     <p className="text-muted-foreground leading-relaxed">
-                      In Beziehungen mit Borderline ist das oft deshalb so wichtig, weil Nichtgesehenwerden,
-                      Kränkung oder Unklarheit rasch zusätzlichen Druck erzeugen. Validierung kann
-                      diesen Druck etwas senken und den Boden für spätere Klärung bereiten.
+                      In Beziehungen mit Borderline ist das oft deshalb so
+                      wichtig, weil Nichtgesehenwerden, Kränkung oder Unklarheit
+                      rasch zusätzlichen Druck erzeugen. Validierung kann diesen
+                      Druck etwas senken und den Boden für spätere Klärung
+                      bereiten.
                     </p>
                   </CardContent>
                 </Card>
@@ -169,8 +133,9 @@ export default function Kommunizieren() {
                 <Card className="bg-sage-wash/50 border-sage-mid/30">
                   <CardContent className="p-5">
                     <p className="text-foreground font-medium text-sm">
-                      Ein hilfreicher innerer Satz für Angehörige: Ich muss nicht recht bekommen, um
-                      zuerst zu zeigen, dass ich den Schmerz wahrnehme.
+                      Ein hilfreicher innerer Satz für Angehörige: Ich muss
+                      nicht recht bekommen, um zuerst zu zeigen, dass ich den
+                      Schmerz wahrnehme.
                     </p>
                   </CardContent>
                 </Card>
@@ -186,7 +151,9 @@ export default function Kommunizieren() {
               <div className="grid sm:grid-cols-2 gap-4">
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Eher jetzt</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Eher jetzt
+                    </h3>
                     <ul className="space-y-2 text-sm text-muted-foreground">
                       <li>kurz spiegeln, was Sie wahrnehmen</li>
                       <li>Ton und Tempo beruhigen</li>
@@ -197,7 +164,9 @@ export default function Kommunizieren() {
                 </Card>
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Eher später</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Eher später
+                    </h3>
                     <ul className="space-y-2 text-sm text-muted-foreground">
                       <li>Fakten prüfen und Missverständnisse sortieren</li>
                       <li>Konsequenzen besprechen</li>
@@ -234,22 +203,33 @@ export default function Kommunizieren() {
                       title: "Grenze und Pause kombinieren",
                       text: "Sie können Kontakt halten und gleichzeitig sagen, dass Beschimpfungen oder Druck nicht gehen.",
                     },
-                  ].map((item) => (
+                  ].map(item => (
                     <Card key={item.title} className="border-border/50">
                       <CardContent className="p-5">
-                        <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                        <p className="text-sm text-muted-foreground leading-relaxed">{item.text}</p>
+                        <h3 className="font-semibold text-foreground mb-2">
+                          {item.title}
+                        </h3>
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          {item.text}
+                        </p>
                       </CardContent>
                     </Card>
                   ))}
                 </div>
                 <Card className="border-l-4 border-l-terracotta-mid bg-terracotta-wash/30">
                   <CardContent className="p-5">
-                    <h4 className="font-semibold text-foreground mb-3">Ein möglicher Ablauf</h4>
+                    <h4 className="font-semibold text-foreground mb-3">
+                      Ein möglicher Ablauf
+                    </h4>
                     <ol className="space-y-2 text-sm text-foreground">
                       <li>1. "Ich sehe, dass es gerade sehr viel ist."</li>
-                      <li>2. "Ich möchte zuhören, aber nicht in diesem Ton."</li>
-                      <li>3. "Lass uns 10 Minuten Pause machen und dann weitersehen."</li>
+                      <li>
+                        2. "Ich möchte zuhören, aber nicht in diesem Ton."
+                      </li>
+                      <li>
+                        3. "Lass uns 10 Minuten Pause machen und dann
+                        weitersehen."
+                      </li>
                     </ol>
                   </CardContent>
                 </Card>
@@ -265,37 +245,49 @@ export default function Kommunizieren() {
               <div className="space-y-4">
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Vorwürfe</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Vorwürfe
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Reagieren Sie eher auf das Gefühl dahinter als auf die ganze Anklage. Sie
-                      müssen nicht jede Verzerrung korrigieren, bevor Sie Beziehung herstellen.
+                      Reagieren Sie eher auf das Gefühl dahinter als auf die
+                      ganze Anklage. Sie müssen nicht jede Verzerrung
+                      korrigieren, bevor Sie Beziehung herstellen.
                     </p>
                   </CardContent>
                 </Card>
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Rückzug und Schweigen</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Rückzug und Schweigen
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Raum geben kann hilfreich sein. Raum geben ist aber etwas anderes als
-                      strafendes Schweigen oder völliges Verschwinden aus Kontakt.
+                      Raum geben kann hilfreich sein. Raum geben ist aber etwas
+                      anderes als strafendes Schweigen oder völliges
+                      Verschwinden aus Kontakt.
                     </p>
                   </CardContent>
                 </Card>
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Schwarz-Weiss-Sätze</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Schwarz-Weiss-Sätze
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Es hilft oft, Gefühle anzuerkennen und gleichzeitig bei Ihrer komplexeren
-                      Wirklichkeit zu bleiben: Beziehung und Konflikt können gleichzeitig wahr sein.
+                      Es hilft oft, Gefühle anzuerkennen und gleichzeitig bei
+                      Ihrer komplexeren Wirklichkeit zu bleiben: Beziehung und
+                      Konflikt können gleichzeitig wahr sein.
                     </p>
                   </CardContent>
                 </Card>
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Nach einem Streit</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Nach einem Streit
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Ein Wiedereinstieg gelingt meist besser über Ruhe, begrenzte Offenheit und
-                      Verantwortung für den eigenen Anteil als über Sieger- oder Schuldsuche.
+                      Ein Wiedereinstieg gelingt meist besser über Ruhe,
+                      begrenzte Offenheit und Verantwortung für den eigenen
+                      Anteil als über Sieger- oder Schuldsuche.
                     </p>
                   </CardContent>
                 </Card>
@@ -311,33 +303,42 @@ export default function Kommunizieren() {
               <div className="space-y-4">
                 <Card className="border-l-4 border-l-terracotta-mid bg-terracotta-wash">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Als Partner/in</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Als Partner/in
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      In Partnerschaften ist die Intensität oft am höchsten. Nähe, Eifersucht,
-                      Angst vor Verlust und wechselseitige Kränkung mischen sich schnell. Gerade
-                      deshalb brauchen Gespräche oft mehr Klarheit und weniger Verschmelzung.
+                      In Partnerschaften ist die Intensität oft am höchsten.
+                      Nähe, Eifersucht, Angst vor Verlust und wechselseitige
+                      Kränkung mischen sich schnell. Gerade deshalb brauchen
+                      Gespräche oft mehr Klarheit und weniger Verschmelzung.
                     </p>
                   </CardContent>
                 </Card>
 
                 <Card className="border-l-4 border-l-slate-mid bg-slate-pale">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Als Elternteil</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Als Elternteil
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Alte Eltern-Kind-Muster färben viele Gespräche mit. Es kann helfen, das
-                      erwachsene Gegenüber nicht nur als Kind von früher zu adressieren, sondern als
-                      eigenständige Person mit eigener Verantwortung.
+                      Alte Eltern-Kind-Muster färben viele Gespräche mit. Es
+                      kann helfen, das erwachsene Gegenüber nicht nur als Kind
+                      von früher zu adressieren, sondern als eigenständige
+                      Person mit eigener Verantwortung.
                     </p>
                   </CardContent>
                 </Card>
 
                 <Card className="border-l-4 border-l-sage-mid bg-sage-pale">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Als erwachsenes Kind</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Als erwachsenes Kind
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Wer als erwachsenes Kind kommuniziert, gerät oft schnell in Loyalitätsdruck.
-                      Gerade dann ist wichtig: Ihre eigene Wahrnehmung und Ihre Begrenzung sind nicht
-                      weniger legitim als die Not Ihres Elternteils.
+                      Wer als erwachsenes Kind kommuniziert, gerät oft schnell
+                      in Loyalitätsdruck. Gerade dann ist wichtig: Ihre eigene
+                      Wahrnehmung und Ihre Begrenzung sind nicht weniger legitim
+                      als die Not Ihres Elternteils.
                     </p>
                   </CardContent>
                 </Card>
@@ -349,7 +350,9 @@ export default function Kommunizieren() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="mb-12 wave-divider-top"
-              style={{ "--wave-color": "var(--background)" } as React.CSSProperties}
+              style={
+                { "--wave-color": "var(--background)" } as React.CSSProperties
+              }
             >
               <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
                 <Download className="w-8 h-8 text-slate-blue" />
@@ -358,18 +361,20 @@ export default function Kommunizieren() {
               <p className="text-sm text-muted-foreground mb-4 flex items-center gap-2">
                 <Eye className="w-4 h-4 flex-shrink-0" />
                 <span>
-                  <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen»
-                  öffnet die A4-Druckversion im neuen Tab.
+                  <strong className="text-foreground">
+                    Vorschau = Web-Bild.
+                  </strong>{" "}
+                  «PDF öffnen» öffnet die A4-Druckversion im neuen Tab.
                 </span>
               </p>
 
               <div className="flex gap-2 overflow-x-auto pb-3 mb-6 scrollbar-none -mx-1 px-1">
-                {kommSubcategories.map((cat) => {
+                {kommSubcategories.map(cat => {
                   const Icon = cat.icon;
                   const count =
                     cat.id === "alle"
                       ? kommItems.length
-                      : kommItems.filter((i) => i.category === cat.id).length;
+                      : kommItems.filter(i => i.category === cat.id).length;
                   return (
                     <Button
                       key={cat.id}
@@ -378,27 +383,39 @@ export default function Kommunizieren() {
                       onClick={() => {
                         setActiveFilter(cat.id);
                         setTimeout(() => {
-                          gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                          gridRef.current?.scrollIntoView({
+                            behavior: "smooth",
+                            block: "start",
+                          });
                         }, 50);
                       }}
                       className={`whitespace-nowrap shrink-0 ${
-                        activeFilter === cat.id ? "bg-terracotta-mid hover:bg-terracotta-dark text-white" : ""
+                        activeFilter === cat.id
+                          ? "bg-terracotta-mid hover:bg-terracotta-dark text-white"
+                          : ""
                       }`}
                     >
                       <Icon className="w-4 h-4 mr-1.5" />
                       {cat.label}
-                      <span className="ml-1.5 text-xs opacity-90">({count})</span>
+                      <span className="ml-1.5 text-xs opacity-90">
+                        ({count})
+                      </span>
                     </Button>
                   );
                 })}
               </div>
 
-              <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+              <div
+                ref={gridRef}
+                className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6"
+              >
                 {filteredItems.map((item, index) => (
                   <Card
                     key={item.title}
                     className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
-                      filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""
+                      filteredItems.length > 1 && index === 0
+                        ? "sm:col-span-2"
+                        : ""
                     }`}
                   >
                     <div className="aspect-[4/3] bg-muted">
@@ -413,7 +430,9 @@ export default function Kommunizieren() {
                       />
                     </div>
                     <CardContent className="p-4">
-                      <h3 className="font-medium text-foreground text-sm mb-2">{item.title}</h3>
+                      <h3 className="font-medium text-foreground text-sm mb-2">
+                        {item.title}
+                      </h3>
                       <a
                         href={item.pdfUrl}
                         target="_blank"

--- a/client/src/pages/Materialien.tsx
+++ b/client/src/pages/Materialien.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from "react";
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
+import MaterialCard from "@/sections/materialien/MaterialCard";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
 import {
@@ -19,209 +20,8 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { Link } from "wouter";
-
-type Material = {
-  id: string;
-  title: string;
-  description: string;
-  category:
-    | "verstehen"
-    | "unterstuetzen"
-    | "kommunizieren"
-    | "grenzen"
-    | "selbstfuersorge"
-    | "genesung"
-    | "soforthilfe";
-  kind: "Infografik" | "Spickzettel" | "Checkliste" | "Notfallkarte" | "Notfallplan";
-  url: string;
-  downloadUrl?: string;
-  pdfUrl?: string;
-  previewUrl?: string;
-  isHtml?: boolean;
-  priority?: "core" | "secondary";
-};
-
-const materials: Material[] = [
-  {
-    id: "notfallkarte-zuerich",
-    title: "Notfallkarte Zürich – Psychische Krise",
-    description:
-      "Alle wichtigen Nummern für Angehörige auf einer A4-Seite. Für akute Orientierung, wenn rasches Handeln nötig ist.",
-    category: "soforthilfe",
-    kind: "Notfallkarte",
-    url: "/notfallkarte.html",
-    previewUrl: "/notfallkarte-preview.webp",
-    downloadUrl: "/notfallkarte.html",
-    pdfUrl: "/Notfallkarte-Zuerich-Psychische-Krise.pdf",
-    isHtml: true,
-    priority: "core",
-  },
-  {
-    id: "notfallplan-krise",
-    title: "Notfallplan Krise – Suizidgedanken & Selbstverletzung",
-    description:
-      "Knappe 4-Schritte-Anleitung für Angehörige bei Suizidgedanken oder Selbstverletzung.",
-    category: "soforthilfe",
-    kind: "Notfallplan",
-    url: "/notfallplan-krise-v03-preview.webp",
-    downloadUrl: "/notfallplan-krise-v03.pdf",
-    priority: "core",
-  },
-  {
-    id: "leuchtturm",
-    title: "Der Leuchtturm – Ihre Rolle als Angehörige/r",
-    description:
-      "Orientierung zur Angehörigenrolle: stabil bleiben, ohne das Schiff steuern zu wollen.",
-    category: "verstehen",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GbFCyQhEWIKomzXw.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DNGijMOYFghXAsLm.pdf",
-    priority: "core",
-  },
-  {
-    id: "eisberg",
-    title: "Der Eisberg – Wut ist oft die Spitze",
-    description:
-      "Wut, Schmerz, Angst und Scham als Beziehungsgeschehen verständlicher einordnen.",
-    category: "verstehen",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MLLwefeyaKvtThbK.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RNKtfQQMvhlSyiIp.pdf",
-    priority: "core",
-  },
-  {
-    id: "rolle-klaeren",
-    title: "Ihre Rolle klären – Was Sie sein können (und was nicht)",
-    description:
-      "Klarheit über hilfreiche Unterstützung, Verantwortung und die Grenzen der Angehörigenrolle.",
-    category: "unterstuetzen",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WUiQpUWjKIjpSRDC.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/JMOjSacqrnDcAkoB.pdf",
-    priority: "core",
-  },
-  {
-    id: "krisenkommunikation",
-    title: "Spickzettel Krisenkommunikation (A4)",
-    description:
-      "Kurze Formulierungen für akute Spannungszustände, wenn klare Sprache mehr hilft als lange Erklärungen.",
-    category: "kommunizieren",
-    kind: "Spickzettel",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tgVHTaXVryVEuEss.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/YvXkEbRmwIcCFtsj.pdf",
-    priority: "core",
-  },
-  {
-    id: "grenzen-spickzettel",
-    title: "Spickzettel Grenzen – Die wichtigsten Sätze",
-    description:
-      "Knappe Formulierungen für klare, respektvolle Grenzsetzung im Alltag und in belasteten Gesprächen.",
-    category: "grenzen",
-    kind: "Spickzettel",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/avGqFKFuKFfFYANu.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/obwIZiRPiVPphIUX.pdf",
-    priority: "core",
-  },
-  {
-    id: "warnsignale",
-    title: "Warnsignale der Überlastung",
-    description:
-      "Orientierung für Angehörige, wenn Erschöpfung, Alarmbereitschaft oder Rückzug zu viel Raum einnehmen.",
-    category: "selbstfuersorge",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OEUNVdTyojBBYTic.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/VdAxPxngFzgNImxg.pdf",
-    priority: "core",
-  },
-  {
-    id: "schuld-verantwortung",
-    title: "Schuld, Verantwortung und was dazwischen liegt",
-    description:
-      "Hilft, Schuldgefühle bei Angehörigen zu entlasten und Verantwortung differenzierter zu sehen.",
-    category: "selbstfuersorge",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/TgzrtmiUbRscTBlg.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/jPuhxPHHtFSjOTly.pdf",
-    priority: "secondary",
-  },
-  {
-    id: "spaltung",
-    title: "Spaltung – das Pendel zwischen Extremen",
-    description:
-      "Einordnung von Idealisierung, Entwertung und dem erschwerten Zugang zu Grautönen unter Stress.",
-    category: "verstehen",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WRORriPmZftmvKTL.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RtdVgflJuCNAhEKk.pdf",
-    priority: "secondary",
-  },
-  {
-    id: "alarm-modus",
-    title: "Alarm-Modus vs. Denk-Modus",
-    description:
-      "Warum logische Klärung unter starker Anspannung oft nicht erreichbar ist und zuerst Beruhigung hilft.",
-    category: "verstehen",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/sSUJoOUTiuWgrkiZ.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tlKAOpYHdCNAtovE.pdf",
-    priority: "secondary",
-  },
-  {
-    id: "wenn-worte-treffen",
-    title: "Wenn Worte treffen – 5 häufige Schuldzuweisungen",
-    description:
-      "Typische anklagende Sätze einordnen und eigene Reaktionen ruhiger und klarer gestalten.",
-    category: "kommunizieren",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/azZbLPyPkSupQskI.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/hEXKCmWYeiyUnwXr.pdf",
-    priority: "secondary",
-  },
-  {
-    id: "dear",
-    title: "Die DEAR-Technik – Grenzen setzen ohne Vorwürfe",
-    description:
-      "DBT-orientierte Struktur für klare Bitten und Grenzsetzungen ohne unnötige Eskalation.",
-    category: "grenzen",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/yBSkvBJGSeNvxINq.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DDkqUiaNJwizEtPv.pdf",
-    priority: "secondary",
-  },
-  {
-    id: "radikale-akzeptanz",
-    title: "Radikale Akzeptanz – Aufhören zu kämpfen, anfangen zu handeln",
-    description:
-      "Hilft Angehörigen, Realität anzuerkennen, ohne aufzugeben oder alles gutzuheissen.",
-    category: "selbstfuersorge",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OmxdguWaaXAkElDp.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/SkBpjnDHfNmPbmnd.pdf",
-    priority: "secondary",
-  },
-  {
-    id: "genesung-zahlen",
-    title: "Genesung in Zahlen – Was die Forschung zeigt",
-    description:
-      "Langfristige Hoffnung mit realistischen Daten: Besserung ist möglich, aber selten linear.",
-    category: "genesung",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tyFTHNjsUagqrXiS.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MunlHDCNqnsOhBFn.pdf",
-    priority: "secondary",
-  },
-  {
-    id: "kinder",
-    title: "Wenn Mama oder Papa grosse Gefühle hat",
-    description:
-      "Altersgerechte Erklärung für Kinder und Hinweise zum Schutz von Kindern im belasteten Familiensystem.",
-    category: "verstehen",
-    kind: "Infografik",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/PrnKdbomSunLKPVv.webp",
-    downloadUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/birikKPATMlHGPWf.pdf",
-    priority: "secondary",
-  },
-];
+import { materials, quickStarts, type Material } from "@/content/materials";
+import MaterialienHeroSection from "@/sections/materialien/MaterialienHeroSection";
 
 const categoryMeta = [
   { id: "alle", label: "Alle", icon: Filter },
@@ -234,106 +34,6 @@ const categoryMeta = [
   { id: "genesung", label: "Genesung", icon: TrendingUp },
 ];
 
-const quickStarts = [
-  {
-    id: "soforthilfe",
-    title: "Akute Krise",
-    text: "Wenn rasche Orientierung und Notfallnummern nötig sind.",
-    color: "var(--color-alert)",
-    bg: "var(--color-alert-wash)",
-  },
-  {
-    id: "verstehen",
-    title: "Ich brauche Orientierung",
-    text: "Wenn Sie Dynamiken besser einordnen möchten.",
-    color: "var(--color-sage-mid)",
-    bg: "var(--color-sage-wash)",
-  },
-  {
-    id: "kommunizieren",
-    title: "Schwierige Gespräche",
-    text: "Wenn Worte schnell kippen oder verletzen.",
-    color: "var(--color-slate-blue)",
-    bg: "var(--color-slate-wash)",
-  },
-  {
-    id: "selbstfuersorge",
-    title: "Ich bin selbst am Limit",
-    text: "Wenn Erschöpfung, Schuld oder Daueranspannung dominieren.",
-    color: "var(--color-terracotta-mid)",
-    bg: "var(--color-terracotta-wash)",
-  },
-];
-
-function MaterialCard({
-  item,
-  onPreview,
-}: {
-  item: Material;
-  onPreview: (image: string, title: string) => void;
-}) {
-  const previewSrc = item.isHtml ? item.previewUrl ?? item.url : item.url;
-  const openHref = item.downloadUrl ?? item.url;
-  const downloadHref = item.pdfUrl ?? item.downloadUrl;
-  const isCrossOriginDownload =
-    !!downloadHref && /^https?:\/\//i.test(downloadHref) && !downloadHref.startsWith(window.location.origin);
-
-  return (
-    <Card className="h-full hover:shadow-lg transition-all hover:border-sage-mid/30 overflow-hidden">
-      <button
-        type="button"
-        className="relative aspect-[4/3] bg-muted overflow-hidden group w-full"
-        onClick={() => {
-          if (item.isHtml) {
-            window.open(openHref, "_blank");
-          } else {
-            onPreview(item.url, item.title);
-          }
-        }}
-        aria-label={`${item.title} öffnen`}
-      >
-        <img
-          src={previewSrc}
-          alt={item.title}
-          className="w-full h-full object-cover object-top transition-transform duration-500 group-hover:scale-105"
-          loading="lazy"
-          width={400}
-          height={300}
-          decoding="async"
-        />
-        <div className="absolute top-2 left-2 bg-background/85 backdrop-blur-sm px-2 py-0.5 rounded text-xs font-medium text-muted-foreground">
-          {item.kind}
-        </div>
-      </button>
-      <CardContent className="p-5">
-        <h3 className="font-semibold text-foreground mb-2 text-lg">{item.title}</h3>
-        <p className="text-sm text-muted-foreground mb-4">{item.description}</p>
-        <div className="flex gap-2 flex-wrap">
-          <a
-            href={openHref}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 bg-sage-dark hover:bg-sage-dark/90 text-white transition-colors"
-          >
-            <ExternalLink className="w-4 h-4" />
-            Öffnen
-          </a>
-          {downloadHref ? (
-            <a
-              href={downloadHref}
-              download={isCrossOriginDownload ? undefined : ""}
-              className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 border border-sage-dark text-sage-dark hover:bg-sage-light/40 transition-colors"
-            >
-              <Download className="w-4 h-4" />
-              Herunterladen
-            </a>
-          ) : null}
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
 export default function Materialien() {
   const [activeCategory, setActiveCategory] = useState("alle");
   const [previewImage, setPreviewImage] = useState<string | null>(null);
@@ -341,18 +41,18 @@ export default function Materialien() {
   const gridRef = useRef<HTMLElement>(null);
 
   const coreMaterials = useMemo(
-    () => materials.filter((item) => item.priority === "core"),
-    [],
+    () => materials.filter(item => item.priority === "core"),
+    []
   );
 
   const secondaryMaterials = useMemo(
     () =>
       activeCategory === "alle"
-        ? materials.filter((item) => item.priority !== "core")
+        ? materials.filter(item => item.priority !== "core")
         : materials.filter(
-            (item) => item.priority !== "core" && item.category === activeCategory,
+            item => item.priority !== "core" && item.category === activeCategory
           ),
-    [activeCategory],
+    [activeCategory]
   );
 
   const scrollToResults = () => {
@@ -369,32 +69,7 @@ export default function Materialien() {
         path="/materialien"
       />
 
-      <section className="py-12 md:py-20 bg-gradient-to-b from-sage-light/30 to-background wave-divider">
-        <div className="container">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="max-w-3xl"
-          >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center">
-                <Download className="w-6 h-6 text-sage-darker" />
-              </div>
-            </div>
-
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
-              Materialien für Angehörige
-            </h1>
-
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Hier finden Sie ausgewählte Handouts, Infografiken und Orientierungshilfen für
-              belastende, unklare oder akute Situationen. Die Sammlung ist bewusst kuratiert: lieber
-              wenige, wirklich hilfreiche Ressourcen als ein unübersichtliches Archiv.
-            </p>
-          </motion.div>
-        </div>
-      </section>
+      <MaterialienHeroSection />
 
       <section className="py-10 wave-divider-top">
         <div className="container">
@@ -403,7 +78,7 @@ export default function Materialien() {
               Was hilft gerade jetzt?
             </h2>
             <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-4">
-              {quickStarts.map((item) => (
+              {quickStarts.map(item => (
                 <button
                   key={item.id}
                   type="button"
@@ -414,7 +89,9 @@ export default function Materialien() {
                   className="text-left rounded-xl border p-5 transition-all hover:shadow-md"
                   style={{ borderColor: item.color, backgroundColor: item.bg }}
                 >
-                  <p className="font-semibold text-foreground mb-2">{item.title}</p>
+                  <p className="font-semibold text-foreground mb-2">
+                    {item.title}
+                  </p>
                   <p className="text-sm text-muted-foreground">{item.text}</p>
                 </button>
               ))}
@@ -437,9 +114,9 @@ export default function Materialien() {
                       Empfohlene Kernmaterialien
                     </h2>
                     <p className="text-muted-foreground">
-                      Wenn Sie gerade nicht lange suchen möchten, beginnen Sie mit diesen
-                      Materialien. Sie decken Krise, Orientierung, Kommunikation, Grenzen und
-                      Selbstfürsorge ab.
+                      Wenn Sie gerade nicht lange suchen möchten, beginnen Sie
+                      mit diesen Materialien. Sie decken Krise, Orientierung,
+                      Kommunikation, Grenzen und Selbstfürsorge ab.
                     </p>
                   </div>
                 </div>
@@ -447,7 +124,7 @@ export default function Materialien() {
             </Card>
 
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              {coreMaterials.map((item) => (
+              {coreMaterials.map(item => (
                 <MaterialCard
                   key={item.id}
                   item={item}
@@ -462,25 +139,32 @@ export default function Materialien() {
         </div>
       </section>
 
-      <section ref={gridRef} className="py-12 md:py-16 border-t border-border/60">
+      <section
+        ref={gridRef}
+        className="py-12 md:py-16 border-t border-border/60"
+      >
         <div className="container">
           <div className="max-w-5xl mx-auto">
             <div className="mb-6 p-3 rounded-lg bg-sand border border-sand-subtle flex items-center gap-2">
               <Eye className="w-4 h-4 text-muted-foreground flex-shrink-0" />
               <p className="text-sm text-muted-foreground">
-                <strong className="text-foreground">Vorschau = Web-Bild.</strong> «Öffnen» öffnet
-                die Druckversion im neuen Tab. Die Notfallkarte öffnet als HTML-Seite.
+                <strong className="text-foreground">
+                  Vorschau = Web-Bild.
+                </strong>{" "}
+                «Öffnen» öffnet die Druckversion im neuen Tab. Die Notfallkarte
+                öffnet als HTML-Seite.
               </p>
             </div>
 
             <div className="flex gap-2 overflow-x-auto pb-3 mb-8 scrollbar-none -mx-4 px-4 md:mx-0 md:px-0 md:flex-wrap md:overflow-visible">
-              {categoryMeta.map((cat) => {
+              {categoryMeta.map(cat => {
                 const Icon = cat.icon;
                 const count =
                   cat.id === "alle"
-                    ? materials.filter((item) => item.priority !== "core").length
+                    ? materials.filter(item => item.priority !== "core").length
                     : materials.filter(
-                        (item) => item.priority !== "core" && item.category === cat.id,
+                        item =>
+                          item.priority !== "core" && item.category === cat.id
                       ).length;
                 return (
                   <Button
@@ -489,7 +173,9 @@ export default function Materialien() {
                     size="sm"
                     onClick={() => setActiveCategory(cat.id)}
                     className={`whitespace-nowrap shrink-0 ${
-                      activeCategory === cat.id ? "bg-sage-dark hover:bg-sage-dark text-white" : ""
+                      activeCategory === cat.id
+                        ? "bg-sage-dark hover:bg-sage-dark text-white"
+                        : ""
                     }`}
                   >
                     <Icon className="w-4 h-4 mr-1.5" />
@@ -502,7 +188,7 @@ export default function Materialien() {
 
             {secondaryMaterials.length > 0 ? (
               <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                {secondaryMaterials.map((item) => (
+                {secondaryMaterials.map(item => (
                   <MaterialCard
                     key={item.id}
                     item={item}
@@ -517,7 +203,8 @@ export default function Materialien() {
               <Card className="border-border/50">
                 <CardContent className="p-8 text-center">
                   <p className="text-muted-foreground">
-                    In dieser Kategorie sind aktuell keine weiteren Materialien sichtbar.
+                    In dieser Kategorie sind aktuell keine weiteren Materialien
+                    sichtbar.
                   </p>
                 </CardContent>
               </Card>
@@ -531,10 +218,13 @@ export default function Materialien() {
           <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-6">
             <Card className="bg-sand-muted border-sand-mid">
               <CardContent className="p-6">
-                <h2 className="font-semibold text-foreground mb-2 text-lg">Besondere Konstellationen</h2>
+                <h2 className="font-semibold text-foreground mb-2 text-lg">
+                  Besondere Konstellationen
+                </h2>
                 <p className="text-sm text-muted-foreground mb-4">
-                  Manche Materialien helfen besonders, wenn Kinder mitbetroffen sind, wenn Schuld
-                  dominiert oder wenn Grenzen und Distanz zum Thema werden.
+                  Manche Materialien helfen besonders, wenn Kinder mitbetroffen
+                  sind, wenn Schuld dominiert oder wenn Grenzen und Distanz zum
+                  Thema werden.
                 </p>
                 <div className="flex flex-wrap gap-2">
                   <Button
@@ -573,10 +263,12 @@ export default function Materialien() {
 
             <Card className="bg-sage-wash border-sage-light">
               <CardContent className="p-6">
-                <h2 className="font-semibold text-foreground mb-2 text-lg">Von hier aus weiter</h2>
+                <h2 className="font-semibold text-foreground mb-2 text-lg">
+                  Von hier aus weiter
+                </h2>
                 <p className="text-sm text-muted-foreground mb-4">
-                  Wenn Sie gerade eher Orientierung als Downloads brauchen, sind die Hauptseiten oft
-                  der bessere Einstieg.
+                  Wenn Sie gerade eher Orientierung als Downloads brauchen, sind
+                  die Hauptseiten oft der bessere Einstieg.
                 </p>
                 <div className="flex flex-wrap gap-2">
                   <Link href="/verstehen">

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -22,58 +22,12 @@ import {
   CheckCircle2,
 } from "lucide-react";
 import { Link } from "wouter";
+import UnterstuetzenHeroSection from "@/sections/unterstuetzen/UnterstuetzenHeroSection";
 
-const unterstuetzenSubcategories = [
-  { id: "alle", label: "Alle", icon: Filter },
-  { id: "grundlagen", label: "Grundlagen", icon: Compass },
-  { id: "haltung", label: "Haltung", icon: Heart },
-  { id: "alltag", label: "Alltag", icon: Users },
-];
-
-const unterstuetzenItems = [
-  {
-    title: "Im Krisenmodus – Orientierung geben",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/gOumJSiPiJFGkSFy.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/FOZYnweFmVcMXYyr.pdf",
-    category: "grundlagen",
-  },
-  {
-    title: "Ihre Rolle klären",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WUiQpUWjKIjpSRDC.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/JMOjSacqrnDcAkoB.pdf",
-    category: "grundlagen",
-  },
-  {
-    title: "Drei Säulen hilfreicher Unterstützung",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WuCBUdnlHakpSnbY.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/AalrNrybgxuMcRcX.pdf",
-    category: "grundlagen",
-  },
-  {
-    title: "Konsistenz-Prinzip",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MCMaGcrhifsekEqb.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/vfDYZzjEwJsEhzch.pdf",
-    category: "haltung",
-  },
-  {
-    title: "Beziehungs-Achtsamkeit",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/toOMoXhzHiaZUlBg.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/oPRapPNKMLHWEior.pdf",
-    category: "haltung",
-  },
-  {
-    title: "6 Leitlinien für Angehörige",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OfOPUMQpHXrpSPgw.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/IIcvvdvSlDcXqwbL.pdf",
-    category: "alltag",
-  },
-  {
-    title: "4 Alltags-Tipps",
-    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/cwhMoIHSUeEWpyWo.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/ipyRcgPjVrRKYqyd.pdf",
-    category: "alltag",
-  },
-];
+import {
+  unterstuetzenItems,
+  unterstuetzenSubcategories,
+} from "@/content/unterstuetzen";
 
 export default function UnterstuetzenUebersicht() {
   const [activeFilter, setActiveFilter] = useState("alle");
@@ -82,7 +36,7 @@ export default function UnterstuetzenUebersicht() {
   const filteredItems =
     activeFilter === "alle"
       ? unterstuetzenItems
-      : unterstuetzenItems.filter((i) => i.category === activeFilter);
+      : unterstuetzenItems.filter(i => i.category === activeFilter);
 
   return (
     <Layout>
@@ -92,41 +46,7 @@ export default function UnterstuetzenUebersicht() {
         path="/unterstuetzen/uebersicht"
       />
 
-      <section className="py-12 md:py-20 bg-gradient-to-b from-terracotta-light/30 to-background wave-divider">
-        <div className="container">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="max-w-3xl"
-          >
-            <Link
-              href="/verstehen"
-              className="text-sm text-muted-foreground hover:text-foreground mb-4 inline-flex items-center gap-1"
-            >
-              ← Zurück zu Verstehen
-            </Link>
-
-            <div className="flex items-center gap-3 mb-6 mt-4">
-              <div className="w-12 h-12 rounded-xl bg-terracotta-light flex items-center justify-center">
-                <Compass className="w-6 h-6 text-terracotta-dark" />
-              </div>
-              <span className="text-sm font-medium text-terracotta-dark">Lesezeit: 8 Minuten</span>
-            </div>
-
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
-              Wie Angehörige hilfreich bleiben können
-            </h1>
-
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Angehörige möchten oft gleichzeitig beruhigen, schützen, verstehen, Grenzen wahren und
-              die Beziehung nicht verlieren. Genau diese Gleichzeitigkeit macht die Rolle so
-              anspruchsvoll. Diese Seite hilft Ihnen, Unterstützung realistischer und tragfähiger zu
-              denken.
-            </p>
-          </motion.div>
-        </div>
-      </section>
+      <UnterstuetzenHeroSection />
 
       <section className="py-12 md:py-16 wave-divider-top">
         <div className="container">
@@ -140,20 +60,23 @@ export default function UnterstuetzenUebersicht() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Angehörige können in belasteten Beziehungen eine wichtige Rolle spielen. Sie können
-                  beruhigen, orientieren, Struktur geben, emotionale Anerkennung vermitteln und
-                  mithelfen, dass Situationen weniger zerstörerisch verlaufen.
+                  Angehörige können in belasteten Beziehungen eine wichtige
+                  Rolle spielen. Sie können beruhigen, orientieren, Struktur
+                  geben, emotionale Anerkennung vermitteln und mithelfen, dass
+                  Situationen weniger zerstörerisch verlaufen.
                 </p>
                 <p className="text-muted-foreground leading-relaxed">
-                  Gleichzeitig ist Unterstützung nie allmächtig. Sie können nicht jede Krise
-                  verhindern, keine Entwicklung erzwingen und nicht dauerhaft die innere Regulation
-                  eines anderen Menschen übernehmen. Gerade diese Grenze ist oft schwer auszuhalten.
+                  Gleichzeitig ist Unterstützung nie allmächtig. Sie können
+                  nicht jede Krise verhindern, keine Entwicklung erzwingen und
+                  nicht dauerhaft die innere Regulation eines anderen Menschen
+                  übernehmen. Gerade diese Grenze ist oft schwer auszuhalten.
                 </p>
                 <Card className="bg-terracotta-light/20 border-terracotta">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Hilfreiche Unterstützung ist deshalb nicht totale Verfügbarkeit, sondern eine
-                      Form von tragfähiger Beziehung: zugewandt, klar, begrenzt und längerfristig
+                      Hilfreiche Unterstützung ist deshalb nicht totale
+                      Verfügbarkeit, sondern eine Form von tragfähiger
+                      Beziehung: zugewandt, klar, begrenzt und längerfristig
                       durchhaltbar.
                     </p>
                   </CardContent>
@@ -181,8 +104,11 @@ export default function UnterstuetzenUebersicht() {
                         "ein Mensch, der Orientierung gibt",
                         "ein Gegenüber mit realistischer Hoffnung",
                         "jemand, der Grenzen klar benennt und hält",
-                      ].map((item) => (
-                        <li key={item} className="flex items-start gap-2 text-muted-foreground">
+                      ].map(item => (
+                        <li
+                          key={item}
+                          className="flex items-start gap-2 text-muted-foreground"
+                        >
                           <span className="text-sage-mid">✓</span>
                           {item}
                         </li>
@@ -204,8 +130,11 @@ export default function UnterstuetzenUebersicht() {
                         "alles Schwierige stellvertretend zu regulieren",
                         "Verhalten permanent zu kontrollieren",
                         "für den Verlauf der Genesung verantwortlich zu sein",
-                      ].map((item) => (
-                        <li key={item} className="flex items-start gap-2 text-muted-foreground">
+                      ].map(item => (
+                        <li
+                          key={item}
+                          className="flex items-start gap-2 text-muted-foreground"
+                        >
                           <span className="text-terracotta-mid">✗</span>
                           {item}
                         </li>
@@ -224,10 +153,11 @@ export default function UnterstuetzenUebersicht() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Viele Angehörige erleben nicht nur die Belastung der betroffenen Person, sondern
-                  auch die eigene Ambivalenz: helfen wollen und gleichzeitig wegwollen, verstehen
-                  wollen und gleichzeitig innerlich hart werden, Grenzen setzen wollen und dann aus
-                  Schuld doch wieder nachgeben.
+                  Viele Angehörige erleben nicht nur die Belastung der
+                  betroffenen Person, sondern auch die eigene Ambivalenz: helfen
+                  wollen und gleichzeitig wegwollen, verstehen wollen und
+                  gleichzeitig innerlich hart werden, Grenzen setzen wollen und
+                  dann aus Schuld doch wieder nachgeben.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   {[
@@ -235,10 +165,12 @@ export default function UnterstuetzenUebersicht() {
                     "aus Schuld zu viel übernehmen",
                     "aus Erschöpfung kalt oder kurz angebunden werden",
                     "zwischen Mitgefühl, Wut, Loyalität und Rückzug schwanken",
-                  ].map((item) => (
+                  ].map(item => (
                     <Card key={item} className="border-border/50">
                       <CardContent className="p-5">
-                        <p className="text-sm text-muted-foreground leading-relaxed">{item}</p>
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          {item}
+                        </p>
                       </CardContent>
                     </Card>
                   ))}
@@ -246,9 +178,10 @@ export default function UnterstuetzenUebersicht() {
                 <Card className="bg-sage-wash/50 border-sage-mid/30">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Diese Ambivalenz ist kein Zeichen fehlender Haltung. Sie ist oft Ausdruck einer
-                      langandauernden Belastung, in der Beziehung, Verantwortung und Selbstschutz
-                      gleichzeitig Platz brauchen.
+                      Diese Ambivalenz ist kein Zeichen fehlender Haltung. Sie
+                      ist oft Ausdruck einer langandauernden Belastung, in der
+                      Beziehung, Verantwortung und Selbstschutz gleichzeitig
+                      Platz brauchen.
                     </p>
                   </CardContent>
                 </Card>
@@ -265,9 +198,10 @@ export default function UnterstuetzenUebersicht() {
                 <Card className="bg-terracotta-wash/30 border-terracotta/50">
                   <CardContent className="p-5 sm:p-6">
                     <p className="text-foreground leading-relaxed">
-                      Wenn Angst, Scham, Wut oder Verlassenheitsgefühl alles verengen, bringt es
-                      meist wenig, sofort Inhalte zu klären oder Schuldfragen zu diskutieren.
-                      Hilfreicher ist zuerst eine Reaktion, die den Zustand etwas beruhigt.
+                      Wenn Angst, Scham, Wut oder Verlassenheitsgefühl alles
+                      verengen, bringt es meist wenig, sofort Inhalte zu klären
+                      oder Schuldfragen zu diskutieren. Hilfreicher ist zuerst
+                      eine Reaktion, die den Zustand etwas beruhigt.
                     </p>
                   </CardContent>
                 </Card>
@@ -278,10 +212,12 @@ export default function UnterstuetzenUebersicht() {
                       <Anchor className="w-4 h-4 text-sage-mid" />
                     </div>
                     <div>
-                      <p className="font-semibold text-foreground text-sm sm:text-base">Sicherheit und Ruhe</p>
+                      <p className="font-semibold text-foreground text-sm sm:text-base">
+                        Sicherheit und Ruhe
+                      </p>
                       <p className="text-muted-foreground text-sm mt-0.5">
-                        Ihre eigene Ruhe ist kein Allheilmittel, aber oft ein wichtiger Gegenpol zur
-                        Eskalation.
+                        Ihre eigene Ruhe ist kein Allheilmittel, aber oft ein
+                        wichtiger Gegenpol zur Eskalation.
                       </p>
                     </div>
                   </div>
@@ -291,10 +227,12 @@ export default function UnterstuetzenUebersicht() {
                       <Heart className="w-4 h-4 text-slate-dark" />
                     </div>
                     <div>
-                      <p className="font-semibold text-foreground text-sm sm:text-base">Validierung</p>
+                      <p className="font-semibold text-foreground text-sm sm:text-base">
+                        Validierung
+                      </p>
                       <p className="text-muted-foreground text-sm mt-0.5">
-                        Den Schmerz anerkennen, ohne alles zu bestätigen. Verstehen heisst nicht
-                        nachgeben.
+                        Den Schmerz anerkennen, ohne alles zu bestätigen.
+                        Verstehen heisst nicht nachgeben.
                       </p>
                     </div>
                   </div>
@@ -304,9 +242,12 @@ export default function UnterstuetzenUebersicht() {
                       <HandHeart className="w-4 h-4 text-sand-mid" />
                     </div>
                     <div>
-                      <p className="font-semibold text-foreground text-sm sm:text-base">Kurze Orientierung und Begrenzung</p>
+                      <p className="font-semibold text-foreground text-sm sm:text-base">
+                        Kurze Orientierung und Begrenzung
+                      </p>
                       <p className="text-muted-foreground text-sm mt-0.5">
-                        Kurz bleiben, nicht diskutieren, aber auch nicht alles offenlassen.
+                        Kurz bleiben, nicht diskutieren, aber auch nicht alles
+                        offenlassen.
                       </p>
                     </div>
                   </div>
@@ -314,9 +255,10 @@ export default function UnterstuetzenUebersicht() {
 
                 <blockquote className="border-l-4 border-sage-mid bg-sage-lighter/50 rounded-r-lg px-4 py-3 sm:px-5 sm:py-4">
                   <p className="text-sm text-foreground leading-relaxed">
-                    <strong>Wichtig:</strong> Unterstützung in der Krise bedeutet nicht, alles zu
-                    tragen. Wenn Sicherheit unklar ist oder Suizidalität im Raum steht, braucht es
-                    rasch zusätzliche Hilfe.
+                    <strong>Wichtig:</strong> Unterstützung in der Krise
+                    bedeutet nicht, alles zu tragen. Wenn Sicherheit unklar ist
+                    oder Suizidalität im Raum steht, braucht es rasch
+                    zusätzliche Hilfe.
                   </p>
                 </blockquote>
               </div>
@@ -346,11 +288,15 @@ export default function UnterstuetzenUebersicht() {
                     title: "Alltag nicht nur um Krise bauen",
                     text: "Wenn sich alles nur noch um Anspannung und Eskalation dreht, geht Beziehungssubstanz verloren. Auch normale Anteile brauchen Platz.",
                   },
-                ].map((item) => (
+                ].map(item => (
                   <Card key={item.title} className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                      <p className="text-sm text-muted-foreground leading-relaxed">{item.text}</p>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        {item.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground leading-relaxed">
+                        {item.text}
+                      </p>
                     </CardContent>
                   </Card>
                 ))}
@@ -365,15 +311,17 @@ export default function UnterstuetzenUebersicht() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Unterstützung wird auf Dauer nur tragfähig, wenn sie begrenzt bleibt. Wer aus Angst
-                  oder Schuld jede Grenze aufweicht, beruhigt eine Situation kurzfristig vielleicht,
-                  macht sie langfristig aber oft unklarer und krisenanfälliger.
+                  Unterstützung wird auf Dauer nur tragfähig, wenn sie begrenzt
+                  bleibt. Wer aus Angst oder Schuld jede Grenze aufweicht,
+                  beruhigt eine Situation kurzfristig vielleicht, macht sie
+                  langfristig aber oft unklarer und krisenanfälliger.
                 </p>
                 <Card className="bg-cream border-border/50">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Grenzen sind kein Liebesentzug. Sie schaffen Berechenbarkeit, schützen Ihre
-                      Integrität und entlasten Beziehungen von der Erwartung, dass ein Mensch alles
+                      Grenzen sind kein Liebesentzug. Sie schaffen
+                      Berechenbarkeit, schützen Ihre Integrität und entlasten
+                      Beziehungen von der Erwartung, dass ein Mensch alles
                       halten müsse.
                     </p>
                   </CardContent>
@@ -389,15 +337,18 @@ export default function UnterstuetzenUebersicht() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Wenn mehrere Angehörige beteiligt sind, entstehen oft Spannungen: Eine Person
-                  grenzt ab, eine andere rettet, eine dritte will Ruhe um jeden Preis. Solche
-                  Unterschiede sind normal. Schwierig wird es, wenn Betroffene und Angehörige in
+                  Wenn mehrere Angehörige beteiligt sind, entstehen oft
+                  Spannungen: Eine Person grenzt ab, eine andere rettet, eine
+                  dritte will Ruhe um jeden Preis. Solche Unterschiede sind
+                  normal. Schwierig wird es, wenn Betroffene und Angehörige in
                   widersprüchliche Bündnisse geraten.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   <Card className="border-l-4 border-l-sage-mid">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Hilfreich</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Hilfreich
+                      </h3>
                       <ul className="text-sm text-muted-foreground space-y-1">
                         <li>gemeinsame Grundlinien klären</li>
                         <li>Absprachen ausserhalb akuter Krisen treffen</li>
@@ -408,7 +359,9 @@ export default function UnterstuetzenUebersicht() {
                   </Card>
                   <Card className="border-l-4 border-l-terracotta-mid">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Belastend</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Belastend
+                      </h3>
                       <ul className="text-sm text-muted-foreground space-y-1">
                         <li>widersprüchliche Botschaften</li>
                         <li>heimliche Sonderabsprachen</li>
@@ -435,10 +388,15 @@ export default function UnterstuetzenUebersicht() {
                   "weniger Schuld und Gegenschuld",
                   "mehr Bereitschaft, Hilfe von aussen einzubeziehen",
                   "mehr Selbstschutz ohne vollständigen Beziehungsabbruch",
-                ].map((item) => (
-                  <div key={item} className="flex items-start gap-3 p-4 rounded-xl bg-cream border border-border/30">
+                ].map(item => (
+                  <div
+                    key={item}
+                    className="flex items-start gap-3 p-4 rounded-xl bg-cream border border-border/30"
+                  >
                     <span className="text-sage-mid mt-0.5">✓</span>
-                    <span className="text-sm text-muted-foreground">{item}</span>
+                    <span className="text-sm text-muted-foreground">
+                      {item}
+                    </span>
                   </div>
                 ))}
               </div>
@@ -452,16 +410,18 @@ export default function UnterstuetzenUebersicht() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Es gibt Konstellationen, in denen Angehörige nicht mehr nur unterstützen, sondern
-                  vor allem schützen müssen: bei eigener Erschöpfung, bei Gewalt oder massiver
-                  Grenzverletzung, wenn Kinder mitbetroffen sind oder wenn sich das ganze Leben nur
+                  Es gibt Konstellationen, in denen Angehörige nicht mehr nur
+                  unterstützen, sondern vor allem schützen müssen: bei eigener
+                  Erschöpfung, bei Gewalt oder massiver Grenzverletzung, wenn
+                  Kinder mitbetroffen sind oder wenn sich das ganze Leben nur
                   noch um Krisen dreht.
                 </p>
                 <Card className="bg-sand-muted border-sand-mid">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Spätestens dann braucht es zusätzliche Hilfe, klarere Grenzen oder auch mehr
-                      Distanz. Das ist kein Versagen, sondern oft Ausdruck verantwortlichen Handelns.
+                      Spätestens dann braucht es zusätzliche Hilfe, klarere
+                      Grenzen oder auch mehr Distanz. Das ist kein Versagen,
+                      sondern oft Ausdruck verantwortlichen Handelns.
                     </p>
                   </CardContent>
                 </Card>
@@ -481,18 +441,21 @@ export default function UnterstuetzenUebersicht() {
               <p className="text-sm text-muted-foreground mb-4 flex items-center gap-2">
                 <Eye className="w-4 h-4 flex-shrink-0" />
                 <span>
-                  <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF öffnen»
-                  öffnet die A4-Druckversion im neuen Tab.
+                  <strong className="text-foreground">
+                    Vorschau = Web-Bild.
+                  </strong>{" "}
+                  «PDF öffnen» öffnet die A4-Druckversion im neuen Tab.
                 </span>
               </p>
 
               <div className="flex gap-2 overflow-x-auto pb-3 mb-6 scrollbar-none -mx-1 px-1">
-                {unterstuetzenSubcategories.map((cat) => {
+                {unterstuetzenSubcategories.map(cat => {
                   const Icon = cat.icon;
                   const count =
                     cat.id === "alle"
                       ? unterstuetzenItems.length
-                      : unterstuetzenItems.filter((i) => i.category === cat.id).length;
+                      : unterstuetzenItems.filter(i => i.category === cat.id)
+                          .length;
                   return (
                     <Button
                       key={cat.id}
@@ -501,7 +464,10 @@ export default function UnterstuetzenUebersicht() {
                       onClick={() => {
                         setActiveFilter(cat.id);
                         setTimeout(() => {
-                          gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                          gridRef.current?.scrollIntoView({
+                            behavior: "smooth",
+                            block: "start",
+                          });
                         }, 50);
                       }}
                       className={`whitespace-nowrap shrink-0 ${
@@ -512,18 +478,25 @@ export default function UnterstuetzenUebersicht() {
                     >
                       <Icon className="w-4 h-4 mr-1.5" />
                       {cat.label}
-                      <span className="ml-1.5 text-xs opacity-90">({count})</span>
+                      <span className="ml-1.5 text-xs opacity-90">
+                        ({count})
+                      </span>
                     </Button>
                   );
                 })}
               </div>
 
-              <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div
+                ref={gridRef}
+                className="grid grid-cols-1 sm:grid-cols-2 gap-4"
+              >
                 {filteredItems.map((item, index) => (
                   <Card
                     key={item.title}
                     className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
-                      filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""
+                      filteredItems.length > 1 && index === 0
+                        ? "sm:col-span-2"
+                        : ""
                     }`}
                   >
                     <div className="aspect-[4/3] bg-muted overflow-hidden">
@@ -538,7 +511,9 @@ export default function UnterstuetzenUebersicht() {
                       />
                     </div>
                     <CardContent className="p-4">
-                      <h3 className="font-medium text-sm text-foreground mb-2">{item.title}</h3>
+                      <h3 className="font-medium text-sm text-foreground mb-2">
+                        {item.title}
+                      </h3>
                       <a
                         href={item.pdfUrl}
                         target="_blank"
@@ -574,10 +549,13 @@ export default function UnterstuetzenUebersicht() {
                   <div className="flex items-start gap-4">
                     <Lightbulb className="w-6 h-6 text-sand-mid flex-shrink-0" />
                     <div>
-                      <h3 className="font-semibold text-foreground mb-2">Denken Sie daran</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Denken Sie daran
+                      </h3>
                       <p className="text-muted-foreground">
-                        Unterstützen heisst nicht, sich selbst aufzugeben. Sie können nur dann
-                        tragfähig unterstützen, wenn Ihr eigenes Fundament geschützt bleibt.
+                        Unterstützen heisst nicht, sich selbst aufzugeben. Sie
+                        können nur dann tragfähig unterstützen, wenn Ihr eigenes
+                        Fundament geschützt bleibt.
                       </p>
                     </div>
                   </div>

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -18,81 +18,32 @@ import {
   Users,
 } from "lucide-react";
 import { Link } from "wouter";
+import VerstehenHeroSection from "@/sections/verstehen/VerstehenHeroSection";
 import { Button } from "@/components/ui/button";
 import { TableOfContents } from "@/components/UXEnhancements";
 import ContentSection from "@/components/ContentSection";
-
-const verstehenInfografiken = [
-  {
-    id: "leuchtturm",
-    title: "Der Leuchtturm",
-    description: "Ihre Rolle als Angehörige/r: Stabil bleiben trotz Sturm.",
-    category: "grundlagen",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GbFCyQhEWIKomzXw.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DNGijMOYFghXAsLm.pdf",
-    alt: "Der Leuchtturm – Ihre Rolle als Angehörige/r",
-    featured: true,
-  },
-  {
-    id: "eisberg",
-    title: "Der Eisberg",
-    description: "Wut ist oft nur die Spitze – darunter liegen Schmerz und Angst.",
-    category: "grundlagen",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MLLwefeyaKvtThbK.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RNKtfQQMvhlSyiIp.pdf",
-    alt: "Der Eisberg – Wut ist oft die Spitze",
-  },
-  {
-    id: "spaltung",
-    title: "Spaltung",
-    description: "Das Pendel zwischen Extremen – die Grauzone stärken.",
-    category: "grundlagen",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WRORriPmZftmvKTL.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/RtdVgflJuCNAhEKk.pdf",
-    alt: "Spaltung – das Pendel zwischen Extremen",
-  },
-  {
-    id: "alarm-modus",
-    title: "Alarm-Modus vs. Denk-Modus",
-    description: "Erst beruhigen, dann klären – warum Logik manchmal nicht ankommt.",
-    category: "neurobiologie",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/sSUJoOUTiuWgrkiZ.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tlKAOpYHdCNAtovE.pdf",
-    alt: "Alarm-Modus vs. Denk-Modus",
-  },
-  {
-    id: "4-phasen",
-    title: "Der 4-Phasen-Zyklus",
-    description: "Ein häufiges Muster in belasteten Beziehungen, nicht ein fixes Schicksal.",
-    category: "neurobiologie",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/BYDbBJaIhetrjHRq.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/PBYpNxZamAxjOHYd.pdf",
-    alt: "Der 4-Phasen-Zyklus",
-  },
-  {
-    id: "gehirn",
-    title: "Das Gehirn verstehen",
-    description: "Neurobiologie einfach erklärt – warum Stress Denken blockiert.",
-    category: "neurobiologie",
-    webpUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/ImASzOTHYdFpxOUI.webp",
-    pdfUrl: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/NViSBQtRBvGWOHPE.pdf",
-    alt: "Das Gehirn verstehen",
-  },
-];
+import { verstehenInfografiken } from "@/content/verstehen";
 
 const verstehenCategories = [
-  { id: "alle", label: "Alle", icon: Filter, count: verstehenInfografiken.length },
+  {
+    id: "alle",
+    label: "Alle",
+    icon: Filter,
+    count: verstehenInfografiken.length,
+  },
   {
     id: "grundlagen",
     label: "Grundlagen",
     icon: BookOpen,
-    count: verstehenInfografiken.filter((i) => i.category === "grundlagen").length,
+    count: verstehenInfografiken.filter(i => i.category === "grundlagen")
+      .length,
   },
   {
     id: "neurobiologie",
     label: "Stress & Gehirn",
     icon: Brain,
-    count: verstehenInfografiken.filter((i) => i.category === "neurobiologie").length,
+    count: verstehenInfografiken.filter(i => i.category === "neurobiologie")
+      .length,
   },
 ];
 
@@ -117,7 +68,7 @@ export default function Verstehen() {
   const filteredItems =
     activeFilter === "alle"
       ? verstehenInfografiken
-      : verstehenInfografiken.filter((i) => i.category === activeFilter);
+      : verstehenInfografiken.filter(i => i.category === activeFilter);
 
   return (
     <Layout>
@@ -128,35 +79,7 @@ export default function Verstehen() {
       />
       <TableOfContents />
 
-      <section className="py-12 md:py-20 bg-gradient-to-b from-sage-light/30 to-background wave-divider">
-        <div className="container">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="max-w-3xl"
-          >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center">
-                <BookOpen className="w-6 h-6 text-sage-dark" />
-              </div>
-              <span className="text-sm font-medium text-sage-dark">Lesezeit: 15 Minuten</span>
-            </div>
-
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
-              Borderline verstehen
-            </h1>
-
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Für Angehörige ist Borderline oft nicht nur schwer zu begreifen, sondern schwer
-              auszuhalten. Situationen können rasch kippen, Reaktionen widersprüchlich wirken und
-              die eigene Rolle unklar werden. Diese Seite hilft Ihnen, typische innere und
-              zwischenmenschliche Dynamiken besser einzuordnen, ohne Verhalten zu beschönigen oder
-              zu verurteilen.
-            </p>
-          </motion.div>
-        </div>
-      </section>
+      <VerstehenHeroSection />
 
       <section className="py-12 md:py-16 wave-divider-top">
         <div className="container">
@@ -170,11 +93,14 @@ export default function Verstehen() {
               <Card className="border-l-4 border-l-sage bg-sage-light/20">
                 <CardContent className="p-6">
                   <p className="text-foreground leading-relaxed italic">
-                    "Verstehen hat mir nicht alles leichter gemacht. Aber ich habe aufgehört, jede
-                    Eskalation nur als Bosheit, jede Distanz nur als Ablehnung und jede Krise nur
-                    als mein persönliches Versagen zu lesen."
+                    "Verstehen hat mir nicht alles leichter gemacht. Aber ich
+                    habe aufgehört, jede Eskalation nur als Bosheit, jede
+                    Distanz nur als Ablehnung und jede Krise nur als mein
+                    persönliches Versagen zu lesen."
                   </p>
-                  <p className="text-muted-foreground text-sm mt-3">— Eine Angehörige</p>
+                  <p className="text-muted-foreground text-sm mt-3">
+                    — Eine Angehörige
+                  </p>
                 </CardContent>
               </Card>
             </motion.div>
@@ -188,22 +114,24 @@ export default function Verstehen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Für Angehörige wirkt Borderline oft widersprüchlich: Nähe kann sehr intensiv
-                  werden und kurz darauf in Angriff, Rückzug oder Funkstille kippen. Eine Beziehung
-                  kann sich gleichzeitig bedeutsam, erschöpfend, zart und bedrohlich anfühlen.
+                  Für Angehörige wirkt Borderline oft widersprüchlich: Nähe kann
+                  sehr intensiv werden und kurz darauf in Angriff, Rückzug oder
+                  Funkstille kippen. Eine Beziehung kann sich gleichzeitig
+                  bedeutsam, erschöpfend, zart und bedrohlich anfühlen.
                 </p>
                 <p className="text-muted-foreground leading-relaxed">
-                  Viele Angehörige schwanken deshalb nicht nur zwischen Mitgefühl und Hilfsbereitschaft,
-                  sondern auch zwischen Angst, Wut, Selbstzweifel, Loyalität und dem Wunsch nach
-                  Abstand. Diese Ambivalenz ist nicht Ausdruck mangelnder Liebe, sondern oft Teil der
-                  Belastungsrealität.
+                  Viele Angehörige schwanken deshalb nicht nur zwischen
+                  Mitgefühl und Hilfsbereitschaft, sondern auch zwischen Angst,
+                  Wut, Selbstzweifel, Loyalität und dem Wunsch nach Abstand.
+                  Diese Ambivalenz ist nicht Ausdruck mangelnder Liebe, sondern
+                  oft Teil der Belastungsrealität.
                 </p>
                 <Card className="bg-cream border-border/50">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      <strong>Wichtig:</strong> Verstehen kann entlasten, weil es Muster einordnen
-                      hilft. Es ersetzt aber weder Grenzsetzung noch Selbstschutz noch professionelle
-                      Hilfe.
+                      <strong>Wichtig:</strong> Verstehen kann entlasten, weil
+                      es Muster einordnen hilft. Es ersetzt aber weder
+                      Grenzsetzung noch Selbstschutz noch professionelle Hilfe.
                     </p>
                   </CardContent>
                 </Card>
@@ -218,21 +146,25 @@ export default function Verstehen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Die Borderline-Persönlichkeitsstörung ist ein komplexes Störungsbild. Typisch sind
-                  starke emotionale Reagibilität, Schwierigkeiten mit innerer Stabilität und ein
-                  Beziehungserleben, das unter Bindungsstress schnell ins Wanken geraten kann.
+                  Die Borderline-Persönlichkeitsstörung ist ein komplexes
+                  Störungsbild. Typisch sind starke emotionale Reagibilität,
+                  Schwierigkeiten mit innerer Stabilität und ein
+                  Beziehungserleben, das unter Bindungsstress schnell ins Wanken
+                  geraten kann.
                 </p>
                 <p className="text-muted-foreground leading-relaxed">
-                  Nicht alle Menschen mit Borderline zeigen dieselben Muster. Manche wirken vor allem
-                  impulsiv und explosiv, andere eher verzweifelt, zurückgezogen, leer oder
-                  selbstabwertend. Ausprägung, Verlauf und Belastung unterscheiden sich deutlich.
+                  Nicht alle Menschen mit Borderline zeigen dieselben Muster.
+                  Manche wirken vor allem impulsiv und explosiv, andere eher
+                  verzweifelt, zurückgezogen, leer oder selbstabwertend.
+                  Ausprägung, Verlauf und Belastung unterscheiden sich deutlich.
                 </p>
                 <Card className="bg-sage-wash/50 border-sage-mid/30">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Für Angehörige ist vor allem wichtig: Hinter heftigen Reaktionen liegen oft
-                      Überflutung, Angst, Scham oder Verlassenheitsstress. Das macht Verhalten nicht
-                      folgenlos, hilft aber, es genauer einzuordnen.
+                      Für Angehörige ist vor allem wichtig: Hinter heftigen
+                      Reaktionen liegen oft Überflutung, Angst, Scham oder
+                      Verlassenheitsstress. Das macht Verhalten nicht folgenlos,
+                      hilft aber, es genauer einzuordnen.
                     </p>
                   </CardContent>
                 </Card>
@@ -247,17 +179,22 @@ export default function Verstehen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Viele Menschen mit Borderline haben ihre grössten Schwierigkeiten nicht in
-                  oberflächlichen Kontakten, sondern in engen Beziehungen. Gerade dort, wo viel
-                  Bindung, Hoffnung und Verletzbarkeit im Spiel sind, werden Unsicherheit,
-                  Unklarheit oder Distanz besonders schmerzhaft erlebt.
+                  Viele Menschen mit Borderline haben ihre grössten
+                  Schwierigkeiten nicht in oberflächlichen Kontakten, sondern in
+                  engen Beziehungen. Gerade dort, wo viel Bindung, Hoffnung und
+                  Verletzbarkeit im Spiel sind, werden Unsicherheit, Unklarheit
+                  oder Distanz besonders schmerzhaft erlebt.
                 </p>
                 <div className="grid gap-4">
-                  {relationshipPatterns.map((item) => (
+                  {relationshipPatterns.map(item => (
                     <Card key={item.title} className="border-border/50">
                       <CardContent className="p-5">
-                        <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                        <p className="text-sm text-muted-foreground leading-relaxed">{item.text}</p>
+                        <h3 className="font-semibold text-foreground mb-2">
+                          {item.title}
+                        </h3>
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          {item.text}
+                        </p>
                       </CardContent>
                     </Card>
                   ))}
@@ -265,9 +202,9 @@ export default function Verstehen() {
                 <Card className="bg-terracotta-wash border-terracotta-mid/20">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Gerade deshalb erleben Angehörige oft etwas Paradoxes: Je wichtiger sie der
-                      betroffenen Person sind, desto stärker können Konflikte, Vorwürfe oder
-                      Grenztests ausfallen.
+                      Gerade deshalb erleben Angehörige oft etwas Paradoxes: Je
+                      wichtiger sie der betroffenen Person sind, desto stärker
+                      können Konflikte, Vorwürfe oder Grenztests ausfallen.
                     </p>
                   </CardContent>
                 </Card>
@@ -282,20 +219,24 @@ export default function Verstehen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Angehörige erleben Wut oft als das dominierende Thema. Sie ist laut, verletzend und
-                  schwer zu übersehen. Gleichzeitig ist Wut bei Borderline häufig nicht der ganze
-                  Kern, sondern eher eine Reaktion auf tiefer liegende Zustände wie Scham,
+                  Angehörige erleben Wut oft als das dominierende Thema. Sie ist
+                  laut, verletzend und schwer zu übersehen. Gleichzeitig ist Wut
+                  bei Borderline häufig nicht der ganze Kern, sondern eher eine
+                  Reaktion auf tiefer liegende Zustände wie Scham,
                   Verlassenheitsangst, Ohnmacht oder innere Leere.
                 </p>
                 <p className="text-muted-foreground leading-relaxed">
-                  Scham spielt dabei eine besonders grosse Rolle. Wer sich tief beschämt, blossgestellt
-                  oder innerlich wertlos fühlt, reagiert leichter mit Angriff, Rückzug,
-                  Selbstentwertung oder abruptem Kontaktabbruch. Für Angehörige wirkt das oft hart
-                  und kalt, innerlich ist es nicht selten hochverletzlich.
+                  Scham spielt dabei eine besonders grosse Rolle. Wer sich tief
+                  beschämt, blossgestellt oder innerlich wertlos fühlt, reagiert
+                  leichter mit Angriff, Rückzug, Selbstentwertung oder abruptem
+                  Kontaktabbruch. Für Angehörige wirkt das oft hart und kalt,
+                  innerlich ist es nicht selten hochverletzlich.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   <div className="p-4 rounded-xl bg-terracotta-wash border border-terracotta-mid/20">
-                    <h3 className="font-semibold text-foreground mb-2">Was sichtbar werden kann</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Was sichtbar werden kann
+                    </h3>
                     <ul className="text-sm text-muted-foreground space-y-1">
                       <li>Wutausbruch oder Vorwurf</li>
                       <li>Rückzug oder Schweigen</li>
@@ -304,7 +245,9 @@ export default function Verstehen() {
                     </ul>
                   </div>
                   <div className="p-4 rounded-xl bg-sage-wash border border-sage-mid/20">
-                    <h3 className="font-semibold text-foreground mb-2">Was darunter liegen kann</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Was darunter liegen kann
+                    </h3>
                     <ul className="text-sm text-muted-foreground space-y-1">
                       <li>Scham und Kränkung</li>
                       <li>Angst vor Verlust oder Abwertung</li>
@@ -324,38 +267,47 @@ export default function Verstehen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Unter hoher emotionaler Überflutung verengt sich das Erleben häufig stark auf den
-                  aktuellen Schmerz, die aktuelle Angst oder den aktuellen Konflikt. Dann verlieren
-                  Menschen leichter den Zugang zu Grautönen, Beziehungsgeschichte und nüchterner
+                  Unter hoher emotionaler Überflutung verengt sich das Erleben
+                  häufig stark auf den aktuellen Schmerz, die aktuelle Angst
+                  oder den aktuellen Konflikt. Dann verlieren Menschen leichter
+                  den Zugang zu Grautönen, Beziehungsgeschichte und nüchterner
                   Einordnung.
                 </p>
                 <div className="grid gap-4">
                   <Card className="border-l-4 border-l-alert">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Alarmmodus</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Alarmmodus
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Das innere Alarmsystem reagiert rasch und heftig. Neutrale Signale können
-                        leichter als Distanz, Kritik oder Bedrohung gelesen werden.
+                        Das innere Alarmsystem reagiert rasch und heftig.
+                        Neutrale Signale können leichter als Distanz, Kritik
+                        oder Bedrohung gelesen werden.
                       </p>
                     </CardContent>
                   </Card>
                   <Card className="border-l-4 border-l-slate-dark">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Tunnelblick</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Tunnelblick
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        In diesem Zustand kommen Argumente, Erklärungen und Korrekturen oft kaum an.
-                        Hilfreicher ist meist zuerst Beruhigung, Orientierung und emotionale
-                        Anerkennung.
+                        In diesem Zustand kommen Argumente, Erklärungen und
+                        Korrekturen oft kaum an. Hilfreicher ist meist zuerst
+                        Beruhigung, Orientierung und emotionale Anerkennung.
                       </p>
                     </CardContent>
                   </Card>
                   <Card className="border-l-4 border-l-sage-mid">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Dissoziation und Entfremdung</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Dissoziation und Entfremdung
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Unter starkem Stress können auch Unwirklichkeitsgefühle, innere Abspaltung
-                        oder das Gefühl auftreten, nicht mehr richtig präsent zu sein. Das ist für
-                        Betroffene wie Angehörige oft verstörend.
+                        Unter starkem Stress können auch Unwirklichkeitsgefühle,
+                        innere Abspaltung oder das Gefühl auftreten, nicht mehr
+                        richtig präsent zu sein. Das ist für Betroffene wie
+                        Angehörige oft verstörend.
                       </p>
                     </CardContent>
                   </Card>
@@ -363,9 +315,10 @@ export default function Verstehen() {
                 <Card className="bg-slate-wash border-slate-mid/20">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      <strong>Für Angehörige heisst das:</strong> Nicht zuerst überzeugen, sondern
-                      zuerst stabilisieren. Erst wenn die Anspannung sinkt, wird gemeinsames Denken
-                      eher wieder möglich.
+                      <strong>Für Angehörige heisst das:</strong> Nicht zuerst
+                      überzeugen, sondern zuerst stabilisieren. Erst wenn die
+                      Anspannung sinkt, wird gemeinsames Denken eher wieder
+                      möglich.
                     </p>
                   </CardContent>
                 </Card>
@@ -380,47 +333,61 @@ export default function Verstehen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Manche Beziehungen folgen über längere Zeit wiederkehrenden Schleifen: Eskalation,
-                  Rückzug, Wiederannäherung, Hoffnung, neue Spannung. Das ist kein starres Gesetz,
-                  aber ein Muster, das Angehörigen helfen kann, Entwicklungen nüchterner zu lesen.
+                  Manche Beziehungen folgen über längere Zeit wiederkehrenden
+                  Schleifen: Eskalation, Rückzug, Wiederannäherung, Hoffnung,
+                  neue Spannung. Das ist kein starres Gesetz, aber ein Muster,
+                  das Angehörigen helfen kann, Entwicklungen nüchterner zu
+                  lesen.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Idealisierung und Entwertung</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Idealisierung und Entwertung
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Eine Person kann zeitweise als einzig sicher und verstehend erlebt werden,
-                        kurz darauf aber als kalt, ungerecht oder gefährlich. Für Angehörige ist das
-                        oft tief verunsichernd.
+                        Eine Person kann zeitweise als einzig sicher und
+                        verstehend erlebt werden, kurz darauf aber als kalt,
+                        ungerecht oder gefährlich. Für Angehörige ist das oft
+                        tief verunsichernd.
                       </p>
                     </CardContent>
                   </Card>
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Rückzug und Funkstille</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Rückzug und Funkstille
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Nach Konflikten kann Schweigen, Abbruch oder Distanzierung folgen. Das ist
-                        nicht zwingend Gleichgültigkeit, für Angehörige aber oft besonders schwer
-                        auszuhalten.
+                        Nach Konflikten kann Schweigen, Abbruch oder
+                        Distanzierung folgen. Das ist nicht zwingend
+                        Gleichgültigkeit, für Angehörige aber oft besonders
+                        schwer auszuhalten.
                       </p>
                     </CardContent>
                   </Card>
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Schuldspiralen</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Schuldspiralen
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Angehörige geben aus Angst oder Schuld nach, fühlen sich danach ausgenutzt,
-                        reagieren irgendwann härter und empfinden dann erneut Schuld. So entsteht ein
-                        Kreislauf, der beide Seiten belastet.
+                        Angehörige geben aus Angst oder Schuld nach, fühlen sich
+                        danach ausgenutzt, reagieren irgendwann härter und
+                        empfinden dann erneut Schuld. So entsteht ein Kreislauf,
+                        der beide Seiten belastet.
                       </p>
                     </CardContent>
                   </Card>
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Nähe und Selbstschutz zugleich</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Nähe und Selbstschutz zugleich
+                      </h3>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Viele Angehörige möchten bleiben und gleichzeitig Abstand. Gerade diese
-                        Ambivalenz verdient Ernstnahme statt moralische Bewertung.
+                        Viele Angehörige möchten bleiben und gleichzeitig
+                        Abstand. Gerade diese Ambivalenz verdient Ernstnahme
+                        statt moralische Bewertung.
                       </p>
                     </CardContent>
                   </Card>
@@ -452,12 +419,19 @@ export default function Verstehen() {
                     text: "Sie müssen nicht alles allein tragen",
                     sub: "Verstehen ist wertvoll, ersetzt aber kein Hilfesystem",
                   },
-                ].map((item) => (
-                  <div key={item.text} className="flex items-start gap-3 p-4 rounded-xl bg-cream border border-border/30">
+                ].map(item => (
+                  <div
+                    key={item.text}
+                    className="flex items-start gap-3 p-4 rounded-xl bg-cream border border-border/30"
+                  >
                     <span className="text-2xl flex-shrink-0">•</span>
                     <div>
-                      <span className="font-medium text-foreground block">{item.text}</span>
-                      <span className="text-sm text-muted-foreground">{item.sub}</span>
+                      <span className="font-medium text-foreground block">
+                        {item.text}
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {item.sub}
+                      </span>
                     </div>
                   </div>
                 ))}
@@ -472,20 +446,23 @@ export default function Verstehen() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Verstehen bedeutet nicht, alles auszuhalten. Es bedeutet auch nicht, dass Sie jede
-                  Eskalation auffangen, jedes Verhalten korrekt einordnen oder jede Krise mit der
-                  richtigen Reaktion entschärfen könnten.
+                  Verstehen bedeutet nicht, alles auszuhalten. Es bedeutet auch
+                  nicht, dass Sie jede Eskalation auffangen, jedes Verhalten
+                  korrekt einordnen oder jede Krise mit der richtigen Reaktion
+                  entschärfen könnten.
                 </p>
                 <p className="text-muted-foreground leading-relaxed">
-                  Mitgefühl und Selbstschutz widersprechen sich nicht. Gerade in belasteten
-                  Beziehungen kann es verantwortungsvoll sein, Grenzen zu setzen, Distanz zu schaffen
-                  oder Hilfe von aussen einzubeziehen.
+                  Mitgefühl und Selbstschutz widersprechen sich nicht. Gerade in
+                  belasteten Beziehungen kann es verantwortungsvoll sein,
+                  Grenzen zu setzen, Distanz zu schaffen oder Hilfe von aussen
+                  einzubeziehen.
                 </p>
                 <Card className="bg-terracotta-lighter/30 border-terracotta/50">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      <strong>Merksatz für Angehörige:</strong> Verstehen hilft, ruhiger und klarer
-                      zu handeln. Es verpflichtet Sie nicht dazu, sich selbst zu verlieren.
+                      <strong>Merksatz für Angehörige:</strong> Verstehen hilft,
+                      ruhiger und klarer zu handeln. Es verpflichtet Sie nicht
+                      dazu, sich selbst zu verlieren.
                     </p>
                   </CardContent>
                 </Card>
@@ -500,9 +477,10 @@ export default function Verstehen() {
             >
               <div className="space-y-5">
                 <p className="text-muted-foreground leading-relaxed">
-                  Für eine Diagnose müssen Fachpersonen mehrere Merkmale über längere Zeit und in
-                  verschiedenen Lebensbereichen beurteilen. Entscheidend ist nicht ein einzelnes
-                  Verhalten, sondern das Gesamtbild.
+                  Für eine Diagnose müssen Fachpersonen mehrere Merkmale über
+                  längere Zeit und in verschiedenen Lebensbereichen beurteilen.
+                  Entscheidend ist nicht ein einzelnes Verhalten, sondern das
+                  Gesamtbild.
                 </p>
 
                 <div className="grid gap-3">
@@ -512,7 +490,7 @@ export default function Verstehen() {
                     "ein schwankendes oder unsicheres Selbstbild",
                     "Impulsivität oder selbstschädigendes Verhalten",
                     "affektive Instabilität, Leere, Wut oder dissoziative Symptome",
-                  ].map((item) => (
+                  ].map(item => (
                     <Card key={item} className="border-border/50">
                       <CardContent className="p-4">
                         <p className="text-sm text-muted-foreground">{item}</p>
@@ -523,12 +501,15 @@ export default function Verstehen() {
 
                 <Card className="border-t-4 border-t-sage-mid">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-2">Ursachen sind nie monokausal</h3>
+                    <h3 className="font-semibold text-foreground mb-2">
+                      Ursachen sind nie monokausal
+                    </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
-                      Borderline entsteht nicht durch eine einzige Ursache, sondern im Zusammenspiel
-                      biologischer Empfindlichkeit, Bindungs- und Entwicklungserfahrungen sowie
-                      Belastungsfaktoren. Schuldzuweisungen an Betroffene oder Angehörige greifen zu
-                      kurz und helfen niemandem.
+                      Borderline entsteht nicht durch eine einzige Ursache,
+                      sondern im Zusammenspiel biologischer Empfindlichkeit,
+                      Bindungs- und Entwicklungserfahrungen sowie
+                      Belastungsfaktoren. Schuldzuweisungen an Betroffene oder
+                      Angehörige greifen zu kurz und helfen niemandem.
                     </p>
                   </CardContent>
                 </Card>
@@ -541,7 +522,9 @@ export default function Verstehen() {
               viewport={{ once: true }}
               className="mb-12 wave-divider-top"
               id="materialien"
-              style={{ "--wave-color": "var(--background)" } as React.CSSProperties}
+              style={
+                { "--wave-color": "var(--background)" } as React.CSSProperties
+              }
             >
               <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
                 <Download className="w-8 h-8 text-sage-dark" />
@@ -549,12 +532,13 @@ export default function Verstehen() {
               </h2>
 
               <p className="text-muted-foreground mb-6">
-                Diese Materialien ergänzen die Seite, ersetzen sie aber nicht. Beginnen Sie mit den
-                Grundlagen, wenn Sie gerade Orientierung brauchen.
+                Diese Materialien ergänzen die Seite, ersetzen sie aber nicht.
+                Beginnen Sie mit den Grundlagen, wenn Sie gerade Orientierung
+                brauchen.
               </p>
 
               <div className="flex flex-wrap gap-2 mb-6">
-                {verstehenCategories.map((cat) => (
+                {verstehenCategories.map(cat => (
                   <Button
                     key={cat.id}
                     variant={activeFilter === cat.id ? "default" : "outline"}
@@ -562,11 +546,16 @@ export default function Verstehen() {
                     onClick={() => {
                       setActiveFilter(cat.id);
                       setTimeout(() => {
-                        gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+                        gridRef.current?.scrollIntoView({
+                          behavior: "smooth",
+                          block: "start",
+                        });
                       }, 50);
                     }}
                     className={`whitespace-nowrap shrink-0 ${
-                      activeFilter === cat.id ? "bg-sage-dark hover:bg-sage-mid text-white" : ""
+                      activeFilter === cat.id
+                        ? "bg-sage-dark hover:bg-sage-mid text-white"
+                        : ""
                     }`}
                   >
                     <cat.icon className="w-4 h-4 mr-1.5" />
@@ -575,8 +564,11 @@ export default function Verstehen() {
                 ))}
               </div>
 
-              <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                {filteredItems.map((item) => (
+              <div
+                ref={gridRef}
+                className="grid grid-cols-1 md:grid-cols-2 gap-6"
+              >
+                {filteredItems.map(item => (
                   <Card
                     key={item.id}
                     className={`${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""} overflow-hidden hover:shadow-lg transition-shadow`}
@@ -598,8 +590,12 @@ export default function Verstehen() {
                       />
                     </button>
                     <CardContent className="p-4">
-                      <h3 className="font-medium text-foreground mb-1">{item.title}</h3>
-                      <p className="text-sm text-muted-foreground mb-3">{item.description}</p>
+                      <h3 className="font-medium text-foreground mb-1">
+                        {item.title}
+                      </h3>
+                      <p className="text-sm text-muted-foreground mb-3">
+                        {item.description}
+                      </p>
                       <a
                         href={item.pdfUrl}
                         target="_blank"
@@ -627,7 +623,9 @@ export default function Verstehen() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               className="mb-12 wave-divider-top"
-              style={{ "--wave-color": "var(--background)" } as React.CSSProperties}
+              style={
+                { "--wave-color": "var(--background)" } as React.CSSProperties
+              }
             >
               <Card className="bg-sage-light/30 border-sage">
                 <CardContent className="p-6 md:p-8">
@@ -638,9 +636,9 @@ export default function Verstehen() {
                         Verstehen ist nur der erste Schritt
                       </h3>
                       <p className="text-muted-foreground leading-relaxed mb-4">
-                        Wenn Sie Dynamiken besser einordnen können, wird oft klarer, wie Sie
-                        hilfreicher reagieren, Grenzen besser halten und die eigene Belastung ernster
-                        nehmen können.
+                        Wenn Sie Dynamiken besser einordnen können, wird oft
+                        klarer, wie Sie hilfreicher reagieren, Grenzen besser
+                        halten und die eigene Belastung ernster nehmen können.
                       </p>
                       <Link href="/unterstuetzen/uebersicht">
                         <Button variant="outline" size="sm" className="gap-2">
@@ -661,11 +659,14 @@ export default function Verstehen() {
               className="text-center"
             >
               <p className="text-muted-foreground mb-6">
-                Als Nächstes geht es darum, wie Unterstützung tragfähig bleiben kann, ohne dass Sie
-                sich selbst verlieren.
+                Als Nächstes geht es darum, wie Unterstützung tragfähig bleiben
+                kann, ohne dass Sie sich selbst verlieren.
               </p>
               <Link href="/unterstuetzen/uebersicht">
-                <Button size="lg" className="bg-terracotta hover:bg-terracotta-mid text-white">
+                <Button
+                  size="lg"
+                  className="bg-terracotta hover:bg-terracotta-mid text-white"
+                >
                   Weiter zu: Unterstützen
                   <ArrowRight className="w-5 h-5 ml-2" />
                 </Button>

--- a/client/src/sections/materialien/MaterialCard.tsx
+++ b/client/src/sections/materialien/MaterialCard.tsx
@@ -1,0 +1,75 @@
+import { Card, CardContent } from "@/components/ui/card";
+import { Download, ExternalLink } from "lucide-react";
+import type { Material } from "@/content/materials";
+
+interface MaterialCardProps {
+  item: Material;
+  onPreview: (image: string, title: string) => void;
+}
+
+export default function MaterialCard({ item, onPreview }: MaterialCardProps) {
+  const previewSrc = item.isHtml ? (item.previewUrl ?? item.url) : item.url;
+  const openHref = item.downloadUrl ?? item.url;
+  const downloadHref = item.pdfUrl ?? item.downloadUrl;
+  const isCrossOriginDownload =
+    !!downloadHref &&
+    /^https?:\/\//i.test(downloadHref) &&
+    !downloadHref.startsWith(window.location.origin);
+
+  return (
+    <Card className="h-full hover:shadow-lg transition-all hover:border-sage-mid/30 overflow-hidden">
+      <button
+        type="button"
+        className="relative aspect-[4/3] bg-muted overflow-hidden group w-full"
+        onClick={() => {
+          if (item.isHtml) {
+            window.open(openHref, "_blank");
+          } else {
+            onPreview(item.url, item.title);
+          }
+        }}
+        aria-label={`${item.title} öffnen`}
+      >
+        <img
+          src={previewSrc}
+          alt={item.title}
+          className="w-full h-full object-cover object-top transition-transform duration-500 group-hover:scale-105"
+          loading="lazy"
+          width={400}
+          height={300}
+          decoding="async"
+        />
+        <div className="absolute top-2 left-2 bg-background/85 backdrop-blur-sm px-2 py-0.5 rounded text-xs font-medium text-muted-foreground">
+          {item.kind}
+        </div>
+      </button>
+      <CardContent className="p-5">
+        <h3 className="font-semibold text-foreground mb-2 text-lg">
+          {item.title}
+        </h3>
+        <p className="text-sm text-muted-foreground mb-4">{item.description}</p>
+        <div className="flex gap-2 flex-wrap">
+          <a
+            href={openHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 bg-sage-dark hover:bg-sage-dark/90 text-white transition-colors"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Öffnen
+          </a>
+          {downloadHref ? (
+            <a
+              href={downloadHref}
+              download={isCrossOriginDownload ? undefined : ""}
+              className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 border border-sage-dark text-sage-dark hover:bg-sage-light/40 transition-colors"
+            >
+              <Download className="w-4 h-4" />
+              Herunterladen
+            </a>
+          ) : null}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/client/src/sections/materialien/MaterialienHeroSection.tsx
+++ b/client/src/sections/materialien/MaterialienHeroSection.tsx
@@ -1,0 +1,35 @@
+import { motion } from "framer-motion";
+import { Download } from "lucide-react";
+
+export default function MaterialienHeroSection() {
+  return (
+    <section className="py-12 md:py-20 bg-gradient-to-b from-sage-light/30 to-background wave-divider">
+      <div className="container">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          className="max-w-3xl"
+        >
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center">
+              <Download className="w-6 h-6 text-sage-dark" />
+            </div>
+            <span className="text-sm font-medium text-sage-dark">
+              Materialsammlung
+            </span>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
+            Materialien für Angehörige
+          </h1>
+
+          <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
+            Kuratierte Infografiken, Spickzettel und Notfallhilfen für
+            Orientierung, Gespräche, Grenzen und Selbstfürsorge.
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/sections/unterstuetzen/UnterstuetzenHeroSection.tsx
+++ b/client/src/sections/unterstuetzen/UnterstuetzenHeroSection.tsx
@@ -1,0 +1,45 @@
+import { motion } from "framer-motion";
+import { Compass } from "lucide-react";
+import { Link } from "wouter";
+
+export default function UnterstuetzenHeroSection() {
+  return (
+    <section className="py-12 md:py-20 bg-gradient-to-b from-terracotta-light/30 to-background wave-divider">
+      <div className="container">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          className="max-w-3xl"
+        >
+          <Link
+            href="/verstehen"
+            className="text-sm text-muted-foreground hover:text-foreground mb-4 inline-flex items-center gap-1"
+          >
+            ← Zurück zu Verstehen
+          </Link>
+
+          <div className="flex items-center gap-3 mb-6 mt-4">
+            <div className="w-12 h-12 rounded-xl bg-terracotta-light flex items-center justify-center">
+              <Compass className="w-6 h-6 text-terracotta-dark" />
+            </div>
+            <span className="text-sm font-medium text-terracotta-dark">
+              Lesezeit: 8 Minuten
+            </span>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
+            Wie Angehörige hilfreich bleiben können
+          </h1>
+
+          <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
+            Angehörige möchten oft gleichzeitig beruhigen, schützen, verstehen,
+            Grenzen wahren und die Beziehung nicht verlieren. Genau diese
+            Gleichzeitigkeit macht die Rolle so anspruchsvoll. Diese Seite hilft
+            Ihnen, Unterstützung realistischer und tragfähiger zu denken.
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/sections/verstehen/VerstehenHeroSection.tsx
+++ b/client/src/sections/verstehen/VerstehenHeroSection.tsx
@@ -1,0 +1,39 @@
+import { motion } from "framer-motion";
+import { BookOpen } from "lucide-react";
+
+export default function VerstehenHeroSection() {
+  return (
+    <section className="py-12 md:py-20 bg-gradient-to-b from-sage-light/30 to-background wave-divider">
+      <div className="container">
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ duration: 0.6, ease: "easeOut" }}
+          className="max-w-3xl"
+        >
+          <div className="flex items-center gap-3 mb-6">
+            <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center">
+              <BookOpen className="w-6 h-6 text-sage-dark" />
+            </div>
+            <span className="text-sm font-medium text-sage-dark">
+              Lesezeit: 15 Minuten
+            </span>
+          </div>
+
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
+            Borderline verstehen
+          </h1>
+
+          <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
+            Für Angehörige ist Borderline oft nicht nur schwer zu begreifen,
+            sondern schwer auszuhalten. Situationen können rasch kippen,
+            Reaktionen widersprüchlich wirken und die eigene Rolle unklar
+            werden. Diese Seite hilft Ihnen, typische innere und
+            zwischenmenschliche Dynamiken besser einzuordnen, ohne Verhalten zu
+            beschönigen oder zu verurteilen.
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  );
+}

--- a/docs/conflict-resolution-log-2026-03-26.md
+++ b/docs/conflict-resolution-log-2026-03-26.md
@@ -1,0 +1,13 @@
+# Conflict Resolution Log – 2026-03-26
+
+## Reported conflict
+- `codex/cleanup-and-optimize-website-functionality`
+
+## Repository check
+- Searched for unresolved Git conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) with an anchored pattern (`^(<<<<<<<|=======|>>>>>>>)`) across the repository.
+- Checked local branch and commit history for the reported branch/merge reference.
+
+## Result
+- No unresolved merge conflicts are currently present.
+- No local evidence for commit `fcca0c9` or branch `codex/cleanup-and-optimize-website-functionality` in this checkout.
+- Working tree is conflict-free with respect to merge markers.

--- a/docs/manus-cdn-audit.md
+++ b/docs/manus-cdn-audit.md
@@ -1,0 +1,15 @@
+# Manus CDN Audit (Follow-up)
+
+Stand: 2026-03-26
+
+## Ergebnis
+- Verbleibende produktive Referenzen in priorisierten Dateien: **62**.
+- Diese Referenzen liegen jetzt zentraler in Content-Dateien (`content/*.ts`) statt verteilt in Seitenkomponenten.
+
+## Warum nicht lokalisiert?
+In dieser Ausführungsumgebung sind direkte Downloads von `files.manuscdn.com` technisch blockiert (Verbindungsfehler über Proxy und ohne Proxy). Daher war eine echte Dateiübernahme nach `public/assets/...` nicht automatisierbar möglich.
+
+## Bereits umgesetzt
+- Logo/Hero der Startseite wurden auf lokale Assets umgestellt.
+- Doppelte Referenzen in Seiten reduziert (z. B. Verstehen, Unterstützen, Genesung jetzt über zentrale Content-Dateien).
+- CSP `connect-src` wurde bereits bereinigt; `img-src/media-src` bleiben wegen verbleibender produktiver Referenzen auf Manus offen.

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(self)"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://files.manuscdn.com https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
 
 [[redirects]]
   from = "/notfallkarte.html"


### PR DESCRIPTION
### Motivation
- Consolidate duplicated inline content into centralized content modules (`content/*`) to make materials, infographics and searchable entries easier to maintain and audit.
- Improve mobile UX by introducing contextual floating controls (Soforthilfe and Inhaltsverzeichnis) that appear only on relevant routes.
- Replace several remote asset references with local assets and reduce reliance on Manus CDN where possible to simplify CSP and deployment.
- Harden SEO/structured-data handling and canonical/meta tag updates for better runtime behavior.

### Description
- Introduced content modules and search index: added `client/src/content/*` (`materials`, `kommunizieren`, `grenzen`, `unterstuetzen`, `searchIndex`) and switched pages/components to consume these centralized arrays instead of in-file literals. 
- Refactored materials and UI sections: added `MaterialCard`, `MaterialienHeroSection`, `UnterstuetzenHeroSection`, `VerstehenHeroSection` and updated `Materialien`, `Grenzen`, `Kommunizieren`, `UnterstuetzenUebersicht`, `Genesung`, `Verstehen`, `Home` pages to use the new components and content imports.
- Search & floating UI: extracted `searchableContent` to `searchIndex.ts` and updated `Search.tsx` to use typed `SearchEntry`; added `domain/floating-ui.ts` and wired `getMobileFloatingMode` into `Layout` and `UXEnhancements` to control mobile floating buttons (emergency + TOC) and ScrollToTop visibility.
- SEO and structured data: improved `SEO.tsx` meta/canonical handling, schema JSON-LD objects and env var handling for `MEDICAL_LAST_REVIEWED` and `SITE_URL`.
- Miscellaneous UI and asset changes: swapped several remote images for local assets (`/favicon-192.png`, `/og-image.jpg`), small markup cleanups, accessibility/ARIA tweaks and many formatting/whitespace fixes.
- Deployment/CSP and docs: updated `netlify.toml` to tighten `connect-src` and added `docs/manus-cdn-audit.md` documenting remaining Manus CDN references.

### Testing
- Type-check: ran `tsc --noEmit` to validate TypeScript types and imports, which completed successfully.
- Production build: executed the site build via `npx vite build` to ensure the app bundles correctly, and the build finished without errors.
- No new automated unit tests were added in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5062e87008332ba90d8f446f13bc1)