### PR TITLE
fix: P2 Soforthilfe – triage section

### DIFF
--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -358,6 +358,61 @@ export default function Notfall() {
         </div>
       </section>
 
+      {/* ═══ TRIAGE ═══ */}
+      <section className="bg-muted/30 border-y border-border/40 py-4 print:hidden">
+        <div className="container">
+          <div className="max-w-2xl mx-auto">
+            <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+              Was ist gerade los?
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              <button
+                type="button"
+                onClick={() =>
+                  document
+                    .getElementById("block-rot")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" })
+                }
+                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-background border border-[var(--color-sos-rot)]/40 hover:border-[var(--color-sos-rot)] hover:bg-[var(--color-sos-rot-wash)] transition-all text-left group"
+              >
+                <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sos-rot)] shrink-0" />
+                <span className="text-sm font-medium text-foreground">
+                  Akute Lebensgefahr
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  document
+                    .getElementById("block-orange")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" })
+                }
+                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-background border border-[var(--color-sos-orange-text)]/30 hover:border-[var(--color-sos-orange-text)] hover:bg-[var(--color-sos-orange-wash)] transition-all text-left group"
+              >
+                <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sos-orange-text)] shrink-0" />
+                <span className="text-sm font-medium text-foreground">
+                  Psychiatrische Krise
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  document
+                    .getElementById("block-gruen")
+                    ?.scrollIntoView({ behavior: "smooth", block: "start" })
+                }
+                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-background border border-[var(--color-sos-gruen-text)]/30 hover:border-[var(--color-sos-gruen-text)] hover:bg-[var(--color-sos-gruen-wash)] transition-all text-left group"
+              >
+                <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sos-gruen-text)] shrink-0" />
+                <span className="text-sm font-medium text-foreground">
+                  Jemand zum Reden
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </section>
+
       {/* ═══ STICKY AMPEL ═══ */}
       <StickyAmpelLeiste />
 


### PR DESCRIPTION
## P2: Soforthilfe Triage Section

### Problem
Users arriving on /soforthilfe had no orientation until they scrolled 280px (when the StickyAmpelLeiste appears). Stressed relatives needed to scan/scroll to find the right section.

### Solution
Static 'Was ist gerade los?' section between hero and content blocks:
- 🔴 Akute Lebensgefahr → scrolls to #block-rot
- 🟠 Psychiatrische Krise → scrolls to #block-orange
- 🟢 Jemand zum Reden → scrolls to #block-gruen

Color-coded to match the existing block system. Hidden from print.