### PR TITLE
P0: Strukturfixes – FAQ-Parallelstruktur, Krise-Grenze, Hub-Duplikat

### DIFF
--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -64,8 +64,8 @@ export default function FAQ() {
         {
           question: "Ist Borderline heilbar?",
           answer:
-            "Die Prognose ist deutlich besser, als lange angenommen wurde. Langzeitstudien zeigen, dass 85–93% der Betroffenen nach 10 Jahren eine symptomatische Remission erreichen – das heisst, sie erfüllen die diagnostischen Kriterien nicht mehr. Etwa 50% erreichen eine weitergehende Genesung mit stabilerer sozialer und beruflicher Funktionsfähigkeit. Gleichzeitig verläuft Entwicklung selten geradlinig: Fortschritte, Rückschläge und belastende Phasen können sich abwechseln. Therapie kann diesen Prozess deutlich unterstützen, aber nicht vollständig planbar machen.",
-          links: [{ text: "Zur Genesung-Seite", url: "/genesung" }],
+            "Die Prognose ist deutlich besser, als lange angenommen wurde – die meisten Betroffenen erreichen im Verlauf eine Remission. Entwicklung verläuft selten geradlinig, Rückschläge gehören dazu. Therapie unterstützt den Prozess, macht ihn aber nicht vollständig planbar.",
+          links: [{ text: "Verlauf & Prognose im Detail", url: "/genesung" }],
         },
         {
           question: "Ist Borderline erblich? Bin ich schuld?",
@@ -125,7 +125,7 @@ export default function FAQ() {
         {
           question: "Wann ist eine Einweisung nötig?",
           answer:
-            "Eine psychiatrische Einweisung (freiwillig oder unfreiwillig) ist angezeigt bei: akuter Suizidalität mit konkreten Plänen oder Mitteln, schwerer Selbstverletzung, die medizinische Versorgung erfordert, Fremdgefährdung, oder wenn die Person so dekompensiert ist, dass sie sich nicht mehr selbst versorgen kann. In der Schweiz kann eine fürsorgerische Unterbringung (FU) durch einen Arzt angeordnet werden, wenn eine ernsthafte Selbst- oder Fremdgefährdung vorliegt. Rufen Sie im Zweifelsfall den psychiatrischen Notdienst an – die können die Situation einschätzen.",
+            "Bei akuter Suizidalität mit konkreten Plänen oder Mitteln, schwerer Selbstverletzung mit Versorgungsbedarf, Fremdgefährdung oder völliger Dekompensation. In der Schweiz kann eine fürsorgerische Unterbringung (FU) durch einen Arzt angeordnet werden. Im Zweifelsfall: psychiatrischen Notdienst anrufen – die können die Situation einschätzen.",
           links: [{ text: "Notfallnummern", url: "/soforthilfe" }],
         },
         {
@@ -173,7 +173,7 @@ export default function FAQ() {
         {
           question: "Welche Therapie ist am besten?",
           answer:
-            "Für Borderline gibt es mehrere evidenzbasierte Therapien: DBT (Dialektisch-Behaviorale Therapie) ist sehr gut erforscht und häufig besonders wirksam bei Selbstverletzung und Suizidalität. MBT (Mentalisierungsbasierte Therapie) fokussiert auf das Verstehen eigener und fremder Gedanken/Gefühle. Schematherapie arbeitet an frühen Prägungen und Beziehungsmustern. TFP (Übertragungsfokussierte Therapie) nutzt die therapeutische Beziehung zur Veränderung. Alle können wirksam sein – wichtiger als die Methode ist oft die Passung zwischen Therapeut und Patient.",
+            "Es gibt mehrere gut erforschte Methoden (DBT, MBT, Schematherapie, TFP). Alle können wirksam sein – wichtiger als die Methode ist oft die Passung zwischen Therapeut und Patient.",
           links: [
             { text: "Therapieformen erklärt", url: "/unterstuetzen/therapie" },
           ],

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -241,6 +241,15 @@ export default function Kommunizieren() {
                     </ol>
                   </CardContent>
                 </Card>
+                <p className="text-sm text-muted-foreground">
+                  Wird aus dem Gespräch eine akute Krise?{" "}
+                  <Link
+                    href="/unterstuetzen/krise"
+                    className="text-sage-dark underline underline-offset-2 hover:text-sage-mid"
+                  >
+                    Krisenbegleitung →
+                  </Link>
+                </p>
               </div>
             </ContentSection>
 

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -14,7 +14,6 @@ import {
   Eye,
   Heart,
   Lightbulb,
-  Shield,
   Users,
   XCircle,
   CheckCircle2,
@@ -230,31 +229,21 @@ export default function UnterstuetzenUebersicht() {
               </div>
             </div>
 
-            <ContentSection
-              title="Unterstützung braucht Grenzen"
-              icon={<Shield className="w-7 h-7 text-sage-mid" />}
-              id="grenzen"
-              preview="Ohne Grenzen wird Unterstützung oft unklar, erschöpfend oder inkonsistent. Grenzen sind nicht das Gegenteil von Mitgefühl, sondern oft seine Voraussetzung."
-            >
-              <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
-                  Unterstützung wird auf Dauer nur tragfähig, wenn sie begrenzt
-                  bleibt. Wer aus Angst oder Schuld jede Grenze aufweicht,
-                  beruhigt eine Situation kurzfristig vielleicht, macht sie
-                  langfristig aber oft unklarer und krisenanfälliger.
+            <Card className="border-sage-mid/40 bg-sage-wash/20">
+              <CardContent className="p-5 flex items-start gap-3">
+                <span className="text-sage-mid mt-0.5">→</span>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  Ohne Grenzen wird Unterstützung oft unklar, erschöpfend oder
+                  inkonsistent. Wie Sie klare Grenzen setzen und halten:{" "}
+                  <Link
+                    href="/grenzen"
+                    className="text-sage-dark underline underline-offset-2 hover:text-sage-mid font-medium"
+                  >
+                    Grenzen setzen →
+                  </Link>
                 </p>
-                <Card className="bg-cream border-border/50">
-                  <CardContent className="p-5">
-                    <p className="text-foreground leading-relaxed">
-                      Grenzen sind kein Liebesentzug. Sie schaffen
-                      Berechenbarkeit, schützen Ihre Integrität und entlasten
-                      Beziehungen von der Erwartung, dass ein Mensch alles
-                      halten müsse.
-                    </p>
-                  </CardContent>
-                </Card>
-              </div>
-            </ContentSection>
+              </CardContent>
+            </Card>
 
             <ContentSection
               title="Wenn mehrere Angehörige beteiligt sind"


### PR DESCRIPTION
## P0-1 · FAQ als Parallelstruktur

Drei FAQ-Antworten haben bisher denselben Inhalt wie die Hauptseiten vollständig repliziert:

| Frage | Vorher | Nachher |
|-------|--------|---------|
| Ist Borderline heilbar? | 5 Sätze mit Zanarini-Statistiken | 3 Sätze Kernaussage + Link /genesung |
| Welche Therapie ist am besten? | 5 Sätze DBT/MBT/Schema/TFP | 2 Sätze + Link /unterstuetzen/therapie |
| Wann ist eine Einweisung nötig? | 3 Sätze FU-Kriterien | 2 Sätze + Link /soforthilfe |

## P0-2 · Kommunizieren ↔ UnterstuetzenKrise

Explizite Grenze zwischen Gesprächsführung und Krisenprotokoll: Am Ende von 'Wenn Gespräche kippen' jetzt ein Übergangslink:
> Wird aus dem Gespräch eine akute Krise? → **Krisenbegleitung**

## P0-3 · UnterstuetzenUebersicht Hub-Duplikat

ContentSection 'Unterstützung braucht Grenzen' entfernt – Inhalt war direktes Duplikat des Grenzen.tsx-Heros. Ersetzt durch kompakten Link-Hinweis.

## QS
- ESLint: ✅ 0 Warnings
- Build: ✅ erfolgreich
- Shield-Icon aus Import bereinigt