### PR TITLE
feat: UnterstuetzenSubNav – Tab-Navigation auf allen Unterstützen-Seiten

### DIFF
--- a/client/src/components/UnterstuetzenSubNav.tsx
+++ b/client/src/components/UnterstuetzenSubNav.tsx
@@ -1,0 +1,44 @@
+import { Link, useLocation } from "wouter";
+import { LayoutGrid, Calendar, AlertTriangle, Brain } from "lucide-react";
+
+const tabs = [
+  { href: "/unterstuetzen/uebersicht", label: "Übersicht", icon: LayoutGrid },
+  { href: "/unterstuetzen/alltag", label: "Im Alltag", icon: Calendar },
+  { href: "/unterstuetzen/krise", label: "In der Krise", icon: AlertTriangle },
+  { href: "/unterstuetzen/therapie", label: "Therapie", icon: Brain },
+];
+
+export default function UnterstuetzenSubNav() {
+  const [location] = useLocation();
+
+  return (
+    <nav
+      aria-label="Unterstützen – Unterseiten"
+      className="border-b border-border/50 bg-background"
+    >
+      <div className="container">
+        <div className="flex overflow-x-auto -mb-px">
+          {tabs.map(({ href, label, icon: Icon }) => {
+            const isActive = location === href;
+            return (
+              <Link
+                key={href}
+                href={href}
+                className={[
+                  "flex items-center gap-2 px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors",
+                  isActive
+                    ? "border-sage-dark text-sage-dark"
+                    : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+                ].join(" ")}
+                aria-current={isActive ? "page" : undefined}
+              >
+                <Icon className="w-4 h-4 shrink-0" />
+                {label}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -1,4 +1,5 @@
 import SEO from "@/components/SEO";
+import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import Layout from "@/components/Layout";
 import ContentSection from "@/components/ContentSection";
 import { Card, CardContent } from "@/components/ui/card";
@@ -44,7 +45,9 @@ export default function UnterstuetzenAlltag() {
               <div className="w-12 h-12 rounded-xl bg-sage-wash flex items-center justify-center">
                 <Calendar className="w-6 h-6 text-sage-dark" />
               </div>
-              <span className="text-sm font-medium text-sage-dark">Lesezeit: 8 Minuten</span>
+              <span className="text-sm font-medium text-sage-dark">
+                Lesezeit: 8 Minuten
+              </span>
             </div>
 
             <h1 className="text-2xl md:text-3xl lg:text-4xl font-normal text-foreground mb-6">
@@ -52,14 +55,17 @@ export default function UnterstuetzenAlltag() {
             </h1>
 
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Belastete Beziehungen bestehen nicht nur aus Krisen. Meist prägen sie den Alltag:
-              Anspannung in der Luft, vorsichtiges Abtasten, Rückzug nach Konflikten, Schuldgefühle,
-              Erreichbarkeitsdruck und die Frage, wie viel Nähe gerade hilfreich ist. Diese Seite
-              geht darum, was im Alltag trägt und was eher erschöpft.
+              Belastete Beziehungen bestehen nicht nur aus Krisen. Meist prägen
+              sie den Alltag: Anspannung in der Luft, vorsichtiges Abtasten,
+              Rückzug nach Konflikten, Schuldgefühle, Erreichbarkeitsdruck und
+              die Frage, wie viel Nähe gerade hilfreich ist. Diese Seite geht
+              darum, was im Alltag trägt und was eher erschöpft.
             </p>
           </motion.div>
         </div>
       </section>
+
+      <UnterstuetzenSubNav />
 
       <section className="py-8 md:py-12">
         <div className="container">
@@ -73,22 +79,25 @@ export default function UnterstuetzenAlltag() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Viele Angehörige kennen weniger den permanenten Ausnahmezustand als einen Alltag,
-                  der unterschwellig unter Spannung steht: Man beobachtet Stimmungen, wägt Worte ab,
-                  rechnet mit plötzlichem Rückzug oder Ärger und versucht gleichzeitig, Normalität
-                  aufrechtzuerhalten.
+                  Viele Angehörige kennen weniger den permanenten
+                  Ausnahmezustand als einen Alltag, der unterschwellig unter
+                  Spannung steht: Man beobachtet Stimmungen, wägt Worte ab,
+                  rechnet mit plötzlichem Rückzug oder Ärger und versucht
+                  gleichzeitig, Normalität aufrechtzuerhalten.
                 </p>
                 <p className="text-muted-foreground leading-relaxed">
-                  Diese dauernde innere Wachsamkeit ist anstrengend. Sie kostet Energie, auch wenn
-                  äusserlich gerade "nichts passiert". Hilfreiche Alltagsunterstützung beginnt oft
-                  damit, diese Belastung ernst zu nehmen und nicht nur auf sichtbare Eskalationen zu
-                  reagieren.
+                  Diese dauernde innere Wachsamkeit ist anstrengend. Sie kostet
+                  Energie, auch wenn äusserlich gerade "nichts passiert".
+                  Hilfreiche Alltagsunterstützung beginnt oft damit, diese
+                  Belastung ernst zu nehmen und nicht nur auf sichtbare
+                  Eskalationen zu reagieren.
                 </p>
                 <Card className="bg-sage-wash/50 border-sage-mid/30">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Alltagshilfe bedeutet deshalb nicht, immer mehr zu tun. Oft bedeutet sie,
-                      Beziehungen etwas vorhersehbarer, klarer und weniger reaktiv zu machen.
+                      Alltagshilfe bedeutet deshalb nicht, immer mehr zu tun.
+                      Oft bedeutet sie, Beziehungen etwas vorhersehbarer, klarer
+                      und weniger reaktiv zu machen.
                     </p>
                   </CardContent>
                 </Card>
@@ -108,36 +117,42 @@ export default function UnterstuetzenAlltag() {
                     description:
                       "Regelmässigkeit und angekündigte Änderungen entlasten oft stärker als spontane intensive Zuwendung.",
                     example:
-                      "\"Ich rufe dich heute Abend nach dem Essen an. Wenn ich mich verspäte, sage ich Bescheid.\"",
+                      '"Ich rufe dich heute Abend nach dem Essen an. Wenn ich mich verspäte, sage ich Bescheid."',
                   },
                   {
                     title: "Klar sagen, was Sie meinen",
                     description:
                       "Doppeldeutigkeiten, Beschwichtigungen oder halbe Zusagen schaffen im Alltag oft mehr Unruhe als ehrliche Klarheit.",
                     example:
-                      "\"Ich brauche heute Abend Ruhe und bin morgen wieder ansprechbar.\"",
+                      '"Ich brauche heute Abend Ruhe und bin morgen wieder ansprechbar."',
                   },
                   {
                     title: "Ruhige Präsenz statt hektisches Reparieren",
                     description:
                       "Nicht jede Stimmung muss sofort gelöst werden. Oft hilft es mehr, ansprechbar und klar zu bleiben, ohne alles zu optimieren.",
                     example:
-                      "\"Ich merke, dass heute viel Anspannung da ist. Ich bin da, aber wir müssen das nicht sofort lösen.\"",
+                      '"Ich merke, dass heute viel Anspannung da ist. Ich bin da, aber wir müssen das nicht sofort lösen."',
                   },
                   {
                     title: "Begrenzte Verfügbarkeit",
                     description:
                       "Alltag wird tragfähiger, wenn Nähe nicht mit permanenter Erreichbarkeit verwechselt wird.",
                     example:
-                      "\"Nach 22 Uhr bin ich nicht mehr am Handy. Wenn es ernst wird, holen wir zusätzliche Hilfe dazu.\"",
+                      '"Nach 22 Uhr bin ich nicht mehr am Handy. Wenn es ernst wird, holen wir zusätzliche Hilfe dazu."',
                   },
-                ].map((item) => (
+                ].map(item => (
                   <Card key={item.title} className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                      <p className="text-muted-foreground text-sm mb-3">{item.description}</p>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        {item.title}
+                      </h3>
+                      <p className="text-muted-foreground text-sm mb-3">
+                        {item.description}
+                      </p>
                       <div className="bg-sage-light/30 rounded-lg p-3">
-                        <p className="text-sm text-foreground italic">{item.example}</p>
+                        <p className="text-sm text-foreground italic">
+                          {item.example}
+                        </p>
                       </div>
                     </CardContent>
                   </Card>
@@ -153,25 +168,33 @@ export default function UnterstuetzenAlltag() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Nach Konflikten entsteht oft ein belastender Zwischenraum. Angehörige wissen nicht,
-                  ob sie nachgehen oder Abstand lassen sollen, ob Schweigen beruhigt oder eskaliert,
-                  ob ein Gespräch hilfreich wäre oder zu früh käme.
+                  Nach Konflikten entsteht oft ein belastender Zwischenraum.
+                  Angehörige wissen nicht, ob sie nachgehen oder Abstand lassen
+                  sollen, ob Schweigen beruhigt oder eskaliert, ob ein Gespräch
+                  hilfreich wäre oder zu früh käme.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Hilfreich kann sein</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Hilfreich kann sein
+                      </h3>
                       <ul className="space-y-2 text-sm text-muted-foreground">
                         <li>ein kurzes, klares Kontaktangebot</li>
                         <li>nicht drängen, aber auch nicht strafen</li>
                         <li>später aufgreifen, was passiert ist</li>
-                        <li>zwischen Raum geben und Beziehungsabbruch unterscheiden</li>
+                        <li>
+                          zwischen Raum geben und Beziehungsabbruch
+                          unterscheiden
+                        </li>
                       </ul>
                     </CardContent>
                   </Card>
                   <Card className="border-border/50">
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">Weniger hilfreich ist oft</h3>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        Weniger hilfreich ist oft
+                      </h3>
                       <ul className="space-y-2 text-sm text-muted-foreground">
                         <li>mehrfach nachfassen aus Panik</li>
                         <li>Gegenrückzug aus Verletzung</li>
@@ -184,8 +207,9 @@ export default function UnterstuetzenAlltag() {
                 <Card className="bg-sage-light/10 border-sage">
                   <CardContent className="p-5">
                     <p className="text-foreground leading-relaxed">
-                      Im Alltag ist nach einem Bruch oft nicht Perfektion gefragt, sondern ein
-                      ruhiger, begrenzter Wiedereinstieg in Kontakt.
+                      Im Alltag ist nach einem Bruch oft nicht Perfektion
+                      gefragt, sondern ein ruhiger, begrenzter Wiedereinstieg in
+                      Kontakt.
                     </p>
                   </CardContent>
                 </Card>
@@ -224,7 +248,7 @@ export default function UnterstuetzenAlltag() {
                     description:
                       "Nicht alles tun, was Beziehung sofort beruhigt, sondern das, was längerfristig tragfähig ist.",
                   },
-                ].map((item) => (
+                ].map(item => (
                   <Card key={item.step} className="border-border/50">
                     <CardContent className="p-4">
                       <div className="flex items-start gap-3">
@@ -232,8 +256,12 @@ export default function UnterstuetzenAlltag() {
                           {item.step}
                         </span>
                         <div>
-                          <h4 className="font-semibold text-foreground">{item.title}</h4>
-                          <p className="text-sm text-muted-foreground">{item.description}</p>
+                          <h4 className="font-semibold text-foreground">
+                            {item.title}
+                          </h4>
+                          <p className="text-sm text-muted-foreground">
+                            {item.description}
+                          </p>
                         </div>
                       </div>
                     </CardContent>
@@ -250,21 +278,38 @@ export default function UnterstuetzenAlltag() {
             >
               <div className="space-y-4">
                 <p className="text-muted-foreground leading-relaxed">
-                  Wenn eine Beziehung fast nur noch um Symptome, Anspannung und Konflikt kreist,
-                  verliert sie ihre tragenden Anteile. Alltagshilfe heisst deshalb auch, kleine
-                  gemeinsame Momente zu schützen, die nicht sofort funktional sein müssen.
+                  Wenn eine Beziehung fast nur noch um Symptome, Anspannung und
+                  Konflikt kreist, verliert sie ihre tragenden Anteile.
+                  Alltagshilfe heisst deshalb auch, kleine gemeinsame Momente zu
+                  schützen, die nicht sofort funktional sein müssen.
                 </p>
                 <div className="grid sm:grid-cols-2 gap-4">
                   {[
-                    { title: "kurzer Spaziergang", examples: "ohne sofortiges Problemgespräch" },
-                    { title: "gemeinsames Essen", examples: "mit klarer zeitlicher Begrenzung" },
-                    { title: "etwas Vertrautes wiederholen", examples: "ein kleines Ritual, das nicht überfordert" },
-                    { title: "15 ruhige Minuten", examples: "ohne Lösungssuche, ohne Handy, ohne Druck" },
-                  ].map((item) => (
+                    {
+                      title: "kurzer Spaziergang",
+                      examples: "ohne sofortiges Problemgespräch",
+                    },
+                    {
+                      title: "gemeinsames Essen",
+                      examples: "mit klarer zeitlicher Begrenzung",
+                    },
+                    {
+                      title: "etwas Vertrautes wiederholen",
+                      examples: "ein kleines Ritual, das nicht überfordert",
+                    },
+                    {
+                      title: "15 ruhige Minuten",
+                      examples: "ohne Lösungssuche, ohne Handy, ohne Druck",
+                    },
+                  ].map(item => (
                     <Card key={item.title} className="border-border/50">
                       <CardContent className="p-4">
-                        <h3 className="font-semibold text-foreground mb-1">{item.title}</h3>
-                        <p className="text-muted-foreground text-sm">{item.examples}</p>
+                        <h3 className="font-semibold text-foreground mb-1">
+                          {item.title}
+                        </h3>
+                        <p className="text-muted-foreground text-sm">
+                          {item.examples}
+                        </p>
                       </CardContent>
                     </Card>
                   ))}
@@ -272,9 +317,10 @@ export default function UnterstuetzenAlltag() {
                 <Card className="mt-2 bg-sand-muted border-sand-mid">
                   <CardContent className="p-5">
                     <p className="text-muted-foreground text-sm">
-                      <strong className="text-foreground">Wichtig:</strong> Positive Momente sind
-                      keine Gegenbeweise gegen Belastung. Sie sind eher kleine Ressourceninseln, die
-                      Beziehungen etwas atmungsfähiger machen können.
+                      <strong className="text-foreground">Wichtig:</strong>{" "}
+                      Positive Momente sind keine Gegenbeweise gegen Belastung.
+                      Sie sind eher kleine Ressourceninseln, die Beziehungen
+                      etwas atmungsfähiger machen können.
                     </p>
                   </CardContent>
                 </Card>
@@ -290,15 +336,19 @@ export default function UnterstuetzenAlltag() {
               <div className="space-y-4">
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Fortschritte benennen</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Fortschritte benennen
+                    </h3>
                     <p className="text-muted-foreground text-sm mb-3">
-                      Nicht überloben, aber wahrnehmen, wenn etwas weniger zerstörerisch, etwas
-                      bewusster oder etwas klarer gelungen ist.
+                      Nicht überloben, aber wahrnehmen, wenn etwas weniger
+                      zerstörerisch, etwas bewusster oder etwas klarer gelungen
+                      ist.
                     </p>
                     <div className="bg-sage-lighter/50 rounded-lg p-3">
                       <p className="text-sm text-foreground italic">
-                        "Ich habe gemerkt, dass du dich heute zurückgezogen hast, ohne dass es ganz
-                        eskaliert ist. Das war nicht leicht."
+                        "Ich habe gemerkt, dass du dich heute zurückgezogen
+                        hast, ohne dass es ganz eskaliert ist. Das war nicht
+                        leicht."
                       </p>
                     </div>
                   </CardContent>
@@ -306,19 +356,26 @@ export default function UnterstuetzenAlltag() {
 
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Fragen statt übernehmen</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Fragen statt übernehmen
+                    </h3>
                     <p className="text-muted-foreground text-sm mb-3">
-                      Alltagshilfe wird tragfähiger, wenn Sie nicht alles lösen, sondern Beteiligung
-                      und Eigenanteil offenlassen.
+                      Alltagshilfe wird tragfähiger, wenn Sie nicht alles lösen,
+                      sondern Beteiligung und Eigenanteil offenlassen.
                     </p>
                     <div className="space-y-2">
                       {[
                         "Was wäre dein Vorschlag?",
                         "Was brauchst du gerade von mir, und was eher nicht?",
                         "Soll ich einfach da sein oder mit dir mitdenken?",
-                      ].map((item) => (
-                        <div key={item} className="bg-sage-lighter/50 rounded-lg p-3">
-                          <p className="text-sm text-foreground italic">"{item}"</p>
+                      ].map(item => (
+                        <div
+                          key={item}
+                          className="bg-sage-lighter/50 rounded-lg p-3"
+                        >
+                          <p className="text-sm text-foreground italic">
+                            "{item}"
+                          </p>
                         </div>
                       ))}
                     </div>
@@ -327,15 +384,20 @@ export default function UnterstuetzenAlltag() {
 
                 <Card className="border-border/50">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Vorhersehbar bleiben</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Vorhersehbar bleiben
+                    </h3>
                     <ul className="space-y-2 text-sm">
                       {[
                         "Änderungen möglichst früh ankündigen",
                         "Versprechen halten oder offen revidieren",
                         "Erreichbarkeit klar benennen",
                         "nicht jedes Mal völlig anders reagieren",
-                      ].map((item) => (
-                        <li key={item} className="flex items-start gap-2 text-muted-foreground">
+                      ].map(item => (
+                        <li
+                          key={item}
+                          className="flex items-start gap-2 text-muted-foreground"
+                        >
                           <CheckCircle2 className="w-4 h-4 text-sage-mid mt-0.5 flex-shrink-0" />
                           <span>{item}</span>
                         </li>
@@ -355,7 +417,8 @@ export default function UnterstuetzenAlltag() {
               <Card className="border-l-4 border-l-sage-mid bg-sage-wash">
                 <CardContent className="p-6">
                   <p className="text-muted-foreground leading-relaxed mb-4">
-                    Auch im Alltag können Sie nicht alles halten. Sie können nicht:
+                    Auch im Alltag können Sie nicht alles halten. Sie können
+                    nicht:
                   </p>
                   <ul className="space-y-2">
                     {[
@@ -363,17 +426,23 @@ export default function UnterstuetzenAlltag() {
                       "alle Trigger vermeiden",
                       "jede Eskalation verhindern",
                       "Therapie oder Krisenhilfe ersetzen",
-                    ].map((item) => (
-                      <li key={item} className="flex items-start gap-2 text-muted-foreground">
+                    ].map(item => (
+                      <li
+                        key={item}
+                        className="flex items-start gap-2 text-muted-foreground"
+                      >
                         <span className="text-sage-mid">•</span>
                         {item}
                       </li>
                     ))}
                   </ul>
                   <p className="text-muted-foreground leading-relaxed mt-4">
-                    <strong className="text-foreground">Das ist keine Niederlage.</strong> Alltag
-                    wird nicht durch Perfektion tragfähig, sondern durch Klarheit, Wiederholbarkeit
-                    und die Bereitschaft, auch Ihre eigene Grenze ernst zu nehmen.
+                    <strong className="text-foreground">
+                      Das ist keine Niederlage.
+                    </strong>{" "}
+                    Alltag wird nicht durch Perfektion tragfähig, sondern durch
+                    Klarheit, Wiederholbarkeit und die Bereitschaft, auch Ihre
+                    eigene Grenze ernst zu nehmen.
                   </p>
                 </CardContent>
               </Card>

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -1,10 +1,20 @@
 import SEO from "@/components/SEO";
+import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import Layout from "@/components/Layout";
 import ContentSection from "@/components/ContentSection";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
-import { AlertTriangle, ArrowRight, Phone, Shield, Clock, Download, MessageCircle, XCircle } from "lucide-react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  Phone,
+  Shield,
+  Clock,
+  Download,
+  MessageCircle,
+  XCircle,
+} from "lucide-react";
 import { Link } from "wouter";
 import { kontaktByIdStrict } from "@/data/kontakte";
 
@@ -14,7 +24,11 @@ const gruen143 = kontaktByIdStrict("GRUEN_143");
 export default function UnterstuetzenKrise() {
   return (
     <Layout>
-      <SEO title="Krisenbegleitung" description="Wie Sie in akuten Krisen richtig reagieren und Hilfe leisten können." path="/unterstuetzen/krise" />
+      <SEO
+        title="Krisenbegleitung"
+        description="Wie Sie in akuten Krisen richtig reagieren und Hilfe leisten können."
+        path="/unterstuetzen/krise"
+      />
       {/* Hero */}
       <section className="py-10 md:py-14 bg-gradient-to-b from-sage-wash/60 to-background">
         <div className="container">
@@ -24,47 +38,78 @@ export default function UnterstuetzenKrise() {
             transition={{ duration: 0.6, ease: "easeOut" }}
             className="max-w-3xl"
           >
-            <Link href="/unterstuetzen/uebersicht" className="text-sm text-muted-foreground hover:text-foreground mb-4 inline-flex items-center gap-1">
+            <Link
+              href="/unterstuetzen/uebersicht"
+              className="text-sm text-muted-foreground hover:text-foreground mb-4 inline-flex items-center gap-1"
+            >
               ← Zurück zur Übersicht
             </Link>
-            
+
             <div className="flex items-center gap-3 mb-6 mt-4">
               <div className="w-12 h-12 rounded-xl bg-sand-muteder flex items-center justify-center">
                 <AlertTriangle className="w-6 h-6 text-sage-mid" />
               </div>
-              <span className="text-sm font-medium text-sage-dark">Lesezeit: 6 Minuten</span>
+              <span className="text-sm font-medium text-sage-dark">
+                Lesezeit: 6 Minuten
+              </span>
             </div>
-            
+
             <h1 className="text-2xl md:text-3xl lg:text-4xl font-normal text-foreground mb-6">
               In der Krise unterstützen
             </h1>
-            
+
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-6">
-              Viele Angehörige erleben Phasen starker Anspannung, Eskalation oder Rückzug. Hier erfahren Sie, wie Sie Krisen besser einordnen, deeskalierend reagieren und Sicherheit im Blick behalten können, ohne Ihre eigene Grenze aus dem Blick zu verlieren.
+              Viele Angehörige erleben Phasen starker Anspannung, Eskalation
+              oder Rückzug. Hier erfahren Sie, wie Sie Krisen besser einordnen,
+              deeskalierend reagieren und Sicherheit im Blick behalten können,
+              ohne Ihre eigene Grenze aus dem Blick zu verlieren.
             </p>
-            
+
             <div className="p-4 rounded-xl bg-sand border border-sand-subtle">
               <p className="text-sm text-muted-foreground">
-                <strong className="text-foreground">Unterschied Krise vs. Notfall:</strong> Diese Seite ist für <strong>emotionale Krisen und Eskalationen</strong> (starke Emotionen, Konflikte, Rückzug). Bei <strong>akuter Gefahr</strong> (Suizidgefahr, Selbstverletzung) gehen Sie direkt zu{" "}
-                <Link href="/soforthilfe" className="text-alert hover:underline font-medium">Soforthilfe & Notfallnummern →</Link>
+                <strong className="text-foreground">
+                  Unterschied Krise vs. Notfall:
+                </strong>{" "}
+                Diese Seite ist für{" "}
+                <strong>emotionale Krisen und Eskalationen</strong> (starke
+                Emotionen, Konflikte, Rückzug). Bei{" "}
+                <strong>akuter Gefahr</strong> (Suizidgefahr, Selbstverletzung)
+                gehen Sie direkt zu{" "}
+                <Link
+                  href="/soforthilfe"
+                  className="text-alert hover:underline font-medium"
+                >
+                  Soforthilfe & Notfallnummern →
+                </Link>
               </p>
             </div>
           </motion.div>
         </div>
       </section>
 
+      <UnterstuetzenSubNav />
+
       {/* Emergency Banner */}
       <section className="py-4 bg-alert">
         <div className="container">
           <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
             <p className="text-white text-center sm:text-left">
-              <strong>Bei akuter Suizidgefahr:</strong> Rufen Sie sofort den Notruf{" "}
-              <a href={`tel:${rot144.tel}`} className="underline font-bold">{rot144.nummer}</a>.
-              Zur Entlastung danach:{" "}
-              <a href={`tel:${gruen143.tel}`} className="underline">{gruen143.label} ({gruen143.nummer})</a>
+              <strong>Bei akuter Suizidgefahr:</strong> Rufen Sie sofort den
+              Notruf{" "}
+              <a href={`tel:${rot144.tel}`} className="underline font-bold">
+                {rot144.nummer}
+              </a>
+              . Zur Entlastung danach:{" "}
+              <a href={`tel:${gruen143.tel}`} className="underline">
+                {gruen143.label} ({gruen143.nummer})
+              </a>
             </p>
             <Link href="/soforthilfe">
-              <Button variant="secondary" size="sm" className="bg-white text-alert">
+              <Button
+                variant="secondary"
+                size="sm"
+                className="bg-white text-alert"
+              >
                 <Phone className="w-4 h-4 mr-2" />
                 Alle Notfallnummern
               </Button>
@@ -77,7 +122,6 @@ export default function UnterstuetzenKrise() {
       <section className="py-8 md:py-12">
         <div className="container">
           <div className="max-w-3xl mx-auto">
-
             {/* Ampel-System */}
             <ContentSection
               title="Das Ampel-System: Krisen erkennen"
@@ -87,47 +131,68 @@ export default function UnterstuetzenKrise() {
               preview="Nicht jede schwierige Situation ist eine Krise. Das Ampel-System hilft Ihnen, die Intensität einzuschätzen."
             >
               <p className="text-muted-foreground leading-relaxed mb-6">
-                Nicht jede schwierige Situation ist eine Krise. Das Ampel-System hilft Ihnen, die Intensität einzuschätzen und angemessen zu reagieren.
+                Nicht jede schwierige Situation ist eine Krise. Das Ampel-System
+                hilft Ihnen, die Intensität einzuschätzen und angemessen zu
+                reagieren.
               </p>
-              
+
               <div className="space-y-4">
                 {[
                   {
                     level: "Grün – Stabil",
-                    description: "Alltägliche Stimmungsschwankungen, normale Belastungen",
+                    description:
+                      "Alltägliche Stimmungsschwankungen, normale Belastungen",
                     action: "Präsent sein, zuhören, Routinen beibehalten",
                     color: "var(--color-sage-mid)",
-                    bgColor: "var(--color-sage-lighter)"
+                    bgColor: "var(--color-sage-lighter)",
                   },
                   {
                     level: "Gelb – Angespannt",
-                    description: "Erhöhte Reizbarkeit, Rückzug, erkennbare Trigger",
+                    description:
+                      "Erhöhte Reizbarkeit, Rückzug, erkennbare Trigger",
                     action: "Validieren, Skills anbieten, Raum geben",
                     color: "var(--color-sand-mid)",
-                    bgColor: "var(--color-sand-muted)"
+                    bgColor: "var(--color-sand-muted)",
                   },
                   {
                     level: "Orange – Eskalierend",
-                    description: "Starke Emotionen, verbale Aggression, Kontrollverlust",
+                    description:
+                      "Starke Emotionen, verbale Aggression, Kontrollverlust",
                     action: "Deeskalieren, Sicherheit prüfen, Grenzen setzen",
                     color: "var(--color-sage-mid)",
-                    bgColor: "var(--color-sage-wash)"
+                    bgColor: "var(--color-sage-wash)",
                   },
                   {
                     level: "Rot – Akute Krise",
-                    description: "Suizidgedanken, Selbstverletzung, akute Gefahr",
+                    description:
+                      "Suizidgedanken, Selbstverletzung, akute Gefahr",
                     action: "Professionelle Hilfe holen, Notruf wenn nötig",
                     color: "var(--color-alert)",
-                    bgColor: "var(--color-sage-wash)"
-                  }
+                    bgColor: "var(--color-sage-wash)",
+                  },
                 ].map((item, index) => (
-                  <Card key={index} style={{ borderColor: item.color, backgroundColor: item.bgColor }} className="border-l-4">
+                  <Card
+                    key={index}
+                    style={{
+                      borderColor: item.color,
+                      backgroundColor: item.bgColor,
+                    }}
+                    className="border-l-4"
+                  >
                     <CardContent className="p-5">
-                      <h3 className="font-semibold text-foreground mb-2">{item.level}</h3>
-                      <p className="text-muted-foreground text-sm mb-2">{item.description}</p>
+                      <h3 className="font-semibold text-foreground mb-2">
+                        {item.level}
+                      </h3>
+                      <p className="text-muted-foreground text-sm mb-2">
+                        {item.description}
+                      </p>
                       <p className="text-sm">
-                        <strong className="text-foreground">Ihre Reaktion:</strong>{" "}
-                        <span className="text-muted-foreground">{item.action}</span>
+                        <strong className="text-foreground">
+                          Ihre Reaktion:
+                        </strong>{" "}
+                        <span className="text-muted-foreground">
+                          {item.action}
+                        </span>
                       </p>
                     </CardContent>
                   </Card>
@@ -147,27 +212,34 @@ export default function UnterstuetzenKrise() {
                   {
                     step: 1,
                     title: "Sicherheit prüfen",
-                    description: "Sind Sie und Ihr Angehöriger sicher? Gibt es gefährliche Gegenstände in der Nähe?",
-                    example: "Entfernen Sie unauffällig scharfe Gegenstände oder Medikamente."
+                    description:
+                      "Sind Sie und Ihr Angehöriger sicher? Gibt es gefährliche Gegenstände in der Nähe?",
+                    example:
+                      "Entfernen Sie unauffällig scharfe Gegenstände oder Medikamente.",
                   },
                   {
                     step: 2,
                     title: "Ruhe bewahren",
-                    description: "Ihre Ruhe kann ansteckend sein. Atmen Sie tief, sprechen Sie langsam und leise.",
-                    example: "\"Ich bin hier. Wir schaffen das zusammen.\""
+                    description:
+                      "Ihre Ruhe kann ansteckend sein. Atmen Sie tief, sprechen Sie langsam und leise.",
+                    example: '"Ich bin hier. Wir schaffen das zusammen."',
                   },
                   {
                     step: 3,
                     title: "Validieren",
-                    description: "Anerkennen Sie die Gefühle, ohne sie zu bewerten oder zu lösen.",
-                    example: "\"Ich sehe, dass du gerade sehr viel Schmerz fühlst. Das muss furchtbar sein.\""
+                    description:
+                      "Anerkennen Sie die Gefühle, ohne sie zu bewerten oder zu lösen.",
+                    example:
+                      '"Ich sehe, dass du gerade sehr viel Schmerz fühlst. Das muss furchtbar sein."',
                   },
                   {
                     step: 4,
                     title: "Skills anbieten",
-                    description: "Erinnern Sie sanft an Strategien, die in der Vergangenheit geholfen haben.",
-                    example: "\"Möchtest du die Atemübung ausprobieren, die dir letztens geholfen hat?\""
-                  }
+                    description:
+                      "Erinnern Sie sanft an Strategien, die in der Vergangenheit geholfen haben.",
+                    example:
+                      '"Möchtest du die Atemübung ausprobieren, die dir letztens geholfen hat?"',
+                  },
                 ].map((item, index) => (
                   <Card key={index} className="border-border/50">
                     <CardContent className="p-5">
@@ -176,10 +248,16 @@ export default function UnterstuetzenKrise() {
                           {item.step}
                         </div>
                         <div>
-                          <h3 className="font-semibold text-foreground mb-2">{item.title}</h3>
-                          <p className="text-muted-foreground text-sm mb-2">{item.description}</p>
+                          <h3 className="font-semibold text-foreground mb-2">
+                            {item.title}
+                          </h3>
+                          <p className="text-muted-foreground text-sm mb-2">
+                            {item.description}
+                          </p>
                           <div className="bg-muted/50 rounded-lg p-3">
-                            <p className="text-sm text-foreground italic">{item.example}</p>
+                            <p className="text-sm text-foreground italic">
+                              {item.example}
+                            </p>
                           </div>
                         </div>
                       </div>
@@ -197,54 +275,87 @@ export default function UnterstuetzenKrise() {
               preview="In einer Krise zählt jedes Wort. Diese Formulierungen haben sich bewährt."
             >
               <p className="text-muted-foreground leading-relaxed mb-6">
-                In einer Krise zählt jedes Wort. Diese Formulierungen haben sich bewährt:
+                In einer Krise zählt jedes Wort. Diese Formulierungen haben sich
+                bewährt:
               </p>
-              
+
               <div className="space-y-4">
                 <Card className="border-l-4 border-l-sage-mid">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Präsenz zeigen</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Präsenz zeigen
+                    </h3>
                     <div className="bg-sage-lighter rounded-lg p-3">
-                      <p className="text-sm text-foreground font-medium">"Ich bin hier. Ich gehe nicht weg. Du bist nicht allein."</p>
-                      <p className="text-xs text-muted-foreground mt-2">Wenn Nähe die Situation verschärft, kann auch eine ruhig angekündigte Distanz hilfreich sein: «Ich bleibe in der Nähe und komme in ein paar Minuten wieder.»</p>
+                      <p className="text-sm text-foreground font-medium">
+                        "Ich bin hier. Ich gehe nicht weg. Du bist nicht
+                        allein."
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-2">
+                        Wenn Nähe die Situation verschärft, kann auch eine ruhig
+                        angekündigte Distanz hilfreich sein: «Ich bleibe in der
+                        Nähe und komme in ein paar Minuten wieder.»
+                      </p>
                     </div>
                   </CardContent>
                 </Card>
-                
+
                 <Card className="border-l-4 border-l-sage-mid">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Gefühle validieren</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Gefühle validieren
+                    </h3>
                     <div className="bg-sage-lighter rounded-lg p-3">
-                      <p className="text-sm text-foreground font-medium">"Ich sehe, dass du gerade unglaublich viel Schmerz fühlst. Das muss sich furchtbar anfühlen."</p>
+                      <p className="text-sm text-foreground font-medium">
+                        "Ich sehe, dass du gerade unglaublich viel Schmerz
+                        fühlst. Das muss sich furchtbar anfühlen."
+                      </p>
                     </div>
                   </CardContent>
                 </Card>
-                
+
                 <Card className="border-l-4 border-l-sage-mid">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Hoffnung vermitteln</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Hoffnung vermitteln
+                    </h3>
                     <div className="bg-sage-lighter rounded-lg p-3">
-                      <p className="text-sm text-foreground font-medium">"Dieses Gefühl wird vorbeigehen. Es fühlt sich jetzt endlos an, aber es wird sich verändern."</p>
+                      <p className="text-sm text-foreground font-medium">
+                        "Dieses Gefühl wird vorbeigehen. Es fühlt sich jetzt
+                        endlos an, aber es wird sich verändern."
+                      </p>
                     </div>
                   </CardContent>
                 </Card>
-                
+
                 <Card className="border-l-4 border-l-sage-mid">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Konkrete Hilfe anbieten</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Konkrete Hilfe anbieten
+                    </h3>
                     <div className="bg-sage-lighter rounded-lg p-3">
-                      <p className="text-sm text-foreground font-medium">"Was brauchst du gerade am meisten? Soll ich einfach hier sitzen? Oder sollen wir zusammen atmen?"</p>
+                      <p className="text-sm text-foreground font-medium">
+                        "Was brauchst du gerade am meisten? Soll ich einfach
+                        hier sitzen? Oder sollen wir zusammen atmen?"
+                      </p>
                     </div>
                   </CardContent>
                 </Card>
-                
+
                 <Card className="border-l-4 border-l-sage-mid">
                   <CardContent className="p-5">
-                    <h3 className="font-semibold text-foreground mb-3">Bei Suizidgedanken direkt ansprechen</h3>
+                    <h3 className="font-semibold text-foreground mb-3">
+                      Bei Suizidgedanken direkt ansprechen
+                    </h3>
                     <div className="bg-sage-lighter rounded-lg p-3">
-                      <p className="text-sm text-foreground font-medium">"Ich mache mir Sorgen um dich. Hast du gerade Gedanken, dir etwas anzutun?"</p>
+                      <p className="text-sm text-foreground font-medium">
+                        "Ich mache mir Sorgen um dich. Hast du gerade Gedanken,
+                        dir etwas anzutun?"
+                      </p>
                     </div>
-                    <p className="text-xs text-muted-foreground mt-2">Hinweis: Direktes Fragen erhöht das Risiko nicht, sondern zeigt, dass Sie die Situation ernst nehmen.</p>
+                    <p className="text-xs text-muted-foreground mt-2">
+                      Hinweis: Direktes Fragen erhöht das Risiko nicht, sondern
+                      zeigt, dass Sie die Situation ernst nehmen.
+                    </p>
                   </CardContent>
                 </Card>
               </div>
@@ -263,12 +374,15 @@ export default function UnterstuetzenKrise() {
                     {[
                       "Drohen oder Ultimaten stellen",
                       "Vorwürfe machen oder Schuld zuweisen",
-                      "Die Gefühle herunterspielen (\"So schlimm ist es doch nicht\")",
+                      'Die Gefühle herunterspielen ("So schlimm ist es doch nicht")',
                       "Logisch argumentieren oder überzeugen wollen",
                       "Die Person alleine lassen, wenn Suizidgefahr besteht",
-                      "Sich selbst in Gefahr bringen"
+                      "Sich selbst in Gefahr bringen",
                     ].map((item, i) => (
-                      <li key={i} className="flex items-start gap-2 text-muted-foreground">
+                      <li
+                        key={i}
+                        className="flex items-start gap-2 text-muted-foreground"
+                      >
                         <span className="text-alert">✗</span>
                         {item}
                       </li>
@@ -288,7 +402,8 @@ export default function UnterstuetzenKrise() {
               <Card className="bg-sage-light/20 border-sage">
                 <CardContent className="p-6">
                   <p className="text-muted-foreground leading-relaxed mb-4">
-                    Wenn die akute Krise vorbei ist, ist es wichtig, das Erlebte zu verarbeiten – für Sie beide:
+                    Wenn die akute Krise vorbei ist, ist es wichtig, das Erlebte
+                    zu verarbeiten – für Sie beide:
                   </p>
                   <ul className="space-y-2">
                     {[
@@ -296,9 +411,12 @@ export default function UnterstuetzenKrise() {
                       "Fragen Sie, was geholfen hat und was nicht",
                       "Aktualisieren Sie gemeinsam den Krisenplan",
                       "Achten Sie auch auf Ihre eigenen Gefühle",
-                      "Holen Sie sich bei Bedarf selbst Unterstützung"
+                      "Holen Sie sich bei Bedarf selbst Unterstützung",
                     ].map((item, i) => (
-                      <li key={i} className="flex items-start gap-2 text-muted-foreground">
+                      <li
+                        key={i}
+                        className="flex items-start gap-2 text-muted-foreground"
+                      >
                         <span className="text-sage-mid">→</span>
                         {item}
                       </li>
@@ -322,12 +440,19 @@ export default function UnterstuetzenKrise() {
                       <ArrowRight className="w-5 h-5 text-sage-mid" />
                     </div>
                     <div>
-                      <h3 className="font-medium text-foreground mb-2">Situations-Wegweiser: «Was tun wenn…»</h3>
+                      <h3 className="font-medium text-foreground mb-2">
+                        Situations-Wegweiser: «Was tun wenn…»
+                      </h3>
                       <p className="text-sm text-muted-foreground mb-3">
-                        In der akuten Situation ist klares Denken schwer. Unser interaktiver Wegweiser führt Sie Schritt für Schritt durch verschiedene Krisenszenarien.
+                        In der akuten Situation ist klares Denken schwer. Unser
+                        interaktiver Wegweiser führt Sie Schritt für Schritt
+                        durch verschiedene Krisenszenarien.
                       </p>
                       <Link href="/wegweiser">
-                        <Button size="sm" className="bg-sage-dark hover:bg-sage-mid text-white">
+                        <Button
+                          size="sm"
+                          className="bg-sage-dark hover:bg-sage-mid text-white"
+                        >
                           Zum Wegweiser
                         </Button>
                       </Link>
@@ -348,7 +473,7 @@ export default function UnterstuetzenKrise() {
                 <Download className="w-8 h-8 text-sage-mid" />
                 Materialien zum Thema
               </h2>
-              
+
               <Card className="bg-sand-muted border-sand-border">
                 <CardContent className="p-6">
                   <div className="flex items-start gap-4">
@@ -356,9 +481,12 @@ export default function UnterstuetzenKrise() {
                       <Download className="w-5 h-5 text-sage-mid" />
                     </div>
                     <div>
-                      <h3 className="font-medium text-foreground mb-2">Alle Materialien als PDF verfügbar</h3>
+                      <h3 className="font-medium text-foreground mb-2">
+                        Alle Materialien als PDF verfügbar
+                      </h3>
                       <p className="text-sm text-muted-foreground mb-3">
-                        Infografiken und Handouts zum Thema Krisenbegleitung finden Sie auf der Materialien-Seite.
+                        Infografiken und Handouts zum Thema Krisenbegleitung
+                        finden Sie auf der Materialien-Seite.
                       </p>
                       <Link href="/materialien">
                         <Button variant="outline" size="sm">
@@ -379,9 +507,7 @@ export default function UnterstuetzenKrise() {
               className="flex justify-between items-center pt-8 border-t border-border"
             >
               <Link href="/unterstuetzen/therapie">
-                <Button variant="ghost">
-                  ← Therapie begleiten
-                </Button>
+                <Button variant="ghost">← Therapie begleiten</Button>
               </Link>
               <Link href="/kommunizieren">
                 <Button className="bg-sage-dark hover:bg-sage-mid text-white">

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -1,4 +1,5 @@
 import SEO from "@/components/SEO";
+import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import Layout from "@/components/Layout";
 import ContentSection from "@/components/ContentSection";
 import { Card, CardContent } from "@/components/ui/card";
@@ -83,6 +84,8 @@ export default function UnterstuetzenTherapie() {
           </motion.div>
         </div>
       </section>
+
+      <UnterstuetzenSubNav />
 
       <section className="py-8 md:py-12">
         <div className="container">

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 import SEO from "@/components/SEO";
+import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import Layout from "@/components/Layout";
 import ContentSection from "@/components/ContentSection";
 import { Card, CardContent } from "@/components/ui/card";
@@ -46,6 +47,8 @@ export default function UnterstuetzenUebersicht() {
       />
 
       <UnterstuetzenHeroSection />
+
+      <UnterstuetzenSubNav />
 
       <section className="py-8 md:py-12">
         <div className="container">


### PR DESCRIPTION
## Was

Neues Komponent `UnterstuetzenSubNav`: horizontale Tab-Leiste, die auf allen 4 Unterstützen-Seiten erscheint.

**Tabs:** Übersicht · Im Alltag · In der Krise · Therapie
**Aktiv-Zustand:** sage-dark Unterstrich + Farbe
**Accessibility:** `aria-current="page"` auf aktivem Tab
**Mobile:** horizontal scrollbar (`overflow-x-auto`)

## Platzierung

Auf jeder Seite direkt nach dem Hero, vor dem ersten Content-Abschnitt.

## Warum

Angehörige, die direkt auf z.B. `/unterstuetzen/krise` landen, sahen bisher nur einen "← Zurück zur Übersicht"-Link. Jetzt ist das Modul sofort als Ganzes erkennbar.