### PR TITLE
feat: Situations-Wegweiser in Navigation aufnehmen

### DIFF
--- a/client/src/domain/navigation.ts
+++ b/client/src/domain/navigation.ts
@@ -2,6 +2,7 @@ import {
   BookMarked,
   BookOpen,
   Building2,
+  Compass,
   Download,
   FileText,
   Heart,
@@ -26,6 +27,7 @@ export const primaryNavigationItems: NavigationItem[] = [
 export const resourceNavigationItems: NavigationItem[] = [
   { href: "/materialien", label: "Materialien & Handouts", icon: Download },
   { href: "/genesung", label: "Genesung & Hoffnung", icon: TrendingUp },
+  { href: "/wegweiser", label: "Situations-Wegweiser", icon: Compass },
   { href: "/notfallkarte", label: "Notfallkarte", icon: FileText },
   { href: "/beratung", label: "Beratung & Netzwerke", icon: Heart },
   { href: "/fachstelle", label: "Fachstelle & Kontakt", icon: Building2 },


### PR DESCRIPTION
## Was

`/wegweiser` in `resourceNavigationItems` eingefügt (zwischen Genesung und Notfallkarte).

## Warum

- Vollständige, 135-Zeilen-Seite mit interaktivem Entscheidungsbaum (`SituationsWegweiser`)
- War nur über Soforthilfe + UnterstuetzenKrise erreichbar – kein direkter Navigationseinstieg
- Inhaltlich krisennah: gehört neben Notfallkarte in die Ressourcen-Gruppe

## Was bleibt

- `/uebungen` bleibt Sub-Page von Kommunizieren (wird bereits verlinkt, hat Back-Link)