### PR TITLE
feat: EvidenceNote auf Kernseiten (Genesung, Verstehen, Selbstfürsorge)

### DIFF
--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import EvidenceNote from "@/components/EvidenceNote";
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
@@ -235,13 +236,27 @@ export default function Genesung() {
                   </div>
                 </div>
 
-                <div className="mt-6 pt-6 border-t border-border/30">
-                  <p className="text-xs text-muted-foreground">
-                    Quellen: McLean Study of Adult Development (Zanarini et
-                    al.); Collaborative Longitudinal Personality Disorders Study
-                    (Gunderson et al.)
-                  </p>
-                </div>
+                <EvidenceNote
+                  className="mt-6"
+                  title="Quellen zu Prognose- und Remissionsaussagen"
+                  sources={[
+                    {
+                      label:
+                        "Zanarini et al. (2010) – McLean Study of Adult Development",
+                      href: "https://pubmed.ncbi.nlm.nih.gov/20395399/",
+                    },
+                    {
+                      label:
+                        "Zanarini et al. (2012) – Sustained remission and recovery in BPD",
+                      href: "https://pubmed.ncbi.nlm.nih.gov/22737693/",
+                    },
+                    {
+                      label:
+                        "Gunderson et al. (2011) – Ten-year course of BPD (CLPS)",
+                      href: "https://pubmed.ncbi.nlm.nih.gov/21464343/",
+                    },
+                  ]}
+                />
               </CardContent>
             </Card>
           </motion.div>

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -1,4 +1,5 @@
 import SEO from "@/components/SEO";
+import EvidenceNote from "@/components/EvidenceNote";
 import { useState, useEffect, useRef, useCallback } from "react";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
@@ -15,7 +16,6 @@ import {
   Brain,
   Wind,
   Shield,
-  BookOpen,
   ChevronDown,
   ChevronUp,
   UserCircle,
@@ -878,28 +878,24 @@ export default function Selbstfuersorge() {
               viewport={{ once: true }}
               className="mb-12"
             >
-              <Card className="bg-muted/30 border-border/50">
-                <CardContent className="p-5">
-                  <h3 className="font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <BookOpen className="w-5 h-5 text-muted-foreground" />
-                    Worauf stützt sich das?
-                  </h3>
-                  <ul className="space-y-2 text-sm text-muted-foreground">
-                    <li>
-                      • Studien zeigen erhöhte Belastung bei Angehörigen von
-                      Menschen mit BPS (Hoffman et al., 2005)
-                    </li>
-                    <li>
-                      • Atemübungen aktivieren den Parasympathikus und
-                      reduzieren Cortisol (Zaccaro et al., 2018)
-                    </li>
-                    <li>
-                      • Soziale Unterstützung ist ein wichtiger Schutzfaktor
-                      gegen Burnout (Maslach & Leiter, 2016)
-                    </li>
-                  </ul>
-                </CardContent>
-              </Card>
+              <EvidenceNote
+                title="Worauf stützt sich das?"
+                sources={[
+                  {
+                    label: "Hoffman et al. (2005) – Caregiver burden in BPD",
+                    href: "https://pubmed.ncbi.nlm.nih.gov/16138007/",
+                  },
+                  {
+                    label:
+                      "Zaccaro et al. (2018) – Slow breathing techniques, autonomic activity and psychophysiology",
+                    href: "https://pubmed.ncbi.nlm.nih.gov/30275827/",
+                  },
+                  {
+                    label:
+                      "Maslach & Leiter (2016) – Burnout, soziale Unterstützung als Schutzfaktor",
+                  },
+                ]}
+              />
             </motion.div>
 
             {/* Abschluss */}

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState } from "react";
+import EvidenceNote from "@/components/EvidenceNote";
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
@@ -643,6 +644,34 @@ export default function Verstehen() {
                 </CardContent>
               </Card>
             </motion.div>
+
+            <EvidenceNote
+              className="mb-8"
+              title="Quellen zu Entstehung und Verlauf von Borderline"
+              definition="Die Inhalte dieser Seite stützen sich auf empirisch gut belegte Modelle und klinische Übersichtsarbeiten."
+              sources={[
+                {
+                  label:
+                    "Lieb et al. (2004) – Borderline personality disorder (Lancet)",
+                  href: "https://pubmed.ncbi.nlm.nih.gov/15488216/",
+                },
+                {
+                  label:
+                    "Leichsenring et al. (2011) – Borderline personality disorder (Lancet)",
+                  href: "https://pubmed.ncbi.nlm.nih.gov/21232218/",
+                },
+                {
+                  label:
+                    "Linehan (1993) – Kognitive Verhaltenstherapie der Borderline-Persönlichkeitsstörung (Biosoziales Modell)",
+                },
+                {
+                  label:
+                    "Storebø et al. (2020) – Psychological therapies for BPD (Cochrane)",
+                  href: "https://pubmed.ncbi.nlm.nih.gov/32368793/",
+                },
+              ]}
+            />
+
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}


### PR DESCRIPTION
## Was

Drei Kernseiten erhalten jetzt das konsistente `EvidenceNote`-Format für Quellenangaben.

### Genesung
- Inline-Text `Quellen: McLean Study...` durch `<EvidenceNote>` ersetzt
- Quellen: Zanarini 2010/2012 (McLean Study), Gunderson 2011 (CLPS)

### Verstehen
- Neue `<EvidenceNote>` vor dem finalen CTA eingefügt
- Quellen: Lieb 2004, Leichsenring 2011, Linehan 1993, Storebø 2020
- Deckt die biopsychosoziale Modell-Aussagen ab

### Selbstfürsorge
- `Worauf stützt sich das?`-Card durch `<EvidenceNote>` ersetzt (gleiche Quellen)
- Nicht mehr verwendeter `BookOpen`-Import entfernt

## Warum

UeberUns verspricht `Wir nennen unsere Quellen`. Bisher war `EvidenceNote` nur auf der FAQ-Seite vorhanden. Diese Änderung löst das Versprechen auf den inhaltlich schwergewichtigsten Seiten ein.