### PR TITLE
fix: P2 – Soforthilfe Regionshinweis, Notfallkarte Storage-Warnung, Fachstelle LastVerifiedBadge

### DIFF
--- a/client/src/pages/Fachstelle.tsx
+++ b/client/src/pages/Fachstelle.tsx
@@ -1,10 +1,25 @@
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
+import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import { Card, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
-import { Building2, Mail, MapPin, Users, BookOpen, Phone, ArrowRight, Info, ExternalLink } from "lucide-react";
+import {
+  Building2,
+  Mail,
+  MapPin,
+  Users,
+  BookOpen,
+  Phone,
+  ArrowRight,
+  Info,
+  ExternalLink,
+} from "lucide-react";
 import { Link } from "wouter";
-import { kontaktByIdStrict, emailByIdStrict, urlByIdStrict } from "@/data/kontakte";
+import {
+  kontaktByIdStrict,
+  emailByIdStrict,
+  urlByIdStrict,
+} from "@/data/kontakte";
 
 const fachstelleTel = kontaktByIdStrict("INFO_FACHSTELLE");
 const fachstelleEmail = emailByIdStrict("EMAIL_ANGEHOERIGEN");
@@ -39,10 +54,12 @@ export default function Fachstelle() {
             </h1>
 
             <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Ein Angebot der Psychiatrischen Universitätsklinik Zürich für Angehörige von Menschen
-              mit psychischen Erkrankungen. Die Fachstelle bietet Orientierung, Entlastung und
-              Beratung für Situationen, die im Alltag oft schwer alleine zu tragen sind.
+              Ein Angebot der Psychiatrischen Universitätsklinik Zürich für
+              Angehörige von Menschen mit psychischen Erkrankungen. Die
+              Fachstelle bietet Orientierung, Entlastung und Beratung für
+              Situationen, die im Alltag oft schwer alleine zu tragen sind.
             </p>
+            <LastVerifiedBadge date="24.03.2026" className="mt-4" />
           </motion.div>
         </div>
       </section>
@@ -51,7 +68,6 @@ export default function Fachstelle() {
       <section className="py-8 md:py-12">
         <div className="container">
           <div className="max-w-3xl mx-auto">
-
             {/* Kurzprofil */}
             <motion.div
               initial={{ opacity: 0, y: 20 }}
@@ -65,9 +81,10 @@ export default function Fachstelle() {
               </h2>
 
               <p className="text-muted-foreground leading-relaxed mb-6">
-                Die Fachstelle ist kein Krisendienst und keine Therapie. Sie ist eine Anlaufstelle
-                für Angehörige, die ihre Rolle klären, Belastung einordnen und passende nächste
-                Schritte finden möchten.
+                Die Fachstelle ist kein Krisendienst und keine Therapie. Sie ist
+                eine Anlaufstelle für Angehörige, die ihre Rolle klären,
+                Belastung einordnen und passende nächste Schritte finden
+                möchten.
               </p>
 
               <div className="grid gap-4">
@@ -75,23 +92,27 @@ export default function Fachstelle() {
                   {
                     icon: Users,
                     title: "Beratung für Angehörige",
-                    description: "Vertrauliche und kostenlose Gespräche für Angehörige, die Orientierung, Entlastung oder Klärung in einer belastenden Situation suchen."
+                    description:
+                      "Vertrauliche und kostenlose Gespräche für Angehörige, die Orientierung, Entlastung oder Klärung in einer belastenden Situation suchen.",
                   },
                   {
                     icon: BookOpen,
                     title: "Psychoedukation & Materialien",
-                    description: "Fachlich fundierte Informationen, Handouts und Materialien, die helfen können, Dynamiken besser einzuordnen und Gespräche vorzubereiten."
+                    description:
+                      "Fachlich fundierte Informationen, Handouts und Materialien, die helfen können, Dynamiken besser einzuordnen und Gespräche vorzubereiten.",
                   },
                   {
                     icon: Phone,
                     title: "Orientierung & Vermittlung",
-                    description: "Unterstützung bei der Suche nach passenden Hilfen, Selbsthilfeangeboten und weiteren Anlaufstellen."
+                    description:
+                      "Unterstützung bei der Suche nach passenden Hilfen, Selbsthilfeangeboten und weiteren Anlaufstellen.",
                   },
                   {
                     icon: Building2,
                     title: "Schulungen & Weiterbildung",
-                    description: "Fachliche Weiterbildung und Sensibilisierung zum Thema Angehörigenarbeit im psychosozialen Kontext."
-                  }
+                    description:
+                      "Fachliche Weiterbildung und Sensibilisierung zum Thema Angehörigenarbeit im psychosozialen Kontext.",
+                  },
                 ].map((item, index) => {
                   const Icon = item.icon;
                   return (
@@ -102,8 +123,12 @@ export default function Fachstelle() {
                             <Icon className="w-5 h-5 text-sage-mid" />
                           </div>
                           <div>
-                            <h3 className="font-semibold text-foreground mb-1">{item.title}</h3>
-                            <p className="text-sm text-muted-foreground leading-relaxed">{item.description}</p>
+                            <h3 className="font-semibold text-foreground mb-1">
+                              {item.title}
+                            </h3>
+                            <p className="text-sm text-muted-foreground leading-relaxed">
+                              {item.description}
+                            </p>
                           </div>
                         </div>
                       </CardContent>
@@ -133,8 +158,12 @@ export default function Fachstelle() {
                         <Building2 className="w-5 h-5 text-sage-mid" />
                       </div>
                       <div>
-                        <p className="font-semibold text-foreground">Fachstelle Angehörigenarbeit</p>
-                        <p className="text-sm text-muted-foreground">Psychiatrische Universitätsklinik Zürich (PUK)</p>
+                        <p className="font-semibold text-foreground">
+                          Fachstelle Angehörigenarbeit
+                        </p>
+                        <p className="text-sm text-muted-foreground">
+                          Psychiatrische Universitätsklinik Zürich (PUK)
+                        </p>
                       </div>
                     </div>
 
@@ -160,7 +189,9 @@ export default function Fachstelle() {
                         >
                           {fachstelleTel.nummer}
                         </a>
-                        <p className="text-sm text-muted-foreground mt-0.5">Terminvereinbarung telefonisch</p>
+                        <p className="text-sm text-muted-foreground mt-0.5">
+                          Terminvereinbarung telefonisch
+                        </p>
                       </div>
                     </div>
 
@@ -175,7 +206,9 @@ export default function Fachstelle() {
                         >
                           {fachstelleEmail.adresse}
                         </a>
-                        <p className="text-sm text-muted-foreground mt-0.5">Terminvereinbarung per E-Mail</p>
+                        <p className="text-sm text-muted-foreground mt-0.5">
+                          Terminvereinbarung per E-Mail
+                        </p>
                       </div>
                     </div>
 
@@ -192,7 +225,9 @@ export default function Fachstelle() {
                         >
                           {pukUrl.url.replace("https://", "")}
                         </a>
-                        <p className="text-sm text-muted-foreground mt-0.5">Website der PUK Zürich</p>
+                        <p className="text-sm text-muted-foreground mt-0.5">
+                          Website der PUK Zürich
+                        </p>
                       </div>
                     </div>
                   </div>
@@ -220,13 +255,15 @@ export default function Fachstelle() {
                     </div>
                     <div>
                       <p className="text-foreground leading-relaxed mb-3">
-                        Diese Website wurde von Ch. Egger innerhalb der Fachstelle Angehörigenarbeit
-                        aufgebaut. Die inhaltliche Verantwortung liegt bei der Fachstelle
+                        Diese Website wurde von Ch. Egger innerhalb der
+                        Fachstelle Angehörigenarbeit aufgebaut. Die inhaltliche
+                        Verantwortung liegt bei der Fachstelle
                         Angehörigenarbeit.
                       </p>
                       <p className="text-sm text-muted-foreground leading-relaxed">
-                        Es handelt sich um ein eigenständig gestaltetes Informationsangebot der
-                        Fachstelle und nicht um einen offiziellen Kommunikationskanal der PUK Zürich.
+                        Es handelt sich um ein eigenständig gestaltetes
+                        Informationsangebot der Fachstelle und nicht um einen
+                        offiziellen Kommunikationskanal der PUK Zürich.
                       </p>
                     </div>
                   </div>
@@ -252,8 +289,12 @@ export default function Fachstelle() {
                       <div className="flex items-center gap-3">
                         <BookOpen className="w-5 h-5 text-sage-mid flex-shrink-0" />
                         <div className="flex-1">
-                          <p className="font-medium text-foreground">Über diese Website</p>
-                          <p className="text-sm text-muted-foreground">Prinzipien, Quellen und Hintergründe</p>
+                          <p className="font-medium text-foreground">
+                            Über diese Website
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            Prinzipien, Quellen und Hintergründe
+                          </p>
                         </div>
                         <ArrowRight className="w-4 h-4 text-muted-foreground" />
                       </div>
@@ -267,8 +308,12 @@ export default function Fachstelle() {
                       <div className="flex items-center gap-3">
                         <Phone className="w-5 h-5 text-alert flex-shrink-0" />
                         <div className="flex-1">
-                          <p className="font-medium text-foreground">Soforthilfe</p>
-                          <p className="text-sm text-muted-foreground">Notfallnummern und Krisenberatung</p>
+                          <p className="font-medium text-foreground">
+                            Soforthilfe
+                          </p>
+                          <p className="text-sm text-muted-foreground">
+                            Notfallnummern und Krisenberatung
+                          </p>
                         </div>
                         <ArrowRight className="w-4 h-4 text-muted-foreground" />
                       </div>
@@ -277,7 +322,6 @@ export default function Fachstelle() {
                 </Link>
               </div>
             </motion.div>
-
           </div>
         </div>
       </section>

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -51,9 +51,9 @@ function createId() {
 // ─── Emergency contacts for print card ────────────────────
 
 /** Contacts shown on the printed card (including nurPdf entries) */
-const CARD_ROT = ROT.filter((k) => k.id !== "ROT_118");
+const CARD_ROT = ROT.filter(k => k.id !== "ROT_118");
 const CARD_GELB = GELB;
-const CARD_GRUEN = GRUEN.filter((k) => k.id === "GRUEN_143");
+const CARD_GRUEN = GRUEN.filter(k => k.id === "GRUEN_143");
 
 // ─── Persistence ──────────────────────────────────────────
 
@@ -71,11 +71,23 @@ function loadData(): NotfallkarteData {
   };
 }
 
-function saveData(data: NotfallkarteData) {
+function isStorageAvailable(): boolean {
+  try {
+    const test = "__storage_test__";
+    localStorage.setItem(test, test);
+    localStorage.removeItem(test);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function saveData(data: NotfallkarteData): boolean {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    return true;
   } catch {
-    /* storage full – silently fail */
+    return false;
   }
 }
 
@@ -120,21 +132,21 @@ function PersonalContactRow({
         <input
           type="text"
           value={contact.name}
-          onChange={(e) => onUpdate({ ...contact, name: e.target.value })}
+          onChange={e => onUpdate({ ...contact, name: e.target.value })}
           placeholder="Name"
           className="rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring print:border-b print:border-t-0 print:border-l-0 print:border-r-0 print:rounded-none print:px-0 print:py-0.5"
         />
         <input
           type="tel"
           value={contact.phone}
-          onChange={(e) => onUpdate({ ...contact, phone: e.target.value })}
+          onChange={e => onUpdate({ ...contact, phone: e.target.value })}
           placeholder="Telefonnummer"
           className="rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring print:border-b print:border-t-0 print:border-l-0 print:border-r-0 print:rounded-none print:px-0 print:py-0.5"
         />
         <input
           type="text"
           value={contact.relation}
-          onChange={(e) => onUpdate({ ...contact, relation: e.target.value })}
+          onChange={e => onUpdate({ ...contact, relation: e.target.value })}
           placeholder="Beziehung (z.B. Therapeut:in)"
           className="rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring print:border-b print:border-t-0 print:border-l-0 print:border-r-0 print:rounded-none print:px-0 print:py-0.5"
         />
@@ -156,11 +168,17 @@ function PersonalContactRow({
 export default function Notfallkarte() {
   const [data, setData] = useState<NotfallkarteData>(loadData);
   const [saved, setSaved] = useState(false);
+  const [storageError, setStorageError] = useState(false);
   const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Detect storage availability once on mount
+  useEffect(() => {
+    if (!isStorageAvailable()) setStorageError(true);
+  }, []);
 
   // Auto-save on changes
   useEffect(() => {
-    saveData(data);
+    if (!saveData(data)) setStorageError(true);
   }, [data]);
 
   useEffect(() => {
@@ -181,7 +199,7 @@ export default function Notfallkarte() {
   }, []);
 
   const addContact = useCallback(() => {
-    setData((prev) => ({
+    setData(prev => ({
       ...prev,
       personalContacts: [
         ...prev.personalContacts,
@@ -191,23 +209,23 @@ export default function Notfallkarte() {
   }, []);
 
   const updateContact = useCallback((updated: PersonalContact) => {
-    setData((prev) => ({
+    setData(prev => ({
       ...prev,
-      personalContacts: prev.personalContacts.map((c) =>
-        c.id === updated.id ? updated : c,
+      personalContacts: prev.personalContacts.map(c =>
+        c.id === updated.id ? updated : c
       ),
     }));
   }, []);
 
   const removeContact = useCallback((id: string) => {
-    setData((prev) => ({
+    setData(prev => ({
       ...prev,
-      personalContacts: prev.personalContacts.filter((c) => c.id !== id),
+      personalContacts: prev.personalContacts.filter(c => c.id !== id),
     }));
   }, []);
 
   const addStrategy = useCallback(() => {
-    setData((prev) => ({
+    setData(prev => ({
       ...prev,
       calmingStrategies: [
         ...prev.calmingStrategies,
@@ -217,18 +235,18 @@ export default function Notfallkarte() {
   }, []);
 
   const updateStrategy = useCallback((id: string, text: string) => {
-    setData((prev) => ({
+    setData(prev => ({
       ...prev,
-      calmingStrategies: prev.calmingStrategies.map((s) =>
-        s.id === id ? { ...s, text } : s,
+      calmingStrategies: prev.calmingStrategies.map(s =>
+        s.id === id ? { ...s, text } : s
       ),
     }));
   }, []);
 
   const removeStrategy = useCallback((id: string) => {
-    setData((prev) => ({
+    setData(prev => ({
       ...prev,
-      calmingStrategies: prev.calmingStrategies.filter((s) => s.id !== id),
+      calmingStrategies: prev.calmingStrategies.filter(s => s.id !== id),
     }));
   }, []);
 
@@ -243,6 +261,20 @@ export default function Notfallkarte() {
       {/* ─── Hero ─────────────────────────────────────────── */}
       <section className="bg-gradient-to-b from-[var(--color-sand)] to-background pt-12 pb-8 print:pt-2 print:pb-2 print:bg-none">
         <div className="container max-w-3xl text-center">
+          {storageError && (
+            <div
+              className="flex items-start gap-3 mb-6 p-4 rounded-xl bg-amber-50 border border-amber-200 text-left print:hidden"
+              role="alert"
+            >
+              <AlertTriangle className="w-5 h-5 text-amber-600 shrink-0 mt-0.5" />
+              <p className="text-sm text-amber-800">
+                <strong>Speichern nicht möglich:</strong> Ihr Browser blockiert
+                den lokalen Speicher (z.B. im privaten Modus). Ihre Eingaben
+                werden nicht gespeichert. Bitte drucken Sie die Karte aus, bevor
+                Sie die Seite verlassen.
+              </p>
+            </div>
+          )}
           <div className="inline-flex items-center gap-2 bg-[var(--color-sos-rot)]/10 text-[var(--color-sos-rot)] px-4 py-1.5 rounded-full text-sm font-medium mb-4 print:hidden">
             <Shield className="w-4 h-4" />
             Soforthilfe-Werkzeug
@@ -251,9 +283,9 @@ export default function Notfallkarte() {
             Persönliche Notfallkarte
           </h1>
           <p className="text-muted-foreground text-lg leading-relaxed max-w-xl mx-auto print:text-sm print:max-w-none">
-            Die wichtigsten Nummern und Ihre persönlichen Strategien –
-            alles auf einen Blick. Zum Ausdrucken, als PDF speichern oder
-            jederzeit hier abrufen.
+            Die wichtigsten Nummern und Ihre persönlichen Strategien – alles auf
+            einen Blick. Zum Ausdrucken, als PDF speichern oder jederzeit hier
+            abrufen.
           </p>
 
           {/* Action buttons – hidden when printing */}
@@ -282,7 +314,7 @@ export default function Notfallkarte() {
               </h2>
             </div>
             <div className="divide-y divide-border/50">
-              {CARD_ROT.map((k) => (
+              {CARD_ROT.map(k => (
                 <EmergencyRow key={k.id} kontakt={k} />
               ))}
             </div>
@@ -299,7 +331,7 @@ export default function Notfallkarte() {
               </h2>
             </div>
             <div className="divide-y divide-border/50">
-              {CARD_GELB.map((k) => (
+              {CARD_GELB.map(k => (
                 <EmergencyRow key={k.id} kontakt={k} />
               ))}
             </div>
@@ -316,7 +348,7 @@ export default function Notfallkarte() {
               </h2>
             </div>
             <div className="divide-y divide-border/50">
-              {CARD_GRUEN.map((k) => (
+              {CARD_GRUEN.map(k => (
                 <EmergencyRow key={k.id} kontakt={k} />
               ))}
             </div>
@@ -346,12 +378,12 @@ export default function Notfallkarte() {
 
             {data.personalContacts.length === 0 ? (
               <p className="text-sm text-muted-foreground py-3 print:hidden">
-                Fügen Sie hier Ihre persönlichen Kontaktpersonen hinzu –
-                z.B. Therapeut:in, Vertrauensperson, Nachbar:in.
+                Fügen Sie hier Ihre persönlichen Kontaktpersonen hinzu – z.B.
+                Therapeut:in, Vertrauensperson, Nachbar:in.
               </p>
             ) : (
               <div className="space-y-0.5">
-                {data.personalContacts.map((c) => (
+                {data.personalContacts.map(c => (
                   <PersonalContactRow
                     key={c.id}
                     contact={c}
@@ -365,7 +397,7 @@ export default function Notfallkarte() {
             {/* Print-only: empty lines if no contacts */}
             {data.personalContacts.length === 0 && (
               <div className="hidden print:block space-y-3 mt-2">
-                {[1, 2, 3].map((i) => (
+                {[1, 2, 3].map(i => (
                   <div key={i} className="grid grid-cols-3 gap-4">
                     <div className="border-b border-gray-400 py-2 text-xs text-gray-500">
                       Name
@@ -412,7 +444,7 @@ export default function Notfallkarte() {
                   <input
                     type="text"
                     value={s.text}
-                    onChange={(e) => updateStrategy(s.id, e.target.value)}
+                    onChange={e => updateStrategy(s.id, e.target.value)}
                     placeholder="Strategie eingeben…"
                     className="flex-1 rounded-md border border-border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring print:border-b print:border-t-0 print:border-l-0 print:border-r-0 print:rounded-none print:px-0 print:py-0.5"
                   />
@@ -441,8 +473,8 @@ export default function Notfallkarte() {
             </div>
             <textarea
               value={data.notes}
-              onChange={(e) =>
-                setData((prev) => ({ ...prev, notes: e.target.value }))
+              onChange={e =>
+                setData(prev => ({ ...prev, notes: e.target.value }))
               }
               placeholder="z.B. Medikamente, Allergien, wichtige Hinweise für Helfer:innen…"
               rows={3}

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -18,12 +18,22 @@ import SEO from "@/components/SEO";
  */
 import Layout from "@/components/Layout";
 import { motion } from "framer-motion";
-import { Phone, AlertTriangle, Clock, Baby, User, Users, Shield, Heart, Pill, Info, ChevronRight } from "lucide-react";
+import {
+  Phone,
+  AlertTriangle,
+  Clock,
+  Baby,
+  User,
+  Users,
+  Shield,
+  Heart,
+  Pill,
+  Info,
+  ChevronRight,
+} from "lucide-react";
 import { useState, useEffect } from "react";
 import { Link } from "wouter";
-import {
-  kontaktByIdStrict,
-} from "@/data/kontakte";
+import { kontaktByIdStrict } from "@/data/kontakte";
 
 // ─── Sticky Ampel-Leiste ──────────────────────────────────
 
@@ -42,9 +52,24 @@ function StickyAmpelLeiste() {
   };
 
   const items = [
-    { id: "block-rot",    label: "Lebensgefahr",         sub: "144 · 117 · 112",  bg: "var(--color-sos-rot)" },
-    { id: "block-orange", label: "Psychiatr. Krise",      sub: "PUK 24/7",         bg: "var(--color-sos-orange-text)" },
-    { id: "block-gruen",  label: "Jemand zum Reden",      sub: "143",              bg: "var(--color-sos-gruen-text)" },
+    {
+      id: "block-rot",
+      label: "Lebensgefahr",
+      sub: "144 · 117 · 112",
+      bg: "var(--color-sos-rot)",
+    },
+    {
+      id: "block-orange",
+      label: "Psychiatr. Krise",
+      sub: "PUK 24/7",
+      bg: "var(--color-sos-orange-text)",
+    },
+    {
+      id: "block-gruen",
+      label: "Jemand zum Reden",
+      sub: "143",
+      bg: "var(--color-sos-gruen-text)",
+    },
   ] as const;
 
   return (
@@ -55,7 +80,7 @@ function StickyAmpelLeiste() {
       <div className="bg-background/95 backdrop-blur-md border-b border-border/50 shadow-sm">
         <div className="container">
           <div className="flex gap-1.5 py-2">
-            {items.map((item) => (
+            {items.map(item => (
               <button
                 key={item.id}
                 type="button"
@@ -64,8 +89,12 @@ function StickyAmpelLeiste() {
                 className="flex-1 flex flex-col sm:flex-row items-center justify-center gap-0.5 sm:gap-2 px-1.5 sm:px-3 py-2 sm:py-2.5 rounded-lg text-white font-medium text-[10px] sm:text-sm transition-all hover:brightness-90 active:scale-[0.97] shadow-sm min-h-[44px]"
                 style={{ backgroundColor: item.bg }}
               >
-                <span className="font-semibold leading-tight text-center">{item.label}</span>
-                <span className="text-white/80 text-[10px] sm:text-xs leading-tight">{item.sub}</span>
+                <span className="font-semibold leading-tight text-center">
+                  {item.label}
+                </span>
+                <span className="text-white/80 text-[10px] sm:text-xs leading-tight">
+                  {item.sub}
+                </span>
               </button>
             ))}
           </div>
@@ -77,7 +106,17 @@ function StickyAmpelLeiste() {
 
 // ─── Grosse Notruf-Karte (ROT) ───────────────────────────
 
-function NotfallKarte({ nummer, label, hinweis, tel }: { nummer: string; label: string; hinweis: string; tel: string }) {
+function NotfallKarte({
+  nummer,
+  label,
+  hinweis,
+  tel,
+}: {
+  nummer: string;
+  label: string;
+  hinweis: string;
+  tel: string;
+}) {
   return (
     <a
       href={`tel:${tel}`}
@@ -89,7 +128,9 @@ function NotfallKarte({ nummer, label, hinweis, tel }: { nummer: string; label: 
           <Phone className="w-5 h-5 sm:w-6 sm:h-6 text-white" />
         </div>
         <div className="min-w-0">
-          <p className="font-bold text-white text-xl sm:text-2xl leading-none mb-0.5">{nummer}</p>
+          <p className="font-bold text-white text-xl sm:text-2xl leading-none mb-0.5">
+            {nummer}
+          </p>
           <p className="text-white/90 font-semibold text-sm">{label}</p>
           <p className="text-white/70 text-xs leading-snug mt-0.5">{hinweis}</p>
         </div>
@@ -103,7 +144,19 @@ function NotfallKarte({ nummer, label, hinweis, tel }: { nummer: string; label: 
 
 // ─── PUK-Karte (ORANGE) ──────────────────────────────────
 
-function PukKarte({ nummer, label, fuerWen, tel, icon }: { nummer: string; label: string; fuerWen: string; tel: string; icon: React.ReactNode }) {
+function PukKarte({
+  nummer,
+  label,
+  fuerWen,
+  tel,
+  icon,
+}: {
+  nummer: string;
+  label: string;
+  fuerWen: string;
+  tel: string;
+  icon: React.ReactNode;
+}) {
   return (
     <a
       href={`tel:${tel}`}
@@ -115,9 +168,15 @@ function PukKarte({ nummer, label, fuerWen, tel, icon }: { nummer: string; label
           {icon}
         </div>
         <div className="min-w-0">
-          <p className="text-xs font-medium text-sos-orange-text mb-0.5">{fuerWen}</p>
-          <p className="font-bold text-foreground text-lg sm:text-xl leading-none mb-0.5">{nummer}</p>
-          <p className="text-muted-foreground text-xs sm:text-sm leading-snug">{label}</p>
+          <p className="text-xs font-medium text-sos-orange-text mb-0.5">
+            {fuerWen}
+          </p>
+          <p className="font-bold text-foreground text-lg sm:text-xl leading-none mb-0.5">
+            {nummer}
+          </p>
+          <p className="text-muted-foreground text-xs sm:text-sm leading-snug">
+            {label}
+          </p>
         </div>
       </div>
       <div className="flex-shrink-0 w-10 h-10 rounded-full bg-sos-orange-light flex items-center justify-center group-hover:bg-sos-orange-border transition-all">
@@ -129,7 +188,19 @@ function PukKarte({ nummer, label, fuerWen, tel, icon }: { nummer: string; label
 
 // ─── Grüne Karte (Entlastung) ─────────────────────────────
 
-function EntlastungKarte({ nummer, label, hinweis, tel, badge }: { nummer: string; label: string; hinweis: string; tel: string; badge?: string }) {
+function EntlastungKarte({
+  nummer,
+  label,
+  hinweis,
+  tel,
+  badge,
+}: {
+  nummer: string;
+  label: string;
+  hinweis: string;
+  tel: string;
+  badge?: string;
+}) {
   return (
     <a
       href={`tel:${tel}`}
@@ -142,11 +213,19 @@ function EntlastungKarte({ nummer, label, hinweis, tel, badge }: { nummer: strin
         </div>
         <div className="min-w-0">
           {badge && (
-            <span className="inline-block text-[10px] font-semibold text-sos-gruen-text bg-sos-gruen-light rounded px-1.5 py-0.5 mb-0.5">{badge}</span>
+            <span className="inline-block text-[10px] font-semibold text-sos-gruen-text bg-sos-gruen-light rounded px-1.5 py-0.5 mb-0.5">
+              {badge}
+            </span>
           )}
-          <p className="font-bold text-foreground text-lg sm:text-xl leading-none mb-0.5">{nummer}</p>
-          <p className="text-muted-foreground text-xs sm:text-sm font-medium">{label}</p>
-          <p className="text-muted-foreground text-xs leading-snug mt-0.5">{hinweis}</p>
+          <p className="font-bold text-foreground text-lg sm:text-xl leading-none mb-0.5">
+            {nummer}
+          </p>
+          <p className="text-muted-foreground text-xs sm:text-sm font-medium">
+            {label}
+          </p>
+          <p className="text-muted-foreground text-xs leading-snug mt-0.5">
+            {hinweis}
+          </p>
         </div>
       </div>
       <div className="flex-shrink-0 w-10 h-10 rounded-full bg-sos-gruen-light flex items-center justify-center group-hover:bg-sos-gruen-border transition-all">
@@ -164,15 +243,15 @@ export default function Notfall() {
   const rot112 = kontaktByIdStrict("ROT_112");
   const pukKjp = kontaktByIdStrict("GELB_PUK_KJP");
   const pukErw = kontaktByIdStrict("GELB_PUK_ERW");
-  const puk65  = kontaktByIdStrict("GELB_PUK_65");
-  const gruen143   = kontaktByIdStrict("GRUEN_143");
+  const puk65 = kontaktByIdStrict("GELB_PUK_65");
+  const gruen143 = kontaktByIdStrict("GRUEN_143");
   const gruenEltern = kontaktByIdStrict("GRUEN_ELTERN");
-  const gruen147   = kontaktByIdStrict("GRUEN_147");
-  const rot145         = kontaktByIdStrict("ROT_145");
-  const infoAerztefon  = kontaktByIdStrict("INFO_AERZTEFON");
+  const gruen147 = kontaktByIdStrict("GRUEN_147");
+  const rot145 = kontaktByIdStrict("ROT_145");
+  const infoAerztefon = kontaktByIdStrict("INFO_AERZTEFON");
   const infoPukZentrale = kontaktByIdStrict("INFO_PUK_ZENTRALE");
   const infoFachstelle = kontaktByIdStrict("INFO_FACHSTELLE");
-  const infoKiz        = kontaktByIdStrict("INFO_KIZ");
+  const infoKiz = kontaktByIdStrict("INFO_KIZ");
 
   return (
     <Layout>
@@ -195,7 +274,9 @@ export default function Notfall() {
               <div className="w-11 h-11 rounded-xl bg-sos-rot flex items-center justify-center">
                 <AlertTriangle className="w-6 h-6 text-white" />
               </div>
-              <span className="text-sm font-semibold text-sos-rot uppercase tracking-wide">Soforthilfe</span>
+              <span className="text-sm font-semibold text-sos-rot uppercase tracking-wide">
+                Soforthilfe
+              </span>
             </div>
 
             <h1 className="text-3xl md:text-4xl font-bold text-foreground mb-4 leading-tight">
@@ -203,16 +284,26 @@ export default function Notfall() {
             </h1>
 
             <p className="text-base md:text-lg text-muted-foreground leading-relaxed mb-5">
-              Notfallnummern und Anlaufstellen für akute Krisen in der Schweiz – wenn sofortiges Handeln erforderlich ist.
+              Notfallnummern und Anlaufstellen für akute Krisen in der Schweiz –
+              wenn sofortiges Handeln erforderlich ist.
             </p>
-            <p className="text-sm text-muted-foreground mb-5">
-              Regionaler Geltungsbereich: Schweiz (mit Schwerpunkt Kanton Zürich).
+            <p className="inline-flex items-center gap-1.5 text-sm text-muted-foreground mb-5 bg-muted/40 px-3 py-1.5 rounded-full border border-border/50">
+              <Info className="w-3.5 h-3.5 shrink-0" />
+              Gilt für die <strong className="text-foreground">
+                Schweiz
+              </strong>{" "}
+              (Schwerpunkt Kanton Zürich) — nicht für Deutschland oder
+              Österreich.
             </p>
 
             <div className="p-4 rounded-xl bg-sos-amber-wash border border-sos-amber-border">
               <p className="text-sm text-sos-amber-dark leading-snug">
-                <strong>Diese Seite ist für akute Gefahrensituationen.</strong> Für emotionale Krisen ohne akute Gefahr besuchen Sie die Seite{" "}
-                <Link href="/unterstuetzen/krise" className="text-terracotta-mid hover:underline font-semibold">
+                <strong>Diese Seite ist für akute Gefahrensituationen.</strong>{" "}
+                Für emotionale Krisen ohne akute Gefahr besuchen Sie die Seite{" "}
+                <Link
+                  href="/unterstuetzen/krise"
+                  className="text-terracotta-mid hover:underline font-semibold"
+                >
                   «In der Krise unterstützen» →
                 </Link>
               </p>
@@ -228,7 +319,6 @@ export default function Notfall() {
       <section className="py-6 md:py-12 pb-32 sm:pb-12">
         <div className="container">
           <div className="max-w-2xl mx-auto space-y-8">
-
             {/* ─── BLOCK 1: LEBENSGEFAHR (ROT) ─── */}
             <motion.div
               id="block-rot"
@@ -241,10 +331,13 @@ export default function Notfall() {
               <div className="px-5 py-4 sm:px-6 sm:py-5 bg-sos-rot">
                 <div className="flex items-center gap-3 mb-1">
                   <AlertTriangle className="w-6 h-6 text-white flex-shrink-0" />
-                  <h2 className="text-lg sm:text-xl font-bold text-white">Lebensgefahr – sofort handeln</h2>
+                  <h2 className="text-lg sm:text-xl font-bold text-white">
+                    Lebensgefahr – sofort handeln
+                  </h2>
                 </div>
                 <p className="text-white/85 text-sm leading-snug ml-9">
-                  Bei akuter Suizidgefahr, schwerer Selbstverletzung, Gewalt oder unmittelbarer Bedrohung.
+                  Bei akuter Suizidgefahr, schwerer Selbstverletzung, Gewalt
+                  oder unmittelbarer Bedrohung.
                 </p>
               </div>
 
@@ -273,7 +366,11 @@ export default function Notfall() {
               {/* Merksatz */}
               <div className="px-5 py-3 sm:px-6 bg-sos-rot/20 border-t border-white/10">
                 <p className="text-white text-xs sm:text-sm leading-snug">
-                  <strong>Merke:</strong> Bei akuter Selbst- oder Fremdgefährdung zuerst <strong>144 / 117 / 112</strong> wählen. Wenn Sie unsicher sind, lassen Sie sich dort oder durch eine psychiatrische Fachstelle sofort zum weiteren Vorgehen anleiten.
+                  <strong>Merke:</strong> Bei akuter Selbst- oder
+                  Fremdgefährdung zuerst <strong>144 / 117 / 112</strong>{" "}
+                  wählen. Wenn Sie unsicher sind, lassen Sie sich dort oder
+                  durch eine psychiatrische Fachstelle sofort zum weiteren
+                  Vorgehen anleiten.
                 </p>
               </div>
             </motion.div>
@@ -292,10 +389,14 @@ export default function Notfall() {
                   <div className="w-8 h-8 rounded-lg bg-sos-orange flex items-center justify-center flex-shrink-0">
                     <Clock className="w-5 h-5 text-white" />
                   </div>
-                  <h2 className="text-lg sm:text-xl font-bold text-sos-orange-dark">Akute psychiatrische Krise</h2>
+                  <h2 className="text-lg sm:text-xl font-bold text-sos-orange-dark">
+                    Akute psychiatrische Krise
+                  </h2>
                 </div>
                 <p className="text-sos-orange-mid text-sm leading-snug ml-11">
-                  Schwere psychische Krise, starke Eskalation oder massiver Kontrollverlust – aber <strong>keine unmittelbare Lebensgefahr</strong>.
+                  Schwere psychische Krise, starke Eskalation oder massiver
+                  Kontrollverlust – aber{" "}
+                  <strong>keine unmittelbare Lebensgefahr</strong>.
                 </p>
               </div>
 
@@ -310,28 +411,35 @@ export default function Notfall() {
                   label="PUK Erwachsene (24/7)"
                   fuerWen="Erwachsene 18–64 Jahre"
                   tel={pukErw.tel}
-                  icon={<User className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />}
+                  icon={
+                    <User className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />
+                  }
                 />
                 <PukKarte
                   nummer={pukKjp.nummer}
                   label="PUK Kinder & Jugendliche (24/7)"
                   fuerWen="Kinder & Jugendliche bis 18 Jahre"
                   tel={pukKjp.tel}
-                  icon={<Baby className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />}
+                  icon={
+                    <Baby className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />
+                  }
                 />
                 <PukKarte
                   nummer={puk65.nummer}
                   label="PUK Erwachsene ab 65 (24/7)"
                   fuerWen="Erwachsene ab 65 Jahren"
                   tel={puk65.tel}
-                  icon={<Users className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />}
+                  icon={
+                    <Users className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />
+                  }
                 />
               </div>
 
               {/* Hinweis */}
               <div className="px-5 py-3 sm:px-6 bg-sos-orange-wash border-t border-sos-orange-light">
                 <p className="text-sos-orange-mid text-xs sm:text-sm leading-snug">
-                  Am Telefon erfolgt eine kurze Einschätzung, was jetzt am besten hilft.
+                  Am Telefon erfolgt eine kurze Einschätzung, was jetzt am
+                  besten hilft.
                 </p>
               </div>
             </motion.div>
@@ -350,10 +458,14 @@ export default function Notfall() {
                   <div className="w-8 h-8 rounded-lg bg-sos-gruen flex items-center justify-center flex-shrink-0">
                     <Heart className="w-5 h-5 text-white" />
                   </div>
-                  <h2 className="text-lg sm:text-xl font-bold text-sos-gruen-dark">Jemand zum Reden / Entlastung</h2>
+                  <h2 className="text-lg sm:text-xl font-bold text-sos-gruen-dark">
+                    Jemand zum Reden / Entlastung
+                  </h2>
                 </div>
                 <p className="text-sos-gruen-mid text-sm leading-snug ml-11">
-                  Für Gespräch, Entlastung und Orientierung – <strong>kein Einsatz vor Ort</strong>, keine unmittelbare Gefahr.
+                  Für Gespräch, Entlastung und Orientierung –{" "}
+                  <strong>kein Einsatz vor Ort</strong>, keine unmittelbare
+                  Gefahr.
                 </p>
               </div>
 
@@ -385,7 +497,8 @@ export default function Notfall() {
               {/* Hinweis */}
               <div className="px-5 py-3 sm:px-6 bg-sos-gruen-wash border-t border-sos-gruen-light">
                 <p className="text-sos-gruen-mid text-xs sm:text-sm leading-snug">
-                  <strong>Bei akuter Gefahr:</strong> Immer zuerst <strong>144 / 117 / 112</strong> rufen.
+                  <strong>Bei akuter Gefahr:</strong> Immer zuerst{" "}
+                  <strong>144 / 117 / 112</strong> rufen.
                 </p>
               </div>
             </motion.div>
@@ -403,7 +516,9 @@ export default function Notfall() {
                   <div className="w-8 h-8 rounded-lg bg-sos-lila flex items-center justify-center flex-shrink-0">
                     <Pill className="w-5 h-5 text-white" />
                   </div>
-                  <h2 className="text-base sm:text-lg font-bold text-sos-lila-dark">Spezialfall: Vergiftung</h2>
+                  <h2 className="text-base sm:text-lg font-bold text-sos-lila-dark">
+                    Spezialfall: Vergiftung
+                  </h2>
                 </div>
               </div>
 
@@ -418,9 +533,15 @@ export default function Notfall() {
                       <Pill className="w-5 h-5 text-sos-lila-text" />
                     </div>
                     <div>
-                      <p className="font-bold text-foreground text-xl leading-none mb-0.5">{rot145.nummer}</p>
-                      <p className="text-muted-foreground text-sm font-medium">{rot145.label}</p>
-                      <p className="text-muted-foreground text-xs mt-0.5">{rot145.hinweis}</p>
+                      <p className="font-bold text-foreground text-xl leading-none mb-0.5">
+                        {rot145.nummer}
+                      </p>
+                      <p className="text-muted-foreground text-sm font-medium">
+                        {rot145.label}
+                      </p>
+                      <p className="text-muted-foreground text-xs mt-0.5">
+                        {rot145.hinweis}
+                      </p>
                     </div>
                   </div>
                   <div className="flex-shrink-0 w-10 h-10 rounded-full bg-sos-lila-light flex items-center justify-center group-hover:bg-sos-lila-border transition-all">
@@ -441,9 +562,13 @@ export default function Notfall() {
               <div className="px-5 py-3 sm:px-6 sm:py-4 bg-muted/40 border-b border-border/50">
                 <div className="flex items-center gap-2">
                   <Info className="w-5 h-5 text-muted-foreground" />
-                  <h2 className="text-sm sm:text-base font-normal text-muted-foreground">Weitere Kontakte</h2>
+                  <h2 className="text-sm sm:text-base font-normal text-muted-foreground">
+                    Weitere Kontakte
+                  </h2>
                 </div>
-                <p className="text-xs text-muted-foreground mt-0.5 ml-7">Allgemeine Beratung und Auskunft – nicht für akute Notfälle</p>
+                <p className="text-xs text-muted-foreground mt-0.5 ml-7">
+                  Allgemeine Beratung und Auskunft – nicht für akute Notfälle
+                </p>
               </div>
 
               <div className="px-4 py-4 sm:px-5 space-y-3 bg-background">
@@ -454,9 +579,15 @@ export default function Notfall() {
                   aria-label={`${infoAerztefon.label} anrufen: ${infoAerztefon.nummer}`}
                 >
                   <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">{infoAerztefon.nummer}</p>
-                    <p className="text-muted-foreground text-xs">{infoAerztefon.label}</p>
-                    <p className="text-muted-foreground text-xs">{infoAerztefon.hinweis}</p>
+                    <p className="font-semibold text-foreground text-sm">
+                      {infoAerztefon.nummer}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {infoAerztefon.label}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {infoAerztefon.hinweis}
+                    </p>
                   </div>
                   <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
                     <Phone className="w-4 h-4 text-muted-foreground" />
@@ -470,9 +601,15 @@ export default function Notfall() {
                   aria-label={`${infoPukZentrale.label} anrufen: ${infoPukZentrale.nummer}`}
                 >
                   <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">{infoPukZentrale.nummer}</p>
-                    <p className="text-muted-foreground text-xs">{infoPukZentrale.label}</p>
-                    <p className="text-muted-foreground text-xs">Allgemeine Auskunft – kein Notfalldienst</p>
+                    <p className="font-semibold text-foreground text-sm">
+                      {infoPukZentrale.nummer}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {infoPukZentrale.label}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      Allgemeine Auskunft – kein Notfalldienst
+                    </p>
                   </div>
                   <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
                     <Phone className="w-4 h-4 text-muted-foreground" />
@@ -486,9 +623,15 @@ export default function Notfall() {
                   aria-label={`${infoFachstelle.label} anrufen: ${infoFachstelle.nummer}`}
                 >
                   <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">{infoFachstelle.nummer}</p>
-                    <p className="text-muted-foreground text-xs">{infoFachstelle.label}</p>
-                    <p className="text-muted-foreground text-xs">{infoFachstelle.hinweis}</p>
+                    <p className="font-semibold text-foreground text-sm">
+                      {infoFachstelle.nummer}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {infoFachstelle.label}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {infoFachstelle.hinweis}
+                    </p>
                   </div>
                   <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
                     <Phone className="w-4 h-4 text-muted-foreground" />
@@ -502,9 +645,15 @@ export default function Notfall() {
                   aria-label={`${infoKiz.label} anrufen: ${infoKiz.nummer}`}
                 >
                   <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">{infoKiz.nummer}</p>
-                    <p className="text-muted-foreground text-xs">{infoKiz.label}</p>
-                    <p className="text-muted-foreground text-xs">{infoKiz.hinweis}</p>
+                    <p className="font-semibold text-foreground text-sm">
+                      {infoKiz.nummer}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {infoKiz.label}
+                    </p>
+                    <p className="text-muted-foreground text-xs">
+                      {infoKiz.hinweis}
+                    </p>
                   </div>
                   <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
                     <Phone className="w-4 h-4 text-muted-foreground" />
@@ -529,35 +678,45 @@ export default function Notfall() {
                   href="/wegweiser"
                   className="flex items-center justify-between gap-3 p-3 rounded-lg bg-background border border-[var(--color-sage-dark)]/30 hover:border-[var(--color-sage-dark)]/50 hover:shadow-sm transition-all group"
                 >
-                  <span className="text-sm text-foreground font-medium">Situations-Wegweiser: «Was tun wenn…»</span>
+                  <span className="text-sm text-foreground font-medium">
+                    Situations-Wegweiser: «Was tun wenn…»
+                  </span>
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-[var(--color-sage-dark)] transition-colors" />
                 </Link>
                 <Link
                   href="/notfallkarte"
                   className="flex items-center justify-between gap-3 p-3 rounded-lg bg-background border border-[var(--color-sos-rot)]/30 hover:border-[var(--color-sos-rot)]/50 hover:shadow-sm transition-all group"
                 >
-                  <span className="text-sm text-foreground font-medium">Persönliche Notfallkarte erstellen</span>
+                  <span className="text-sm text-foreground font-medium">
+                    Persönliche Notfallkarte erstellen
+                  </span>
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-[var(--color-sos-rot)] transition-colors" />
                 </Link>
                 <Link
                   href="/unterstuetzen/krise"
                   className="flex items-center justify-between gap-3 p-3 rounded-lg bg-background border border-border/50 hover:border-terracotta/40 hover:shadow-sm transition-all group"
                 >
-                  <span className="text-sm text-foreground">Deeskalation und Krisenbegleitung</span>
+                  <span className="text-sm text-foreground">
+                    Deeskalation und Krisenbegleitung
+                  </span>
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-terracotta-mid transition-colors" />
                 </Link>
                 <Link
                   href="/selbstfuersorge"
                   className="flex items-center justify-between gap-3 p-3 rounded-lg bg-background border border-border/50 hover:border-terracotta/40 hover:shadow-sm transition-all group"
                 >
-                  <span className="text-sm text-foreground">Selbstfürsorge für Angehörige</span>
+                  <span className="text-sm text-foreground">
+                    Selbstfürsorge für Angehörige
+                  </span>
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-terracotta-mid transition-colors" />
                 </Link>
                 <Link
                   href="/beratung"
                   className="flex items-center justify-between gap-3 p-3 rounded-lg bg-background border border-border/50 hover:border-terracotta/40 hover:shadow-sm transition-all group"
                 >
-                  <span className="text-sm text-foreground">Beratung und Selbsthilfegruppen</span>
+                  <span className="text-sm text-foreground">
+                    Beratung und Selbsthilfegruppen
+                  </span>
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-terracotta-mid transition-colors" />
                 </Link>
               </div>
@@ -565,10 +724,11 @@ export default function Notfall() {
 
             <div className="rounded-xl border border-border/60 bg-muted/20 p-4">
               <p className="text-xs text-muted-foreground leading-relaxed">
-                Diese Informationen ersetzen keine medizinische oder rechtliche Beratung. In akuten Gefahrensituationen zählt das sofortige Einbeziehen von Notruf und Fachpersonen.
+                Diese Informationen ersetzen keine medizinische oder rechtliche
+                Beratung. In akuten Gefahrensituationen zählt das sofortige
+                Einbeziehen von Notruf und Fachpersonen.
               </p>
             </div>
-
           </div>
         </div>
       </section>


### PR DESCRIPTION
Drei kleine aber sinnvolle Fixes.

## Soforthilfe: Regionshinweis als Info-Badge
Bisheriger Text war ein unauffälliges `text-muted-foreground`-Paragraph. Jetzt: Pill-Badge mit Info-Icon + explizite Nennung 'nicht für Deutschland oder Österreich'. Verhindert, dass DE/AT-Besucher Schweizer Notfallnummern anrufen.

## Notfallkarte: Storage-Warnung bei blockiertem localStorage
- `isStorageAvailable()` prüft einmalig beim Laden
- `saveData()` gibt jetzt boolean zurück
- Bei geblocketem Storage (privater Modus, iOS Safari): amber Warning-Banner mit Hinweis aufs Drucken
- Bisher: stumme Fehler, Daten wurden verloren ohne Rückmeldung

## Fachstelle: LastVerifiedBadge
Import + Badge (24.03.2026) im Hero. Konsistent mit Selbsthilfegruppen-Seite.