### PR TITLE
feat: Genesung und Notfallkarte in Ressourcen-Navigation

### DIFF
--- a/client/src/domain/navigation.ts
+++ b/client/src/domain/navigation.ts
@@ -3,6 +3,7 @@ import {
   BookOpen,
   Building2,
   Download,
+  FileText,
   Heart,
   HelpCircle,
   MessageCircle,
@@ -10,6 +11,7 @@ import {
   Shield,
   Sparkles,
   Stethoscope,
+  TrendingUp,
 } from "lucide-react";
 import type { NavigationItem } from "@/domain/content-types";
 
@@ -23,6 +25,8 @@ export const primaryNavigationItems: NavigationItem[] = [
 
 export const resourceNavigationItems: NavigationItem[] = [
   { href: "/materialien", label: "Materialien & Handouts", icon: Download },
+  { href: "/genesung", label: "Genesung & Hoffnung", icon: TrendingUp },
+  { href: "/notfallkarte", label: "Notfallkarte", icon: FileText },
   { href: "/beratung", label: "Beratung & Netzwerke", icon: Heart },
   { href: "/fachstelle", label: "Fachstelle & Kontakt", icon: Building2 },
   { href: "/faq", label: "Häufige Fragen (FAQ)", icon: HelpCircle },


### PR DESCRIPTION
## Was

/genesung und /notfallkarte in `resourceNavigationItems` aufgenommen → erscheinen jetzt im Ressourcen-Dropdown (Header) und im Footer.

## Warum

Beide Seiten waren Navigation-Waisen:
- `/genesung` (482 Zeilen) war nur via einem FAQ-Link und der internen Suche erreichbar
- `/notfallkarte` (476 Zeilen) war nur von der Soforthilfe-Seite aus verlinkt

## Änderung

`client/src/domain/navigation.ts` — 2 neue Einträge nach Materialien:
- **Genesung & Hoffnung** (`/genesung`) mit `TrendingUp`-Icon
- **Notfallkarte** (`/notfallkarte`) mit `FileText`-Icon

## Verifikation

- ✅ TypeScript: 0 Fehler
- ✅ ESLint: 0 Warnings