### PR TITLE
refactor P1: consolidate Soforthilfe card components

### DIFF
--- a/client/src/components/interactive/KommunikationsUebung.tsx
+++ b/client/src/components/interactive/KommunikationsUebung.tsx
@@ -127,7 +127,8 @@ const SCENARIOS: Scenario[] = [
     technique: "DEAR",
     context:
       "Ihr Angehöriger hat zum dritten Mal einen gemeinsamen Termin kurzfristig abgesagt. Sie möchten das Thema mit DEAR MAN ansprechen: Describe, Express, Assert, Reinforce.",
-    statement: "Sie bereiten ein ruhiges Gespräch vor. Welche Formulierung nutzen Sie?",
+    statement:
+      "Sie bereiten ein ruhiges Gespräch vor. Welche Formulierung nutzen Sie?",
     options: [
       {
         id: "a",
@@ -297,8 +298,30 @@ const TECHNIQUE_META: Record<
   },
 };
 
-function groupByTechnique(scenarios: Scenario[]): Record<Technique, Scenario[]> {
-  const grouped: Record<Technique, Scenario[]> = { SET: [], DEAR: [], Validierung: [] };
+const TECHNIQUE_STEPS: Partial<
+  Record<Technique, { letter: string; label: string; desc: string }[]>
+> = {
+  SET: [
+    { letter: "S", label: "Support", desc: "Unterstützung zeigen" },
+    { letter: "E", label: "Empathie", desc: "Gefühle anerkennen" },
+    { letter: "T", label: "Truth", desc: "Sachliche Klarheit" },
+  ],
+  DEAR: [
+    { letter: "D", label: "Describe", desc: "Situation beschreiben" },
+    { letter: "E", label: "Express", desc: "Gefühl ausdrücken" },
+    { letter: "A", label: "Assert", desc: "Wunsch benennen" },
+    { letter: "R", label: "Reinforce", desc: "Positive Folge" },
+  ],
+};
+
+function groupByTechnique(
+  scenarios: Scenario[]
+): Record<Technique, Scenario[]> {
+  const grouped: Record<Technique, Scenario[]> = {
+    SET: [],
+    DEAR: [],
+    Validierung: [],
+  };
   for (const s of scenarios) grouped[s.technique].push(s);
   return grouped;
 }
@@ -316,7 +339,7 @@ function ScenarioCard({
   const [revealed, setRevealed] = useState(false);
   const meta = TECHNIQUE_META[scenario.technique];
 
-  const selectedOption = scenario.options.find((o) => o.id === selectedId);
+  const selectedOption = scenario.options.find(o => o.id === selectedId);
 
   const handleSelect = useCallback(
     (optionId: string) => {
@@ -324,7 +347,7 @@ function ScenarioCard({
       setSelectedId(optionId);
       setRevealed(true);
     },
-    [revealed],
+    [revealed]
   );
 
   const handleReset = useCallback(() => {
@@ -342,7 +365,10 @@ function ScenarioCard({
         <div className="flex items-center gap-2 mb-2">
           <span
             className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold"
-            style={{ color: meta.color, backgroundColor: "rgba(255,255,255,0.7)" }}
+            style={{
+              color: meta.color,
+              backgroundColor: "rgba(255,255,255,0.7)",
+            }}
           >
             {meta.icon}
             {meta.label}
@@ -374,11 +400,12 @@ function ScenarioCard({
           <p className="text-sm font-medium text-foreground">
             Wie reagieren Sie?
           </p>
-          {scenario.options.map((option) => {
+          {scenario.options.map(option => {
             const isSelected = selectedId === option.id;
             const showResult = revealed;
 
-            let borderClass = "border-border/60 hover:border-[var(--color-sage-dark)]/40";
+            let borderClass =
+              "border-border/60 hover:border-[var(--color-sage-dark)]/40";
             let bgClass = "bg-background hover:bg-muted/30";
 
             if (showResult && isSelected && option.correct) {
@@ -399,7 +426,9 @@ function ScenarioCard({
                 onClick={() => handleSelect(option.id)}
                 disabled={revealed}
                 className={`w-full text-left p-4 rounded-xl border ${borderClass} ${bgClass} transition-all ${
-                  !revealed ? "cursor-pointer active:scale-[0.99]" : "cursor-default"
+                  !revealed
+                    ? "cursor-pointer active:scale-[0.99]"
+                    : "cursor-default"
                 }`}
               >
                 <div className="flex items-start gap-3">
@@ -464,7 +493,7 @@ function ScenarioCard({
                   Bessere Antwort:
                 </p>
                 <p className="text-sm text-green-700 leading-relaxed">
-                  {scenario.options.find((o) => o.correct)?.feedback}
+                  {scenario.options.find(o => o.correct)?.feedback}
                 </p>
               </div>
             </motion.div>
@@ -488,7 +517,10 @@ function ScenarioCard({
                 }}
               >
                 <p className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
-                  <Lightbulb className="w-4 h-4" style={{ color: meta.color }} />
+                  <Lightbulb
+                    className="w-4 h-4"
+                    style={{ color: meta.color }}
+                  />
                   Merke
                 </p>
                 <p className="text-sm text-muted-foreground leading-relaxed">
@@ -539,12 +571,54 @@ function TechniqueSection({
           {meta.icon}
         </div>
         <div>
-          <h2 className="text-xl font-semibold text-foreground">{meta.label}</h2>
+          <h2 className="text-xl font-semibold text-foreground">
+            {meta.label}
+          </h2>
           <p className="text-xs text-muted-foreground">
-            {scenarios.length} {scenarios.length === 1 ? "Szenario" : "Szenarien"}
+            {scenarios.length}{" "}
+            {scenarios.length === 1 ? "Szenario" : "Szenarien"}
           </p>
         </div>
       </div>
+
+      {/* Technique component breakdown */}
+      {TECHNIQUE_STEPS[technique] && (
+        <div
+          className="rounded-lg p-3 mb-5 border border-border/30"
+          style={{ backgroundColor: meta.bgColor }}
+        >
+          <p
+            className="text-xs font-medium mb-2.5"
+            style={{ color: meta.color }}
+          >
+            Aufbau der Technik
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {TECHNIQUE_STEPS[technique]!.map(comp => (
+              <div
+                key={comp.letter}
+                className="flex items-center gap-1.5 bg-background/60 rounded px-2.5 py-1.5"
+              >
+                <span
+                  className="text-sm font-bold"
+                  style={{ color: meta.color }}
+                >
+                  {comp.letter}
+                </span>
+                <div>
+                  <p className="text-xs font-semibold text-foreground leading-none">
+                    {comp.label}
+                  </p>
+                  <p className="text-[10px] text-muted-foreground leading-none mt-0.5">
+                    {comp.desc}
+                  </p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
       <div className="space-y-5">
         {scenarios.map((s, i) => (
           <ScenarioCard key={s.id} scenario={s} index={i} />
@@ -562,14 +636,14 @@ export default function KommunikationsUebung() {
   return (
     <div className="space-y-10">
       {(["SET", "DEAR", "Validierung"] as Technique[]).map(
-        (tech) =>
+        tech =>
           grouped[tech].length > 0 && (
             <TechniqueSection
               key={tech}
               technique={tech}
               scenarios={grouped[tech]}
             />
-          ),
+          )
       )}
     </div>
   );

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -299,6 +299,12 @@ export default function FAQ() {
                     href={`#${slugifyCategory(category.title)}`}
                     className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/20"
                   >
+                    <span
+                      className="flex-shrink-0"
+                      style={{ color: category.color }}
+                    >
+                      {category.icon}
+                    </span>
                     {category.title}
                   </a>
                 ))}

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -288,6 +288,96 @@ export default function Genesung() {
                     </p>
                   </CardContent>
                 </Card>
+
+                {/* Genesungsverlauf – Wellenlinie */}
+                <div className="rounded-lg border border-border/40 bg-slate-wash/10 p-4">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2 text-center">
+                    Genesungsverlauf: nicht linear
+                  </p>
+                  <svg
+                    viewBox="0 0 300 70"
+                    className="w-full h-14"
+                    aria-hidden="true"
+                  >
+                    <line
+                      x1="15"
+                      y1="58"
+                      x2="285"
+                      y2="12"
+                      stroke="var(--color-sage-mid)"
+                      strokeWidth="1"
+                      strokeDasharray="5,4"
+                      opacity="0.35"
+                    />
+                    <path
+                      d="M 15,56 C 40,56 48,22 65,28 S 95,60 115,50 S 155,16 182,22 S 215,48 245,36 S 272,14 285,10"
+                      fill="none"
+                      stroke="var(--color-sage-dark)"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <text
+                      x="15"
+                      y="68"
+                      fontSize="8"
+                      fill="currentColor"
+                      opacity="0.45"
+                    >
+                      Beginn
+                    </text>
+                    <text
+                      x="255"
+                      y="9"
+                      fontSize="8"
+                      fill="currentColor"
+                      opacity="0.45"
+                    >
+                      Ziel
+                    </text>
+                    <text
+                      x="88"
+                      y="68"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.5"
+                    >
+                      Rückschritt
+                    </text>
+                    <line
+                      x1="115"
+                      y1="65"
+                      x2="115"
+                      y2="52"
+                      stroke="currentColor"
+                      strokeWidth="0.8"
+                      opacity="0.35"
+                    />
+                    <text
+                      x="187"
+                      y="68"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.5"
+                    >
+                      Rückschritt
+                    </text>
+                    <line
+                      x1="215"
+                      y1="65"
+                      x2="215"
+                      y2="49"
+                      stroke="currentColor"
+                      strokeWidth="0.8"
+                      opacity="0.35"
+                    />
+                  </svg>
+                  <p className="text-[11px] text-muted-foreground text-center mt-1">
+                    Rückschritte gehören zum Weg — die gestrichelte Linie zeigt
+                    den Gesamttrend
+                  </p>
+                </div>
+
                 <div className="grid sm:grid-cols-2 gap-4">
                   {[
                     "Rückschritte einordnen, statt sofort zu katastrophisieren",

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -135,6 +135,25 @@ export default function Genesung() {
         </div>
       </section>
 
+      {/* PDF-Hinweis */}
+      <div className="container">
+        <div className="max-w-3xl mx-auto py-3">
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-sage-wash/40 border border-sage-mid/20 px-4 py-2.5">
+            <p className="text-xs text-muted-foreground">
+              Alle Infografiken auch als druckbare PDFs verfügbar.
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-sage-dark shrink-0"
+              asChild
+            >
+              <Link href="/materialien">Materialien →</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
       <section className="py-8 md:py-12">
         <div className="container">
           <motion.div

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -38,7 +38,7 @@ export default function Grenzen() {
             className="max-w-3xl"
           >
             <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sand-muteder flex items-center justify-center">
+              <div className="w-12 h-12 rounded-xl bg-sand-muted flex items-center justify-center">
                 <Shield className="w-6 h-6 text-sage-mid" />
               </div>
               <span className="text-sm font-medium text-sage-dark">

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -158,6 +158,78 @@ export default function Grenzen() {
               </div>
             </ContentSection>
 
+            {/* Grenzen-Priorisierungsmatrix */}
+            <ContentSection
+              title="Welche Grenzen zuerst?"
+              icon={<CheckCircle2 className="w-7 h-7 text-sage-dark" />}
+              id="priorisierung"
+              preview="Nicht alle Grenzen lassen sich gleichzeitig setzen. Diese Orientierung hilft, die wichtigsten zuerst anzugehen."
+            >
+              <p className="text-muted-foreground leading-relaxed mb-4">
+                Wer versucht, alle Grenzen auf einmal zu setzen, scheitert meist
+                an sich selbst. Sinnvoller ist es, nach Dringlichkeit und
+                emotionaler Last zu priorisieren.
+              </p>
+              <div className="grid grid-cols-2 gap-2">
+                <div className="rounded-lg bg-alert/10 border border-alert/30 p-4">
+                  <p className="text-[10px] font-bold text-alert uppercase tracking-wide mb-1">
+                    Dringend · Emotional hoch
+                  </p>
+                  <p className="text-sm font-semibold text-foreground mb-2">
+                    Sofort setzen
+                  </p>
+                  <ul className="text-xs text-muted-foreground space-y-1">
+                    <li>• Körperliche Sicherheit</li>
+                    <li>• Bedrohungen / Übergriffe</li>
+                    <li>• Eigene Gesundheit</li>
+                  </ul>
+                </div>
+                <div className="rounded-lg bg-sand-muted border border-sand-mid/30 p-4">
+                  <p className="text-[10px] font-bold text-sand-mid uppercase tracking-wide mb-1">
+                    Dringend · Emotional niedriger
+                  </p>
+                  <p className="text-sm font-semibold text-foreground mb-2">
+                    Klar kommunizieren
+                  </p>
+                  <ul className="text-xs text-muted-foreground space-y-1">
+                    <li>• Erreichbarkeitszeiten</li>
+                    <li>• Gesprächsregeln</li>
+                    <li>• Alltägliche Abläufe</li>
+                  </ul>
+                </div>
+                <div className="rounded-lg bg-sage-lighter/50 border border-sage-mid/20 p-4">
+                  <p className="text-[10px] font-bold text-sage-dark uppercase tracking-wide mb-1">
+                    Langfristig · Emotional hoch
+                  </p>
+                  <p className="text-sm font-semibold text-foreground mb-2">
+                    Sorgfältig vorbereiten
+                  </p>
+                  <ul className="text-xs text-muted-foreground space-y-1">
+                    <li>• Finanzielle Regelungen</li>
+                    <li>• Wohnsituation</li>
+                    <li>• Langfristige Rollen</li>
+                  </ul>
+                </div>
+                <div className="rounded-lg bg-slate-wash border border-border/30 p-4">
+                  <p className="text-[10px] font-bold text-muted-foreground uppercase tracking-wide mb-1">
+                    Langfristig · Emotional niedrig
+                  </p>
+                  <p className="text-sm font-semibold text-foreground mb-2">
+                    Im Blick behalten
+                  </p>
+                  <ul className="text-xs text-muted-foreground space-y-1">
+                    <li>• Kleine Gewohnheitsfragen</li>
+                    <li>• Alltagsabsprachen</li>
+                    <li>• Schrittweise Anpassungen</li>
+                  </ul>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground mt-4">
+                Wenige zentrale Grenzen, klar gehalten, tragen mehr als viele
+                gleichzeitig.
+              </p>
+            </ContentSection>
+
             <ContentSection
               title="Wie Grenzen eher gut kommuniziert werden"
               icon={<Heart className="w-7 h-7 text-sage-dark" />}

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -76,6 +76,25 @@ export default function Grenzen() {
         </div>
       </section>
 
+      {/* PDF-Hinweis */}
+      <div className="container">
+        <div className="max-w-3xl mx-auto py-3">
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-sage-wash/40 border border-sage-mid/20 px-4 py-2.5">
+            <p className="text-xs text-muted-foreground">
+              Alle Infografiken auch als druckbare PDFs verfügbar.
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-sage-dark shrink-0"
+              asChild
+            >
+              <Link href="/materialien">Materialien →</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
       <section className="py-8 md:py-12">
         <div className="container">
           <div className="max-w-3xl mx-auto">

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -120,6 +120,69 @@ export default function Kommunizieren() {
 
                 <ValidierungsStufenleiter />
 
+                {/* Validierungs-Situationsmatrix */}
+                <div className="rounded-lg border border-sage-mid/30 bg-sage-light/5 p-4">
+                  <p className="text-sm font-semibold text-foreground mb-3">
+                    Wann welche Stufe passt
+                  </p>
+                  <div className="space-y-3">
+                    {(
+                      [
+                        {
+                          situation: "Alltag, kleine Frustration",
+                          fit: [true, true, false, false, false, false],
+                          note: "Stufe 1–2",
+                        },
+                        {
+                          situation: "Streit, Vorwürfe, Anspannung",
+                          fit: [false, true, true, true, false, false],
+                          note: "Stufe 2–4",
+                        },
+                        {
+                          situation: "Starke Emotion, Kontrollverlust",
+                          fit: [false, false, true, true, true, false],
+                          note: "Stufe 3–5",
+                        },
+                        {
+                          situation: "Krise, Suizidgedanken",
+                          fit: [false, false, false, false, true, true],
+                          note: "Stufe 5–6 + Hilfe",
+                        },
+                      ] as { situation: string; fit: boolean[]; note: string }[]
+                    ).map(row => (
+                      <div
+                        key={row.situation}
+                        className="flex flex-col sm:flex-row sm:items-center gap-2"
+                      >
+                        <p className="text-sm text-foreground sm:min-w-[220px]">
+                          {row.situation}
+                        </p>
+                        <div className="flex items-center gap-1">
+                          {row.fit.map((active, i) => (
+                            <div
+                              key={i}
+                              className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold border ${
+                                active
+                                  ? "bg-sage-lighter text-sage-dark border-sage-mid/50"
+                                  : "bg-background text-muted-foreground border-border/30"
+                              }`}
+                            >
+                              {i + 1}
+                            </div>
+                          ))}
+                          <span className="text-xs text-muted-foreground ml-2">
+                            {row.note}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  <p className="text-[11px] text-muted-foreground mt-3">
+                    Stufen sind keine Hierarchie — sie sind Werkzeuge. Kein
+                    Ansatz passt in jeder Situation gleich gut.
+                  </p>
+                </div>
+
                 <Card className="bg-sage-wash/50 border-sage-mid/30">
                   <CardContent className="p-5">
                     <p className="text-foreground font-medium text-sm">

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -64,6 +64,25 @@ export default function Kommunizieren() {
         </div>
       </section>
 
+      {/* PDF-Hinweis */}
+      <div className="container">
+        <div className="max-w-3xl mx-auto py-3">
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-sage-wash/40 border border-sage-mid/20 px-4 py-2.5">
+            <p className="text-xs text-muted-foreground">
+              Kommunikations-Übungen und Infografiken auch als PDFs verfügbar.
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-sage-dark shrink-0"
+              asChild
+            >
+              <Link href="/materialien">Materialien →</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
       <section className="py-8 md:py-12">
         <div className="container">
           <div className="max-w-3xl mx-auto">

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -138,6 +138,25 @@ export default function Selbstfuersorge() {
         </div>
       </section>
 
+      {/* PDF-Hinweis */}
+      <div className="container">
+        <div className="max-w-3xl mx-auto py-3">
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-sage-wash/40 border border-sage-mid/20 px-4 py-2.5">
+            <p className="text-xs text-muted-foreground">
+              Selbstfürsorge-Checklisten auch als druckbare PDFs verfügbar.
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-sage-dark shrink-0"
+              asChild
+            >
+              <Link href="/materialien">Materialien →</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
       {/* Aufklappbare Abschnitte */}
       <section className="py-8 md:py-12">
         <div className="container">

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -371,10 +371,48 @@ export default function Selbstfuersorge() {
               id="langfristige-strategien"
               preview="Tägliche Mini-Auszeiten, Bewegung, soziale Kontakte und professionelle Unterstützung."
             >
-              <p className="text-muted-foreground leading-relaxed mb-6">
+              <p className="text-muted-foreground leading-relaxed mb-4">
                 Neben den Sofort-Übungen brauchen Sie auch langfristige
                 Strategien, um Ihre Gesundheit zu erhalten:
               </p>
+
+              {/* 4-Quadranten-Modell */}
+              <div className="grid grid-cols-2 gap-2 mb-6">
+                <div className="rounded-lg bg-sage-lighter/50 border border-sage-mid/20 p-4 text-center">
+                  <Heart className="w-5 h-5 text-sage-dark mx-auto mb-1.5" />
+                  <p className="text-sm font-semibold text-foreground">
+                    Körper
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Bewegung, Schlaf, Ernährung
+                  </p>
+                </div>
+                <div className="rounded-lg bg-sand-muted border border-sand-mid/20 p-4 text-center">
+                  <Brain className="w-5 h-5 text-sand-mid mx-auto mb-1.5" />
+                  <p className="text-sm font-semibold text-foreground">Geist</p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Reflexion, Grenzen, Akzeptanz
+                  </p>
+                </div>
+                <div className="rounded-lg bg-slate-wash border border-border/30 p-4 text-center">
+                  <Users className="w-5 h-5 text-slate-dark mx-auto mb-1.5" />
+                  <p className="text-sm font-semibold text-foreground">
+                    Beziehungen
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Freunde, Familie, Beratung
+                  </p>
+                </div>
+                <div className="rounded-lg bg-amber-50 border border-amber-100 p-4 text-center">
+                  <Clock className="w-5 h-5 text-amber-600 mx-auto mb-1.5" />
+                  <p className="text-sm font-semibold text-foreground">
+                    Struktur
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Routinen, Auszeiten, Planung
+                  </p>
+                </div>
+              </div>
 
               <div className="space-y-3">
                 <UebungAkkordeon

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -106,130 +106,160 @@ function StickyAmpelLeiste() {
 
 // ─── Grosse Notruf-Karte (ROT) ───────────────────────────
 
-function NotfallKarte({
-  nummer,
-  label,
-  hinweis,
-  tel,
-}: {
+// ─── Unified KontaktKarte (danger / orange / green / lila) ───
+
+type KarteVariant = "danger" | "orange" | "green" | "lila";
+
+interface KontaktKarteProps {
+  variant: KarteVariant;
   nummer: string;
   label: string;
-  hinweis: string;
   tel: string;
-}) {
-  return (
-    <a
-      href={`tel:${tel}`}
-      className="flex items-center justify-between gap-4 p-4 sm:p-5 rounded-xl bg-white/15 hover:bg-white/25 active:bg-white/30 transition-all border border-white/20 group"
-      aria-label={`${label} anrufen: ${nummer}`}
-    >
-      <div className="flex items-center gap-3 min-w-0">
-        <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-white/20 flex items-center justify-center flex-shrink-0">
-          <Phone className="w-5 h-5 sm:w-6 sm:h-6 text-white" />
-        </div>
-        <div className="min-w-0">
-          <p className="font-bold text-white text-xl sm:text-2xl leading-none mb-0.5">
-            {nummer}
-          </p>
-          <p className="text-white/90 font-semibold text-sm">{label}</p>
-          <p className="text-white/70 text-xs leading-snug mt-0.5">{hinweis}</p>
-        </div>
-      </div>
-      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-white/20 flex items-center justify-center group-hover:bg-white/30 transition-all">
-        <Phone className="w-5 h-5 text-white" />
-      </div>
-    </a>
-  );
+  hinweis?: string;
+  subLabel?: string;
+  icon?: React.ReactNode;
 }
 
-// ─── PUK-Karte (ORANGE) ──────────────────────────────────
+const KARTE_STYLES: Record<
+  KarteVariant,
+  {
+    container: string;
+    iconBox: string;
+    numberCls: string;
+    subLabelCls: string;
+    labelCls: string;
+    hinweisCls: string;
+    arrowBox: string;
+    arrowIconCls: string;
+  }
+> = {
+  danger: {
+    container:
+      "bg-white/15 hover:bg-white/25 active:bg-white/30 border-white/20",
+    iconBox: "rounded-full bg-white/20",
+    numberCls: "text-white text-xl sm:text-2xl",
+    subLabelCls: "text-white/80 text-xs font-semibold",
+    labelCls: "text-white/90 font-semibold text-sm",
+    hinweisCls: "text-white/70 text-xs leading-snug mt-0.5",
+    arrowBox: "bg-white/20 group-hover:bg-white/30",
+    arrowIconCls: "text-white",
+  },
+  orange: {
+    container:
+      "bg-white border-sos-orange-border hover:border-sos-orange-border-h hover:shadow-md active:scale-[0.98]",
+    iconBox: "rounded-xl bg-sos-orange-light",
+    numberCls: "text-foreground text-lg sm:text-xl",
+    subLabelCls: "text-xs font-medium text-sos-orange-text",
+    labelCls: "text-muted-foreground text-xs sm:text-sm leading-snug",
+    hinweisCls: "text-muted-foreground text-xs leading-snug mt-0.5",
+    arrowBox: "bg-sos-orange-light group-hover:bg-sos-orange-border",
+    arrowIconCls: "text-sos-orange-text",
+  },
+  green: {
+    container:
+      "bg-white border-sos-gruen-border hover:border-sos-gruen-border-h hover:shadow-md active:scale-[0.98]",
+    iconBox: "rounded-xl bg-sos-gruen-light",
+    numberCls: "text-foreground text-lg sm:text-xl",
+    subLabelCls:
+      "text-[10px] font-semibold text-sos-gruen-text bg-sos-gruen-light rounded px-1.5 py-0.5",
+    labelCls: "text-muted-foreground text-xs sm:text-sm font-medium",
+    hinweisCls: "text-muted-foreground text-xs leading-snug mt-0.5",
+    arrowBox: "bg-sos-gruen-light group-hover:bg-sos-gruen-border",
+    arrowIconCls: "text-sos-gruen-text",
+  },
+  lila: {
+    container:
+      "bg-sos-lila-wash border-sos-lila-border hover:border-sos-lila-border-h hover:shadow-md active:scale-[0.98]",
+    iconBox: "rounded-xl bg-sos-lila-light",
+    numberCls: "text-foreground text-lg sm:text-xl",
+    subLabelCls: "text-xs font-medium text-sos-lila-text",
+    labelCls: "text-muted-foreground text-sm font-medium",
+    hinweisCls: "text-muted-foreground text-xs mt-0.5",
+    arrowBox: "bg-sos-lila-light group-hover:bg-sos-lila-border",
+    arrowIconCls: "text-sos-lila-text",
+  },
+};
 
-function PukKarte({
+function KontaktKarte({
+  variant,
   nummer,
   label,
-  fuerWen,
   tel,
+  hinweis,
+  subLabel,
   icon,
-}: {
-  nummer: string;
-  label: string;
-  fuerWen: string;
-  tel: string;
-  icon: React.ReactNode;
-}) {
+}: KontaktKarteProps) {
+  const s = KARTE_STYLES[variant];
+  const defaultIcon =
+    variant === "danger" ? (
+      <Phone className="w-5 h-5 sm:w-6 sm:h-6 text-white" />
+    ) : variant === "orange" ? (
+      <Phone className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />
+    ) : variant === "lila" ? (
+      <Pill className="w-5 h-5 sm:w-6 sm:h-6 text-sos-lila-text" />
+    ) : (
+      <Heart className="w-5 h-5 sm:w-6 sm:h-6 text-sos-gruen-text" />
+    );
   return (
     <a
       href={`tel:${tel}`}
-      className="flex items-center justify-between gap-3 p-4 sm:p-5 rounded-xl bg-white border border-sos-orange-border hover:border-sos-orange-border-h hover:shadow-md active:scale-[0.98] transition-all group"
+      className={`flex items-center justify-between gap-3 p-4 sm:p-5 rounded-xl border transition-all group ${s.container}`}
       aria-label={`${label} anrufen: ${nummer}`}
     >
       <div className="flex items-center gap-3 min-w-0">
-        <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-xl bg-sos-orange-light flex items-center justify-center flex-shrink-0">
-          {icon}
+        <div
+          className={`w-10 h-10 sm:w-12 sm:h-12 flex items-center justify-center flex-shrink-0 ${s.iconBox}`}
+        >
+          {icon ?? defaultIcon}
         </div>
         <div className="min-w-0">
-          <p className="text-xs font-medium text-sos-orange-text mb-0.5">
-            {fuerWen}
-          </p>
-          <p className="font-bold text-foreground text-lg sm:text-xl leading-none mb-0.5">
-            {nummer}
-          </p>
-          <p className="text-muted-foreground text-xs sm:text-sm leading-snug">
-            {label}
-          </p>
-        </div>
-      </div>
-      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-sos-orange-light flex items-center justify-center group-hover:bg-sos-orange-border transition-all">
-        <Phone className="w-5 h-5 text-sos-orange-text" />
-      </div>
-    </a>
-  );
-}
-
-// ─── Grüne Karte (Entlastung) ─────────────────────────────
-
-function EntlastungKarte({
-  nummer,
-  label,
-  hinweis,
-  tel,
-  badge,
-}: {
-  nummer: string;
-  label: string;
-  hinweis: string;
-  tel: string;
-  badge?: string;
-}) {
-  return (
-    <a
-      href={`tel:${tel}`}
-      className="flex items-center justify-between gap-3 p-4 sm:p-5 rounded-xl bg-white border border-sos-gruen-border hover:border-sos-gruen-border-h hover:shadow-md active:scale-[0.98] transition-all group"
-      aria-label={`${label} anrufen: ${nummer}`}
-    >
-      <div className="flex items-center gap-3 min-w-0">
-        <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-xl bg-sos-gruen-light flex items-center justify-center flex-shrink-0">
-          <Heart className="w-5 h-5 sm:w-6 sm:h-6 text-sos-gruen-text" />
-        </div>
-        <div className="min-w-0">
-          {badge && (
-            <span className="inline-block text-[10px] font-semibold text-sos-gruen-text bg-sos-gruen-light rounded px-1.5 py-0.5 mb-0.5">
-              {badge}
+          {subLabel && (
+            <span className={`inline-block mb-0.5 ${s.subLabelCls}`}>
+              {subLabel}
             </span>
           )}
-          <p className="font-bold text-foreground text-lg sm:text-xl leading-none mb-0.5">
+          <p className={`font-bold leading-none mb-0.5 ${s.numberCls}`}>
             {nummer}
           </p>
-          <p className="text-muted-foreground text-xs sm:text-sm font-medium">
-            {label}
-          </p>
-          <p className="text-muted-foreground text-xs leading-snug mt-0.5">
-            {hinweis}
-          </p>
+          <p className={s.labelCls}>{label}</p>
+          {hinweis && <p className={s.hinweisCls}>{hinweis}</p>}
         </div>
       </div>
-      <div className="flex-shrink-0 w-10 h-10 rounded-full bg-sos-gruen-light flex items-center justify-center group-hover:bg-sos-gruen-border transition-all">
-        <Phone className="w-5 h-5 text-sos-gruen-text" />
+      <div
+        className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center transition-all ${s.arrowBox}`}
+      >
+        <Phone className={`w-5 h-5 ${s.arrowIconCls}`} />
+      </div>
+    </a>
+  );
+}
+
+// ─── InfoKarte (nachrangige Kontakte, grau) ───────────────
+
+function InfoKarte({
+  nummer,
+  label,
+  hinweis,
+  tel,
+}: {
+  nummer: string;
+  label: string;
+  hinweis: string;
+  tel: string;
+}) {
+  return (
+    <a
+      href={`tel:${tel}`}
+      className="flex items-center justify-between gap-3 p-3.5 rounded-xl border border-border/60 hover:border-border hover:shadow-sm active:scale-[0.98] transition-all group"
+      aria-label={`${label} anrufen: ${nummer}`}
+    >
+      <div className="min-w-0">
+        <p className="font-semibold text-foreground text-sm">{nummer}</p>
+        <p className="text-muted-foreground text-xs">{label}</p>
+        <p className="text-muted-foreground text-xs">{hinweis}</p>
+      </div>
+      <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
+        <Phone className="w-4 h-4 text-muted-foreground" />
       </div>
     </a>
   );
@@ -360,19 +390,22 @@ export default function Notfall() {
 
               {/* Nummern */}
               <div className="px-4 py-4 sm:px-5 sm:py-5 space-y-3 bg-sos-rot-body">
-                <NotfallKarte
+                <KontaktKarte
+                  variant="danger"
                   nummer={rot144.nummer}
                   label={rot144.label}
                   hinweis={rot144.hinweis}
                   tel={rot144.tel}
                 />
-                <NotfallKarte
+                <KontaktKarte
+                  variant="danger"
                   nummer={rot117.nummer}
                   label={rot117.label}
                   hinweis={rot117.hinweis}
                   tel={rot117.tel}
                 />
-                <NotfallKarte
+                <KontaktKarte
+                  variant="danger"
                   nummer={rot112.nummer}
                   label={rot112.label}
                   hinweis={rot112.hinweis}
@@ -423,28 +456,31 @@ export default function Notfall() {
                   Kontaktieren Sie die PUK Zürich – rund um die Uhr, 24/7:
                 </p>
 
-                <PukKarte
+                <KontaktKarte
+                  variant="orange"
                   nummer={pukErw.nummer}
                   label="PUK Erwachsene (24/7)"
-                  fuerWen="Erwachsene 18–64 Jahre"
+                  subLabel="Erwachsene 18–64 Jahre"
                   tel={pukErw.tel}
                   icon={
                     <User className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />
                   }
                 />
-                <PukKarte
+                <KontaktKarte
+                  variant="orange"
                   nummer={pukKjp.nummer}
                   label="PUK Kinder & Jugendliche (24/7)"
-                  fuerWen="Kinder & Jugendliche bis 18 Jahre"
+                  subLabel="Kinder & Jugendliche bis 18 Jahre"
                   tel={pukKjp.tel}
                   icon={
                     <Baby className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />
                   }
                 />
-                <PukKarte
+                <KontaktKarte
+                  variant="orange"
                   nummer={puk65.nummer}
                   label="PUK Erwachsene ab 65 (24/7)"
-                  fuerWen="Erwachsene ab 65 Jahren"
+                  subLabel="Erwachsene ab 65 Jahren"
                   tel={puk65.tel}
                   icon={
                     <Users className="w-5 h-5 sm:w-6 sm:h-6 text-sos-orange-text" />
@@ -488,26 +524,29 @@ export default function Notfall() {
 
               {/* Karten */}
               <div className="px-4 py-4 sm:px-5 sm:py-5 space-y-3 bg-white">
-                <EntlastungKarte
+                <KontaktKarte
+                  variant="green"
                   nummer={gruen143.nummer}
                   label="Dargebotene Hand"
                   hinweis="Anonym, vertraulich – Gesprächs- und Krisenangebot"
                   tel={gruen143.tel}
-                  badge="24/7"
+                  subLabel="24/7"
                 />
-                <EntlastungKarte
+                <KontaktKarte
+                  variant="green"
                   nummer={gruenEltern.nummer}
                   label="Elternnotruf"
                   hinweis="Beratung für Eltern – anonym, vertraulich"
                   tel={gruenEltern.tel}
-                  badge="24/7 · Für Eltern"
+                  subLabel="24/7 · Für Eltern"
                 />
-                <EntlastungKarte
+                <KontaktKarte
+                  variant="green"
                   nummer={gruen147.nummer}
                   label="Pro Juventute"
                   hinweis="Beratung für Kinder und Jugendliche – vertraulich"
                   tel={gruen147.tel}
-                  badge="24/7 · Für Kinder & Jugendliche"
+                  subLabel="24/7 · Für Kinder & Jugendliche"
                 />
               </div>
 
@@ -540,31 +579,13 @@ export default function Notfall() {
               </div>
 
               <div className="px-4 py-4 sm:px-5 bg-white">
-                <a
-                  href={`tel:${rot145.tel}`}
-                  className="flex items-center justify-between gap-3 p-4 rounded-xl bg-sos-lila-wash border border-sos-lila-border hover:border-sos-lila-border-h hover:shadow-md active:scale-[0.98] transition-all group"
-                  aria-label={`${rot145.label} anrufen: ${rot145.nummer}`}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div className="w-10 h-10 rounded-xl bg-sos-lila-light flex items-center justify-center flex-shrink-0">
-                      <Pill className="w-5 h-5 text-sos-lila-text" />
-                    </div>
-                    <div>
-                      <p className="font-bold text-foreground text-xl leading-none mb-0.5">
-                        {rot145.nummer}
-                      </p>
-                      <p className="text-muted-foreground text-sm font-medium">
-                        {rot145.label}
-                      </p>
-                      <p className="text-muted-foreground text-xs mt-0.5">
-                        {rot145.hinweis}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex-shrink-0 w-10 h-10 rounded-full bg-sos-lila-light flex items-center justify-center group-hover:bg-sos-lila-border transition-all">
-                    <Phone className="w-5 h-5 text-sos-lila-text" />
-                  </div>
-                </a>
+                <KontaktKarte
+                  variant="lila"
+                  nummer={rot145.nummer}
+                  label={rot145.label}
+                  hinweis={rot145.hinweis}
+                  tel={rot145.tel}
+                />
               </div>
             </motion.div>
 
@@ -589,93 +610,30 @@ export default function Notfall() {
               </div>
 
               <div className="px-4 py-4 sm:px-5 space-y-3 bg-background">
-                {/* Ärztefon */}
-                <a
-                  href={`tel:${infoAerztefon.tel}`}
-                  className="flex items-center justify-between gap-3 p-3.5 rounded-xl border border-border/60 hover:border-border hover:shadow-sm active:scale-[0.98] transition-all group"
-                  aria-label={`${infoAerztefon.label} anrufen: ${infoAerztefon.nummer}`}
-                >
-                  <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">
-                      {infoAerztefon.nummer}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {infoAerztefon.label}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {infoAerztefon.hinweis}
-                    </p>
-                  </div>
-                  <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
-                    <Phone className="w-4 h-4 text-muted-foreground" />
-                  </div>
-                </a>
-
-                {/* PUK Zentrale – explizit als Auskunft, nicht Notfall */}
-                <a
-                  href={`tel:${infoPukZentrale.tel}`}
-                  className="flex items-center justify-between gap-3 p-3.5 rounded-xl border border-border/60 hover:border-border hover:shadow-sm active:scale-[0.98] transition-all group"
-                  aria-label={`${infoPukZentrale.label} anrufen: ${infoPukZentrale.nummer}`}
-                >
-                  <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">
-                      {infoPukZentrale.nummer}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {infoPukZentrale.label}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      Allgemeine Auskunft – kein Notfalldienst
-                    </p>
-                  </div>
-                  <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
-                    <Phone className="w-4 h-4 text-muted-foreground" />
-                  </div>
-                </a>
-
-                {/* Fachstelle Angehörigenarbeit */}
-                <a
-                  href={`tel:${infoFachstelle.tel}`}
-                  className="flex items-center justify-between gap-3 p-3.5 rounded-xl border border-border/60 hover:border-border hover:shadow-sm active:scale-[0.98] transition-all group"
-                  aria-label={`${infoFachstelle.label} anrufen: ${infoFachstelle.nummer}`}
-                >
-                  <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">
-                      {infoFachstelle.nummer}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {infoFachstelle.label}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {infoFachstelle.hinweis}
-                    </p>
-                  </div>
-                  <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
-                    <Phone className="w-4 h-4 text-muted-foreground" />
-                  </div>
-                </a>
-
-                {/* KIZ – Kriseninterventionszentrum */}
-                <a
-                  href={`tel:${infoKiz.tel}`}
-                  className="flex items-center justify-between gap-3 p-3.5 rounded-xl border border-border/60 hover:border-border hover:shadow-sm active:scale-[0.98] transition-all group"
-                  aria-label={`${infoKiz.label} anrufen: ${infoKiz.nummer}`}
-                >
-                  <div className="min-w-0">
-                    <p className="font-semibold text-foreground text-sm">
-                      {infoKiz.nummer}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {infoKiz.label}
-                    </p>
-                    <p className="text-muted-foreground text-xs">
-                      {infoKiz.hinweis}
-                    </p>
-                  </div>
-                  <div className="flex-shrink-0 w-9 h-9 rounded-full bg-muted flex items-center justify-center group-hover:bg-muted/80 transition-all">
-                    <Phone className="w-4 h-4 text-muted-foreground" />
-                  </div>
-                </a>
+                <InfoKarte
+                  nummer={infoAerztefon.nummer}
+                  label={infoAerztefon.label}
+                  hinweis={infoAerztefon.hinweis}
+                  tel={infoAerztefon.tel}
+                />
+                <InfoKarte
+                  nummer={infoPukZentrale.nummer}
+                  label={infoPukZentrale.label}
+                  hinweis="Allgemeine Auskunft – kein Notfalldienst"
+                  tel={infoPukZentrale.tel}
+                />
+                <InfoKarte
+                  nummer={infoFachstelle.nummer}
+                  label={infoFachstelle.label}
+                  hinweis={infoFachstelle.hinweis}
+                  tel={infoFachstelle.tel}
+                />
+                <InfoKarte
+                  nummer={infoKiz.nummer}
+                  label={infoKiz.label}
+                  hinweis={infoKiz.hinweis}
+                  tel={infoKiz.tel}
+                />
               </div>
             </motion.div>
 

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -262,7 +262,7 @@ export default function Notfall() {
       />
 
       {/* ═══ HERO ═══ */}
-      <section className="py-6 md:py-16 bg-gradient-to-b from-sos-rot-wash to-background">
+      <section className="py-6 md:py-16 bg-gradient-to-b from-slate-wash/60 to-background">
         <div className="container">
           <motion.div
             initial={{ opacity: 0, y: 16 }}

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -102,6 +102,115 @@ export default function UnterstuetzenAlltag() {
                     </p>
                   </CardContent>
                 </Card>
+
+                {/* Alltags-Spannungsdiagramm */}
+                <div className="rounded-lg border border-border/40 bg-slate-wash/10 p-4">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-2 text-center">
+                    Spannungsverlauf im Alltag
+                  </p>
+                  <svg
+                    viewBox="0 0 300 72"
+                    className="w-full h-16"
+                    aria-hidden="true"
+                  >
+                    {/* Ruhepuls-Linie (Vergleich) */}
+                    <path
+                      d="M 15,48 C 60,48 80,38 120,42 S 180,48 240,44 S 270,42 285,42"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeDasharray="4,3"
+                      opacity="0.25"
+                    />
+                    {/* Erhöhte Grundspannung mit Spitzen */}
+                    <path
+                      d="M 15,35 C 40,33 55,32 70,33 S 85,30 90,18 S 95,32 110,32 S 140,30 155,32 S 165,28 170,14 S 175,32 195,31 S 220,30 235,31 S 250,28 255,20 S 260,32 285,30"
+                      fill="none"
+                      stroke="var(--color-sage-dark)"
+                      strokeWidth="2.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    {/* Labels */}
+                    <text
+                      x="15"
+                      y="68"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.45"
+                    >
+                      Mo
+                    </text>
+                    <text
+                      x="82"
+                      y="68"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.45"
+                    >
+                      Di
+                    </text>
+                    <text
+                      x="160"
+                      y="68"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.45"
+                    >
+                      Mi
+                    </text>
+                    <text
+                      x="244"
+                      y="68"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.45"
+                    >
+                      Do
+                    </text>
+                    {/* Legend */}
+                    <line
+                      x1="15"
+                      y1="8"
+                      x2="32"
+                      y2="8"
+                      stroke="var(--color-sage-dark)"
+                      strokeWidth="2"
+                    />
+                    <text
+                      x="35"
+                      y="11"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.6"
+                    >
+                      Mit Angehörigem
+                    </text>
+                    <line
+                      x1="140"
+                      y1="8"
+                      x2="157"
+                      y2="8"
+                      stroke="currentColor"
+                      strokeWidth="1.2"
+                      strokeDasharray="3,2"
+                      opacity="0.4"
+                    />
+                    <text
+                      x="160"
+                      y="11"
+                      fontSize="7.5"
+                      fill="currentColor"
+                      opacity="0.6"
+                    >
+                      Ohne Belastung
+                    </text>
+                  </svg>
+                  <p className="text-[11px] text-muted-foreground text-center mt-1">
+                    Erhöhte Grundspannung kostet Energie — auch wenn äusserlich
+                    "nichts passiert"
+                  </p>
+                </div>
               </div>
             </ContentSection>
 

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -470,6 +470,60 @@ export default function UnterstuetzenKrise() {
               preview="Die akute Krise ist vorbei – aber die innere Landschaft braucht Zeit. Was jetzt hilft: für die betroffene Person, für Sie, und gemeinsam."
             >
               <div className="space-y-6">
+                {/* Krisenphase-Timeline */}
+                <div className="rounded-lg border border-border/40 bg-slate-wash/20 p-4">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3 text-center">
+                    Typischer Krisenverlauf
+                  </p>
+                  <div className="flex flex-col sm:flex-row items-center gap-1.5">
+                    <div className="bg-sand-muted rounded-md px-3 py-2 text-center flex-1 w-full">
+                      <p className="text-xs font-semibold text-sand-mid">
+                        Anspannung
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Minuten–Stunden
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground rotate-90 sm:rotate-0 flex-shrink-0" />
+                    <div className="bg-amber-100 rounded-md px-3 py-2 text-center flex-1 w-full">
+                      <p className="text-xs font-semibold text-amber-700">
+                        Eskalation
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        15–90 Min
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground rotate-90 sm:rotate-0 flex-shrink-0" />
+                    <div className="bg-alert/15 rounded-md px-3 py-2 text-center flex-1 w-full">
+                      <p className="text-xs font-semibold text-alert">Peak</p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Spitze
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground rotate-90 sm:rotate-0 flex-shrink-0" />
+                    <div className="bg-amber-50 rounded-md px-3 py-2 text-center flex-1 w-full">
+                      <p className="text-xs font-semibold text-amber-600">
+                        Abklingen
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        1–4 Std
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground rotate-90 sm:rotate-0 flex-shrink-0" />
+                    <div className="bg-sage-lighter/60 rounded-md px-3 py-2 text-center flex-1 w-full">
+                      <p className="text-xs font-semibold text-sage-dark">
+                        Erschöpfung
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Stunden–Tage
+                      </p>
+                    </div>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground mt-3 text-center">
+                    Zeitangaben sind Richtwerte — jede Krise verläuft anders
+                  </p>
+                </div>
+
                 {/* Für die betroffene Person */}
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -202,6 +202,72 @@ export default function UnterstuetzenKrise() {
                   </Card>
                 ))}
               </div>
+
+              {/* De-Eskalations-Pfad */}
+              <div className="mt-4 rounded-lg bg-slate-wash/20 p-4 border border-border/30">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3">
+                  Was konkret hilft – je nach Stufe
+                </p>
+                <div className="space-y-2">
+                  <div className="flex items-start gap-3 rounded-md bg-alert/10 p-3">
+                    <span className="text-xs font-bold min-w-[52px] text-alert pt-0.5">
+                      Rot
+                    </span>
+                    <div className="flex flex-wrap gap-1.5">
+                      {[
+                        "Professionelle Hilfe holen",
+                        "Eigene Sicherheit sichern",
+                        "Nicht allein lassen",
+                      ].map(s => (
+                        <span
+                          key={s}
+                          className="text-xs bg-background/70 rounded px-2 py-0.5 text-foreground border border-border/30"
+                        >
+                          {s}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3 rounded-md bg-sand-muted p-3">
+                    <span className="text-xs font-bold min-w-[52px] text-sand-mid pt-0.5">
+                      Orange
+                    </span>
+                    <div className="flex flex-wrap gap-1.5">
+                      {[
+                        "Nicht diskutieren",
+                        "Körperabstand anbieten",
+                        "Kurze, ruhige Sätze",
+                      ].map(s => (
+                        <span
+                          key={s}
+                          className="text-xs bg-background/70 rounded px-2 py-0.5 text-foreground border border-border/30"
+                        >
+                          {s}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex items-start gap-3 rounded-md bg-sage-lighter/50 p-3">
+                    <span className="text-xs font-bold min-w-[52px] text-sage-dark pt-0.5">
+                      Gelb
+                    </span>
+                    <div className="flex flex-wrap gap-1.5">
+                      {[
+                        "Validieren",
+                        "Raum geben",
+                        "Skills gemeinsam erinnern",
+                      ].map(s => (
+                        <span
+                          key={s}
+                          className="text-xs bg-background/70 rounded px-2 py-0.5 text-foreground border border-border/30"
+                        >
+                          {s}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
             </ContentSection>
 
             {/* 4 Schritte der Deeskalation */}

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -50,6 +50,25 @@ export default function Verstehen() {
 
       <VerstehenHeroSection />
 
+      {/* PDF-Hinweis */}
+      <div className="container">
+        <div className="max-w-3xl mx-auto py-3">
+          <div className="flex items-center justify-between gap-3 rounded-lg bg-sage-wash/40 border border-sage-mid/20 px-4 py-2.5">
+            <p className="text-xs text-muted-foreground">
+              Alle Infografiken auch als druckbare PDFs verfügbar.
+            </p>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 text-xs text-sage-dark shrink-0"
+              asChild
+            >
+              <Link href="/materialien">Materialien →</Link>
+            </Button>
+          </div>
+        </div>
+      </div>
+
       <section className="py-8 md:py-12">
         <div className="container">
           <div className="max-w-3xl mx-auto">

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -308,6 +308,64 @@ export default function Verstehen() {
                   das Angehörigen helfen kann, Entwicklungen nüchterner zu
                   lesen.
                 </p>
+
+                {/* Eskalations-Prozessdiagramm */}
+                <div className="rounded-lg border border-border/40 bg-slate-wash/20 p-4">
+                  <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide mb-3 text-center">
+                    Typischer Eskalationsverlauf
+                  </p>
+                  <div className="flex flex-wrap items-center justify-center gap-1.5">
+                    <div className="rounded-md bg-slate-wash px-3 py-2 text-center min-w-[72px]">
+                      <p className="text-xs font-semibold text-slate-dark">
+                        Trigger
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Auslöser
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                    <div className="rounded-md bg-sand-muted px-3 py-2 text-center min-w-[72px]">
+                      <p className="text-xs font-semibold text-sand-mid">
+                        Überflutung
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Emotion steigt
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                    <div className="rounded-md bg-amber-100 px-3 py-2 text-center min-w-[72px]">
+                      <p className="text-xs font-semibold text-amber-700">
+                        Reaktion
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Impuls, Worte
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                    <div className="rounded-md bg-alert/10 px-3 py-2 text-center min-w-[72px]">
+                      <p className="text-xs font-semibold text-alert">
+                        Eskalation
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Spitze
+                      </p>
+                    </div>
+                    <ArrowRight className="w-3 h-3 text-muted-foreground flex-shrink-0" />
+                    <div className="rounded-md bg-sage-lighter/60 px-3 py-2 text-center min-w-[72px]">
+                      <p className="text-xs font-semibold text-sage-dark">
+                        Rückzug
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        Stille, Abstand
+                      </p>
+                    </div>
+                  </div>
+                  <p className="text-[11px] text-muted-foreground mt-3 text-center">
+                    Kein starres Schema — aber ein häufig wiedererkennbarer
+                    Verlauf in belasteten Beziehungen
+                  </p>
+                </div>
+
                 <div className="grid sm:grid-cols-2 gap-4">
                   <Card className="border-border/50">
                     <CardContent className="p-5">

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -372,11 +372,37 @@ export default function Verstehen() {
                       <h3 className="font-semibold text-foreground mb-2">
                         Idealisierung und Entwertung
                       </h3>
-                      <p className="text-sm text-muted-foreground leading-relaxed">
+                      <p className="text-sm text-muted-foreground leading-relaxed mb-3">
                         Eine Person kann zeitweise als einzig sicher und
                         verstehend erlebt werden, kurz darauf aber als kalt,
                         ungerecht oder gefährlich. Für Angehörige ist das oft
                         tief verunsichernd.
+                      </p>
+                      {/* Spaltungs-Skala */}
+                      <div className="flex items-stretch gap-1.5">
+                        <div className="flex-1 rounded bg-sage-lighter/60 px-2 py-1.5 text-center">
+                          <p className="text-[10px] font-semibold text-sage-dark">
+                            Idealisierung
+                          </p>
+                          <p className="text-[9px] text-muted-foreground leading-tight mt-0.5">
+                            «Du allein verstehst mich»
+                          </p>
+                        </div>
+                        <div className="flex items-center text-sm text-muted-foreground px-0.5">
+                          ↔
+                        </div>
+                        <div className="flex-1 rounded bg-alert/10 px-2 py-1.5 text-center">
+                          <p className="text-[10px] font-semibold text-alert">
+                            Entwertung
+                          </p>
+                          <p className="text-[9px] text-muted-foreground leading-tight mt-0.5">
+                            «Du lässt mich im Stich»
+                          </p>
+                        </div>
+                      </div>
+                      <p className="text-[10px] text-muted-foreground text-center mt-1.5">
+                        Beide Extreme sind echte Wahrnehmungen — keine
+                        Manipulation
                       </p>
                     </CardContent>
                   </Card>

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -55,8 +55,8 @@ export default function VerstehenInfografikenSection() {
       </h2>
 
       <p className="text-muted-foreground mb-6">
-        Vorschau = Web-Bild. \u00abPDF \u00f6ffnen\u00bb \u00f6ffnet die A4-Druckversion im neuen
-        Tab \u2013 Download im PDF-Viewer oben rechts.
+        Vorschau = Web-Bild. «PDF öffnen» öffnet die A4-Druckversion im neuen
+        Tab – Download im PDF-Viewer oben rechts.
       </p>
 
       <div className="flex flex-wrap gap-2 mb-6">
@@ -92,7 +92,7 @@ export default function VerstehenInfografikenSection() {
               type="button"
               className="aspect-[3/4] bg-muted cursor-pointer w-full"
               onClick={() => window.open(item.webpUrl, "_blank")}
-              aria-label={`${item.alt} \u2013 Vorschau \u00f6ffnen`}
+              aria-label={`${item.alt} – Vorschau öffnen`}
             >
               <img
                 src={item.webpUrl}
@@ -113,11 +113,11 @@ export default function VerstehenInfografikenSection() {
                 href={item.pdfUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                aria-label={`PDF \u00f6ffnen: ${item.title} (neuer Tab)`}
+                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
                 className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
               >
                 <ExternalLink className="w-4 h-4" />
-                PDF \u00f6ffnen
+                PDF öffnen
               </a>
             </CardContent>
           </Card>

--- a/client/src/sections/materialien/MaterialCard.tsx
+++ b/client/src/sections/materialien/MaterialCard.tsx
@@ -62,10 +62,12 @@ export default function MaterialCard({ item, onPreview }: MaterialCardProps) {
             <a
               href={downloadHref}
               download={isCrossOriginDownload ? undefined : ""}
+              target={isCrossOriginDownload ? "_blank" : undefined}
+              rel={isCrossOriginDownload ? "noopener noreferrer" : undefined}
               className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 border border-sage-dark text-sage-dark hover:bg-sage-light/40 transition-colors"
             >
               <Download className="w-4 h-4" />
-              Herunterladen
+              {isCrossOriginDownload ? "PDF ansehen" : "Herunterladen"}
             </a>
           ) : null}
         </div>


### PR DESCRIPTION
Konsolidiert 5 separate/inline Karten-Patterns in Soforthilfe.tsx auf 2 Komponenten:

**`KontaktKarte`** (neu) — ersetzt:
- `NotfallKarte` (danger-Variante, weißer Text auf farbigem Hintergrund)
- `PukKarte` (orange-Variante, weiße Karte mit orangem Border)
- `EntlastungKarte` (green-Variante, weiße Karte mit grünem Border)
- Inline Lila-Karte für Vergiftung (lila-Variante)

**`InfoKarte`** (neu) — ersetzt die 4 identischen `<a>`-Tags in Block 5 (Weitere Kontakte)

Entfernt ~130 Zeilen duplizierter JSX. Visuelles Ergebnis identisch.