### PR TITLE
fix: P1 mobile menu – Ressourcen grouped, Soforthilfe deduplicated

### DIFF
--- a/client/src/components/layout/MobileMenu.tsx
+++ b/client/src/components/layout/MobileMenu.tsx
@@ -1,6 +1,11 @@
 import { Link } from "wouter";
 import { AnimatePresence, motion } from "framer-motion";
-import { ChevronDown, FolderOpen, Phone, Search as SearchIcon } from "lucide-react";
+import {
+  ChevronDown,
+  FolderOpen,
+  Phone,
+  Search as SearchIcon,
+} from "lucide-react";
 import { navItems, ressourcenItems } from "@/components/layout/navigationData";
 
 interface MobileMenuProps {
@@ -12,6 +17,17 @@ interface MobileMenuProps {
   onSearchOpen: () => void;
 }
 
+// Ressourcen-Items nach Gruppe sortieren
+function groupRessourcenItems(items: typeof ressourcenItems) {
+  const groups: Record<string, typeof ressourcenItems> = {};
+  for (const item of items) {
+    const key = item.group ?? "Weitere";
+    if (!groups[key]) groups[key] = [];
+    groups[key].push(item);
+  }
+  return groups;
+}
+
 export function MobileMenu({
   isOpen,
   location,
@@ -20,9 +36,11 @@ export function MobileMenu({
   closeMenu,
   onSearchOpen,
 }: MobileMenuProps) {
-  const isRessourcenActive = ressourcenItems.some((item) =>
-    location.startsWith(item.href.split("#")[0]),
+  const isRessourcenActive = ressourcenItems.some(item =>
+    location.startsWith(item.href.split("#")[0])
   );
+
+  const groupedRessourcen = groupRessourcenItems(ressourcenItems);
 
   return (
     <AnimatePresence>
@@ -37,7 +55,7 @@ export function MobileMenu({
             maxHeight: "calc(100dvh - 5rem)",
             WebkitOverflowScrolling: "touch",
           }}
-          onKeyDown={(e) => {
+          onKeyDown={e => {
             if (e.key === "Escape") {
               closeMenu();
             }
@@ -45,9 +63,12 @@ export function MobileMenu({
         >
           <nav
             className="container py-4 flex flex-col gap-2"
-            style={{ paddingBottom: "calc(16px + env(safe-area-inset-bottom, 0px) + 88px)" }}
+            style={{
+              paddingBottom:
+                "calc(16px + env(safe-area-inset-bottom, 0px) + 88px)",
+            }}
           >
-            {navItems.map((item) => {
+            {navItems.map(item => {
               const Icon = item.icon;
               const isActive = location.startsWith(item.href);
               return (
@@ -101,36 +122,45 @@ export function MobileMenu({
                       id="mobile-ressourcen-menu"
                       role="menu"
                       aria-label="Ressourcen-Navigation"
-                      className="pl-4 mt-1 flex flex-col gap-1"
+                      className="pl-4 mt-1 flex flex-col gap-0"
                     >
-                      {ressourcenItems.map((item) => {
-                        const Icon = item.icon;
-                        const normalizedHref = item.href.split("#")[0];
-                        const isActive = location === normalizedHref;
-                        const isSoforthilfe = item.href === "/soforthilfe";
-
-                        return (
-                          <Link
-                            key={item.href}
-                            href={item.href}
-                            role="menuitem"
-                            onClick={() => {
-                              closeMenu();
-                              setMobileRessourcenOpen(false);
-                            }}
-                            className={`flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm font-medium transition-all ${
-                              isSoforthilfe
-                                ? "text-alert font-semibold"
-                                : isActive
-                                  ? "bg-sage-wash/50 text-sage-darker"
-                                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
-                            }`}
+                      {Object.entries(groupedRessourcen).map(
+                        ([groupName, items], groupIndex) => (
+                          <div
+                            key={groupName}
+                            className={groupIndex > 0 ? "mt-2" : ""}
                           >
-                            <Icon className={`w-4 h-4 ${isSoforthilfe ? "text-alert" : ""}`} />
-                            {item.label}
-                          </Link>
-                        );
-                      })}
+                            <p className="px-4 pt-2 pb-1 text-xs font-semibold text-muted-foreground/60 uppercase tracking-wider">
+                              {groupName}
+                            </p>
+                            {items.map(item => {
+                              const Icon = item.icon;
+                              const normalizedHref = item.href.split("#")[0];
+                              const isActive = location === normalizedHref;
+
+                              return (
+                                <Link
+                                  key={item.href}
+                                  href={item.href}
+                                  role="menuitem"
+                                  onClick={() => {
+                                    closeMenu();
+                                    setMobileRessourcenOpen(false);
+                                  }}
+                                  className={`flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm font-medium transition-all ${
+                                    isActive
+                                      ? "bg-sage-wash/50 text-sage-darker"
+                                      : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                  }`}
+                                >
+                                  <Icon className="w-4 h-4" />
+                                  {item.label}
+                                </Link>
+                              );
+                            })}
+                          </div>
+                        )
+                      )}
                     </div>
                   </motion.div>
                 )}

--- a/client/src/components/layout/RessourcenMenu.tsx
+++ b/client/src/components/layout/RessourcenMenu.tsx
@@ -85,11 +85,12 @@ export function RessourcenMenu({
                 const isActive =
                   location === normalizedHref ||
                   location.startsWith(`${normalizedHref}/`);
-                const isSoforthilfe = item.href === "/soforthilfe";
+                const prevItem = ressourcenItems[index - 1];
+                const isNewGroup = index > 0 && item.group !== prevItem?.group;
 
                 return (
                   <div key={item.href}>
-                    {index === 1 && (
+                    {isNewGroup && (
                       <div className="mx-3 my-1 border-t border-border/40" />
                     )}
                     <Link
@@ -104,16 +105,12 @@ export function RessourcenMenu({
                       }}
                       onClick={closeDropdown}
                       className={`flex items-center gap-3 px-4 py-2.5 text-sm transition-all outline-none focus-visible:ring-2 focus-visible:ring-sage-dark/40 focus-visible:ring-inset ${
-                        isSoforthilfe
-                          ? "text-alert font-medium hover:bg-alert/8 focus:bg-alert/8"
-                          : isActive
-                            ? "bg-sage-wash/50 text-sage-darker font-medium"
-                            : "text-muted-foreground hover:text-foreground hover:bg-muted/60 focus:text-foreground focus:bg-muted/60"
+                        isActive
+                          ? "bg-sage-wash/50 text-sage-darker font-medium"
+                          : "text-muted-foreground hover:text-foreground hover:bg-muted/60 focus:text-foreground focus:bg-muted/60"
                       }`}
                     >
-                      <Icon
-                        className={`w-4 h-4 shrink-0 ${isSoforthilfe ? "text-alert" : ""}`}
-                      />
+                      <Icon className="w-4 h-4 shrink-0" />
                       {item.label}
                     </Link>
                   </div>

--- a/client/src/domain/content-types.ts
+++ b/client/src/domain/content-types.ts
@@ -4,6 +4,7 @@ export interface NavigationItem {
   href: string;
   label: string;
   icon: LucideIcon;
+  group?: string;
 }
 
 export interface SelectableCategory<TId extends string = string> {

--- a/client/src/domain/navigation.ts
+++ b/client/src/domain/navigation.ts
@@ -9,7 +9,6 @@ import {
   Heart,
   HelpCircle,
   MessageCircle,
-  Phone,
   Shield,
   Sparkles,
   Stethoscope,
@@ -26,20 +25,73 @@ export const primaryNavigationItems: NavigationItem[] = [
 ];
 
 export const resourceNavigationItems: NavigationItem[] = [
-  { href: "/selbsttest", label: "Selbsttest", icon: ClipboardCheck },
-  { href: "/materialien", label: "Materialien & Handouts", icon: Download },
-  { href: "/genesung", label: "Genesung & Hoffnung", icon: TrendingUp },
-  { href: "/wegweiser", label: "Situations-Wegweiser", icon: Compass },
-  { href: "/notfallkarte", label: "Notfallkarte", icon: FileText },
-  { href: "/beratung", label: "Beratung & Netzwerke", icon: Heart },
-  { href: "/fachstelle", label: "Fachstelle & Kontakt", icon: Building2 },
-  { href: "/faq", label: "Häufige Fragen (FAQ)", icon: HelpCircle },
-  { href: "/glossar", label: "Glossar", icon: BookMarked },
-  { href: "/buchempfehlungen", label: "Buchempfehlungen", icon: BookOpen },
+  // Gruppe: Sofortige Hilfe
+  {
+    href: "/notfallkarte",
+    label: "Notfallkarte",
+    icon: FileText,
+    group: "Sofortige Hilfe",
+  },
+  {
+    href: "/wegweiser",
+    label: "Situations-Wegweiser",
+    icon: Compass,
+    group: "Sofortige Hilfe",
+  },
+  {
+    href: "/selbsttest",
+    label: "Selbsttest",
+    icon: ClipboardCheck,
+    group: "Sofortige Hilfe",
+  },
+  // Gruppe: Wissen & Materialien
+  {
+    href: "/materialien",
+    label: "Materialien & Handouts",
+    icon: Download,
+    group: "Wissen & Materialien",
+  },
+  {
+    href: "/genesung",
+    label: "Genesung & Hoffnung",
+    icon: TrendingUp,
+    group: "Wissen & Materialien",
+  },
+  {
+    href: "/faq",
+    label: "Häufige Fragen (FAQ)",
+    icon: HelpCircle,
+    group: "Wissen & Materialien",
+  },
+  {
+    href: "/glossar",
+    label: "Glossar",
+    icon: BookMarked,
+    group: "Wissen & Materialien",
+  },
+  {
+    href: "/buchempfehlungen",
+    label: "Buchempfehlungen",
+    icon: BookOpen,
+    group: "Wissen & Materialien",
+  },
+  // Gruppe: Beratung & Netzwerke
+  {
+    href: "/beratung",
+    label: "Beratung & Netzwerke",
+    icon: Heart,
+    group: "Beratung & Netzwerke",
+  },
+  {
+    href: "/fachstelle",
+    label: "Fachstelle & Kontakt",
+    icon: Building2,
+    group: "Beratung & Netzwerke",
+  },
   {
     href: "/unterstuetzen/therapie#therapieangebote",
     label: "Therapieangebote Zürich",
     icon: Stethoscope,
+    group: "Beratung & Netzwerke",
   },
-  { href: "/soforthilfe", label: "Soforthilfe", icon: Phone },
 ];


### PR DESCRIPTION
## P1 Mobile Menu Grouping

### Problem
12 resource links in a flat unordered list overwhelm mobile users in stress.
Soforthilfe appeared twice (in resource list + dedicated red button).

### Changes
- **NavigationItem type**: add optional `group` field
- **navigation.ts**: 3 logical groups, Soforthilfe removed from list
  - Sofortige Hilfe: Notfallkarte, Situations-Wegweiser, Selbsttest
  - Wissen & Materialien: Materialien, Genesung, FAQ, Glossar, Buchempfehlungen
  - Beratung & Netzwerke: Beratung, Fachstelle, Therapieangebote
- **MobileMenu**: section headers per group
- **RessourcenMenu (desktop)**: group-based dividers, removed dead `isSoforthilfe` code