### PR TITLE
refactor: R2 – Grenzen vs. Selbstfürsorge klar unterscheiden

### DIFF
--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -59,13 +59,28 @@ export default function Grenzen() {
               Grenzen setzen
             </h1>
 
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
+            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-5">
               Grenzen sind kein Gegenpol zu Mitgefühl, sondern oft seine
               Voraussetzung. Sie schützen Ihre Integrität, machen Beziehungen
               berechenbarer und verhindern, dass Unterstützung in Selbstaufgabe
               kippt. Gleichzeitig können Grenzen Spannungen auslösen. Genau
               deshalb brauchen sie Klarheit, Wiederholbarkeit und Konsequenz.
             </p>
+
+            <Card className="bg-slate-50 border-border/40">
+              <CardContent className="p-4 text-sm text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Diese Seite:</strong> Was
+                Sie gegenüber anderen kommunizieren und einhalten — Klarheit
+                nach aussen.{" "}
+                <Link
+                  href="/selbstfuersorge"
+                  className="text-sage-dark underline underline-offset-2 hover:text-sage-mid"
+                >
+                  Selbstfürsorge →
+                </Link>{" "}
+                zeigt, wie Sie sich selbst stabilisieren und regenerieren.
+              </CardContent>
+            </Card>
           </motion.div>
         </div>
       </section>
@@ -141,7 +156,15 @@ export default function Grenzen() {
                 <CardContent className="p-5">
                   <p className="text-foreground leading-relaxed">
                     Grenzen beginnen oft nicht mit dem Satz an den anderen,
-                    sondern mit dem ernsten Wahrnehmen Ihrer eigenen Belastung.
+                    sondern mit dem ernsten Wahrnehmen Ihrer eigenen Belastung.{" "}
+                    <Link
+                      href="/selbstfuersorge"
+                      className="text-sage-dark underline underline-offset-2 hover:text-sage-mid"
+                    >
+                      Selbstfürsorge →
+                    </Link>{" "}
+                    zeigt, was Sie tun können, wenn Sie merken, dass Sie sich
+                    selbst vernachlässigt haben.
                   </p>
                 </CardContent>
               </Card>

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -243,6 +243,22 @@ export default function Selbstfuersorge() {
               Sie handlungsfähig und innerlich beweglich bleiben.
             </p>
 
+            <Card className="bg-slate-50 border-border/40 mb-5">
+              <CardContent className="p-4 text-sm text-muted-foreground leading-relaxed">
+                <strong className="text-foreground">Diese Seite:</strong> Was
+                Sie für sich tun — Erholung, Stabilisierung, innere
+                Regeneration.{" "}
+                <Link
+                  href="/grenzen"
+                  className="text-sage-dark underline underline-offset-2 hover:text-sage-mid"
+                >
+                  Grenzen setzen →
+                </Link>{" "}
+                zeigt, wie Sie Klarheit gegenüber anderen kommunizieren und
+                einhalten.
+              </CardContent>
+            </Card>
+
             <Card className="bg-sage-lighter/20 border-sage-mid">
               <CardContent className="p-5">
                 <p className="text-foreground leading-relaxed italic">
@@ -400,10 +416,21 @@ export default function Selbstfuersorge() {
 
               <Card className="mt-6 bg-sage-mid/10 border-sage-mid">
                 <CardContent className="p-5">
-                  <p className="text-foreground font-medium">
+                  <p className="text-foreground font-medium mb-2">
                     Wenn Sie mehrere dieser Warnsignale bei sich bemerken, ist
                     es Zeit zu handeln. Sprechen Sie mit Ihrem Hausarzt oder
                     suchen Sie professionelle Unterstützung.
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Merken Sie ausserdem, dass Sie Andere nicht mehr klar auf
+                    Distanz halten können?{" "}
+                    <Link
+                      href="/grenzen"
+                      className="text-sage-dark underline underline-offset-2 hover:text-sage-mid"
+                    >
+                      Grenzen setzen →
+                    </Link>{" "}
+                    zeigt, wie Sie das konkret kommunizieren.
                   </p>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Was

Disambiguierung der zwei am stärksten überlappenden Seiten.

## Problem

Beide Seiten behandeln "Schutz vor Überlastung" — ohne je zu sagen, was sie unterscheidet. Nutzer wissen nicht, welche Seite für ihr Anliegen gilt.

## Lösung

| Seite | Reframe | Querlink |
|---|---|---|
| **Grenzen** | Hero: *"Was Sie gegenüber anderen kommunizieren"* | → /selbstfuersorge in Hero + warnsignale |
| **Selbstfürsorge** | Hero: *"Was Sie für sich tun — Erholung, Regeneration"* | → /grenzen in Hero + warnsignale |

Jede Seite hat nun am Anfang eine Abgrenzungs-Karte, die erklärt, was sie ist — und was die andere Seite ist.

## Bewusst ausgelassen

Interaktive Komponenten (Atemübung, GroundingTimer) auslagern → separates Ticket.