### PR TITLE
P2: structural polish – 5 targeted fixes

### DIFF
--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -44,7 +44,7 @@ function GenesungInfografiken() {
 
   return (
     <ContentSection
-      title="Genesung auf einen Blick"
+      title="Materialien & Infografiken"
       icon={<ImageIcon className="w-6 h-6 text-sage-dark" />}
       id="infografiken"
       preview="Vertiefende Materialien zu Verlauf, Hoffnung, Rückschritten und der Rolle von Angehörigen."

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -70,11 +70,23 @@ export default function Home() {
         {/* Geometrische Kreise (SA-Pattern) */}
         <div
           className="absolute rounded-full"
-          style={{ top: '-60px', right: '-60px', width: '300px', height: '300px', background: 'rgba(82, 150, 160, 0.12)' }}
+          style={{
+            top: "-60px",
+            right: "-60px",
+            width: "300px",
+            height: "300px",
+            background: "rgba(82, 150, 160, 0.12)",
+          }}
         />
         <div
           className="absolute rounded-full"
-          style={{ bottom: '-40px', left: '30%', width: '200px', height: '200px', background: 'rgba(180, 83, 9, 0.08)' }}
+          style={{
+            bottom: "-40px",
+            left: "30%",
+            width: "200px",
+            height: "200px",
+            background: "rgba(180, 83, 9, 0.08)",
+          }}
         />
 
         <div className="container relative z-10 py-12 md:py-14 lg:py-16">
@@ -129,7 +141,9 @@ export default function Home() {
               >
                 <Phone className="w-4 h-4" />
                 <span>Akute Krise? Soforthilfe</span>
-                <span className="group-hover:translate-x-1 transition-transform">→</span>
+                <span className="group-hover:translate-x-1 transition-transform">
+                  →
+                </span>
               </Link>
             </motion.div>
           </div>
@@ -196,7 +210,10 @@ export default function Home() {
                           className="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0"
                           style={{ backgroundColor: item.iconBg }}
                         >
-                          <Icon className="w-[18px] h-[18px]" style={{ color: item.color }} />
+                          <Icon
+                            className="w-[18px] h-[18px]"
+                            style={{ color: item.color }}
+                          />
                         </div>
                         <div>
                           <h3 className="font-semibold text-foreground text-sm mb-1">
@@ -232,9 +249,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section
-        className="py-8 md:py-12 bg-cream"
-      >
+      <section className="py-8 md:py-12 bg-cream">
         <div className="container">
           <div className="max-w-5xl mx-auto">
             <motion.div
@@ -270,45 +285,9 @@ export default function Home() {
         </div>
       </section>
 
-      <section
-        className="py-8 md:py-10"
-      >
+      <section className="py-8 md:py-10">
         <div className="container">
-          <div className="max-w-5xl mx-auto grid md:grid-cols-2 gap-4">
-            <Card className="border-border/50">
-              <CardContent className="p-5">
-                <h2 className="text-xl font-normal text-foreground mb-2">
-                  Kernwege
-                </h2>
-                <p className="text-sm text-muted-foreground mb-3">
-                  Wenn Sie nicht über die Lage-Karten einsteigen möchten:
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  {[
-                    "/verstehen",
-                    "/unterstuetzen/uebersicht",
-                    "/kommunizieren",
-                    "/grenzen",
-                    "/selbstfuersorge",
-                  ].map(href => (
-                    <Link
-                      key={href}
-                      href={href}
-                      className="text-sm px-3 py-1.5 rounded-full bg-muted text-foreground hover:bg-muted/70 transition-colors"
-                    >
-                      {{
-                        "/verstehen": "Verstehen",
-                        "/unterstuetzen/uebersicht": "Unterstützen",
-                        "/kommunizieren": "Kommunizieren",
-                        "/grenzen": "Grenzen",
-                        "/selbstfuersorge": "Selbstfürsorge",
-                      }[href] ?? href}
-                    </Link>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-
+          <div className="max-w-2xl mx-auto">
             <Card className="border-border/50 bg-sand-muted/40">
               <CardContent className="p-5">
                 <h2 className="text-xl font-normal text-foreground mb-2">

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -701,15 +701,6 @@ export default function Notfall() {
                   <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-[var(--color-sage-dark)] transition-colors" />
                 </Link>
                 <Link
-                  href="/notfallkarte"
-                  className="flex items-center justify-between gap-3 p-3 rounded-lg bg-background border border-[var(--color-sos-rot)]/30 hover:border-[var(--color-sos-rot)]/50 hover:shadow-sm transition-all group"
-                >
-                  <span className="text-sm text-foreground font-medium">
-                    Persönliche Notfallkarte erstellen
-                  </span>
-                  <ChevronRight className="w-4 h-4 text-muted-foreground group-hover:text-[var(--color-sos-rot)] transition-colors" />
-                </Link>
-                <Link
                   href="/unterstuetzen/krise"
                   className="flex items-center justify-between gap-3 p-3 rounded-lg bg-background border border-border/50 hover:border-terracotta/40 hover:shadow-sm transition-all group"
                 >

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -474,7 +474,8 @@ export default function Verstehen() {
               title="Diagnostischer Überblick"
               icon={<BookOpen className="w-7 h-7 text-sage-dark" />}
               id="diagnostischer-ueberblick"
-              preview="Die diagnostische Perspektive kann hilfreich sein, sollte aber die Beziehungsperspektive nicht dominieren."
+              defaultOpen={false}
+              preview="Für alle, die auch die klinische Perspektive kennen möchten: DSM-Merkmale und Entstehungshintergründe im Überblick."
             >
               <div className="space-y-5">
                 <p className="text-muted-foreground leading-relaxed">

--- a/client/src/pages/Wegweiser.tsx
+++ b/client/src/pages/Wegweiser.tsx
@@ -104,9 +104,9 @@ export default function Wegweiser() {
                     sub: "Persönliche Karte erstellen",
                   },
                   {
-                    href: "/kommunizieren",
-                    label: "Kommunizieren",
-                    sub: "SET, DEAR MAN und mehr",
+                    href: "/selbstfuersorge",
+                    label: "Selbstfürsorge",
+                    sub: "Strategien für die Zeit danach",
                   },
                 ].map(item => (
                   <Link


### PR DESCRIPTION
## Änderungen

- **Verstehen**: Diagnostischer Überblick `defaultOpen={false}` — signalisiert als optionaler Anhang
- **Home**: Kernwege-Chips-Card entfernt, Materialien-Card vollbreit
- **Wegweiser**: Link «Kommunizieren» durch «Selbstfürsorge» ersetzt in weiterführende Links
- **Soforthilfe**: Doppelter Notfallkarte-Hinweis bereinigt — Bottom-Card entfernt, Hero-Hinweis bleibt
- **Genesung**: Abschnitt umbenannt von «Genesung auf einen Blick» → «Materialien & Infografiken»

P1-2 (Selbstfuersorge letzte Sections): kein Handlungsbedarf — ContentSection defaults bereits auf `defaultOpen=false`.