### PR TITLE
fix: R1 – Nav-Bug UnterstuetzenAlltag (Weiter → Krise)

### DIFF
--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -672,9 +672,9 @@ export default function UnterstuetzenAlltag() {
               <Link href="/unterstuetzen/uebersicht">
                 <Button variant="ghost">← Wie kann ich helfen?</Button>
               </Link>
-              <Link href="/unterstuetzen/therapie">
+              <Link href="/unterstuetzen/krise">
                 <Button className="bg-sage-dark hover:bg-sage-mid text-white">
-                  Weiter: Therapie begleiten
+                  Weiter: Krisen begleiten
                   <ArrowRight className="w-4 h-4 ml-2" />
                 </Button>
               </Link>


### PR DESCRIPTION
## Was

Weiter-Button auf UnterstuetzenAlltag zeigte fälschlicherweise auf `/unterstuetzen/therapie` statt `/unterstuetzen/krise`.

## Warum

Logische Reihenfolge des Unterstützen-Moduls: **Alltag → Krise → Therapie**.
Der Sprung Alltag → Therapie übersprang die Krise-Seite vollständig.

## Hinweis zu Krise

UnterstuetzenKrise hat bereits einen Breadcrumb-Link `← Zurück zur Übersicht` → kein weiterer Rückverweis nötig.