### PR TITLE
feat: P1 actionability — Telefon-Leitfaden, Nachkrisenwoche, Musterbrief

### DIFF
--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -422,6 +422,45 @@ export default function Notfall() {
                   Vorgehen anleiten.
                 </p>
               </div>
+
+              {/* Telefon-Leitfaden */}
+              <div className="px-5 py-4 sm:px-6 sm:py-5 bg-sos-rot-body border-t border-white/10">
+                <p className="text-white/90 text-xs font-semibold uppercase tracking-wide mb-3">
+                  Die ersten 30 Sekunden am Telefon
+                </p>
+                <div className="space-y-2">
+                  {[
+                    {
+                      nr: "1",
+                      text: "Name nennen + Beziehung: «Ich bin [Name], ich rufe für meine Tochter/meinen Partner/…»",
+                    },
+                    {
+                      nr: "2",
+                      text: "Art der Situation: «Es geht um eine Suizidgefahr / Selbstverletzung / unkontrolliertes Verhalten»",
+                    },
+                    {
+                      nr: "3",
+                      text: "Was passiert gerade: «Sie sitzt in ihrem Zimmer und sagt, sie will nicht mehr leben»",
+                    },
+                    {
+                      nr: "4",
+                      text: "Sicherheit klären: «Ich bin bei ihr / sie ist alleine / wir sind in Sicherheit»",
+                    },
+                  ].map(item => (
+                    <div
+                      key={item.nr}
+                      className="flex items-start gap-3 p-3 rounded-lg bg-white/10"
+                    >
+                      <span className="flex-shrink-0 w-5 h-5 rounded-full bg-white/20 text-white text-xs font-bold flex items-center justify-center">
+                        {item.nr}
+                      </span>
+                      <p className="text-white/90 text-sm leading-snug">
+                        {item.text}
+                      </p>
+                    </div>
+                  ))}
+                </div>
+              </div>
             </motion.div>
 
             {/* ─── BLOCK 2: PSYCHIATRISCHE KRISE (ORANGE) ─── */}

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -18,6 +18,7 @@ import {
   CheckCircle2,
   Users,
   Lightbulb,
+  CalendarDays,
 } from "lucide-react";
 import { Link } from "wouter";
 import { kontaktByIdStrict } from "@/data/kontakte";
@@ -679,6 +680,75 @@ export default function UnterstuetzenKrise() {
                       </ul>
                     </CardContent>
                   </Card>
+                </div>
+
+                {/* Tag-für-Tag: Erste Woche nach der Krise */}
+                <div>
+                  <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
+                    <CalendarDays className="w-5 h-5 text-sage-mid" />
+                    Erste Woche nach der Krise – Tag für Tag
+                  </h3>
+                  <div className="space-y-3">
+                    {[
+                      {
+                        tage: "Tag 1–2",
+                        titel: "Ruhe und Sicherheit",
+                        farbe: "bg-sage-wash/40 border-sage/40",
+                        punkte: [
+                          "Keine Aufarbeitung, keine Erklärungen, kein Warum",
+                          "Sagen Sie: «Ich bin froh, dass du da bist. Wir müssen jetzt nichts besprechen.»",
+                          "Grundbedürfnisse sichern: Schlafen, Essen, körperliche Anwesenheit",
+                        ],
+                      },
+                      {
+                        tage: "Tag 3–4",
+                        titel: "Kurze Check-ins",
+                        farbe: "bg-cream border-border/40",
+                        punkte: [
+                          "Kurzes, konkretes Nachfragen erlaubt: «Wie geht es dir gerade – in diesem Moment?»",
+                          "Keine Bewertungen, keine Rückblicke auf die Krise",
+                          "Therapeut oder Krisentelefon kontaktieren, falls nötig",
+                        ],
+                      },
+                      {
+                        tage: "Tag 5–7",
+                        titel: "Aufarbeitung vorbereiten",
+                        farbe: "bg-muted/30 border-border/40",
+                        punkte: [
+                          "Erst wenn beide bereit sind: Was hat geholfen? Was hat die Krise ausgelöst?",
+                          "Kein Vorwurf, kein Schuldaufbau – gemeinsames Lernen",
+                          "Nächsten Termin beim Therapeuten koordinieren",
+                        ],
+                      },
+                    ].map(phase => (
+                      <Card
+                        key={phase.tage}
+                        className={`border ${phase.farbe}`}
+                      >
+                        <CardContent className="p-4">
+                          <div className="flex items-center gap-2 mb-2">
+                            <span className="text-xs font-semibold text-sage-dark bg-sage-wash px-2 py-0.5 rounded-full">
+                              {phase.tage}
+                            </span>
+                            <span className="text-sm font-semibold text-foreground">
+                              {phase.titel}
+                            </span>
+                          </div>
+                          <ul className="space-y-1.5">
+                            {phase.punkte.map((p, i) => (
+                              <li
+                                key={i}
+                                className="flex items-start gap-2 text-sm text-muted-foreground"
+                              >
+                                <span className="text-sage-mid mt-0.5">→</span>
+                                {p}
+                              </li>
+                            ))}
+                          </ul>
+                        </CardContent>
+                      </Card>
+                    ))}
+                  </div>
                 </div>
 
                 {/* Früherkennung für nächste Krise */}

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -341,6 +341,56 @@ export default function UnterstuetzenTherapie() {
             </ContentSection>
 
             <ContentSection
+              title="Erstkontakt mit dem Therapeuten – Musterbrief"
+              icon={<Mail className="w-7 h-7 text-sage-mid" />}
+              id="musterbrief"
+              preview="Eine kurze, klare E-Mail kann den Einstieg erleichtern. Hier ein Muster, das Sie anpassen können."
+            >
+              <div className="space-y-4">
+                <p className="text-muted-foreground leading-relaxed">
+                  Wenn Sie als Angehörige/r Kontakt mit dem Therapeuten
+                  aufnehmen möchten – z. B. um sich zu informieren oder Ihre
+                  Perspektive einzubringen – kann eine kurze schriftliche
+                  Nachricht helfen. Das Muster unten dient als Ausgangspunkt.
+                </p>
+                <Card className="border-border/50 bg-cream">
+                  <CardContent className="p-5">
+                    <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
+                      Muster-E-Mail
+                    </p>
+                    <div className="font-mono text-sm text-foreground leading-relaxed space-y-3 whitespace-pre-line">
+                      <p>
+                        {`Betreff: Kurze Anfrage als Angehörige/r von [Vorname]
+
+Sehr geehrte/r Frau/Herr [Name],
+
+ich bin [Ihre Beziehung zur Person, z. B. Mutter / Partner] von [Vorname], der/die bei Ihnen in Behandlung ist.
+
+Ich möchte Sie nicht in die Behandlung einbeziehen oder Informationen über meinen Angehörigen einholen – das liegt allein bei ihm/ihr.
+
+Mir wäre es wichtig zu wissen, ob es für Angehörige die Möglichkeit gibt, einmal kurz mit Ihnen zu sprechen – nicht über die Therapie, sondern über meine eigene Rolle und Unterstützungsmöglichkeiten.
+
+Mit freundlichen Grüssen,
+[Ihr Name]
+[Optional: Telefonnummer für Rückruf]`}
+                      </p>
+                    </div>
+                  </CardContent>
+                </Card>
+                <div className="flex items-start gap-3 p-4 rounded-xl bg-sage-wash/40 border border-sage/30">
+                  <CheckCircle2 className="w-4 h-4 text-sage-mid mt-0.5 flex-shrink-0" />
+                  <p className="text-sm text-muted-foreground">
+                    <strong className="text-foreground">Wichtig:</strong> Der
+                    Therapeut ist an die Schweigepflicht gebunden und darf ohne
+                    Einwilligung Ihres Angehörigen keine Inhalte der Behandlung
+                    besprechen. Das ist kein Ablehnen – sondern professionelles
+                    Handeln.
+                  </p>
+                </div>
+              </div>
+            </ContentSection>
+
+            <ContentSection
               title="Rückschläge und Unterbrüche"
               icon={<RefreshCw className="w-7 h-7 text-sage-mid" />}
               id="rueckschlaege"


### PR DESCRIPTION
## P1 Actionability Fixes

Drei konkrete Ergänzungen um die Handlungsfähigkeit der Angehörigen zu stärken.

### Soforthilfe.tsx
- Neuer Abschnitt **«Die ersten 30 Sekunden am Telefon»** im roten Block (Lebensgefahr)
- 4 nummerierte Schritte: Name/Beziehung → Krisenart → Was passiert → Sicherheitslage
- Visuell konsistent im roten Block (bg-white/10 Karten)

### UnterstuetzenKrise.tsx
- Neue Sektion **«Erste Woche nach der Krise – Tag für Tag»** im Abschnitt «Nach der Krise»
- 3 Phasen: Tag 1–2 (Ruhe), Tag 3–4 (Check-ins), Tag 5–7 (Aufarbeitung)
- Je 3 konkrete Handlungsanweisungen pro Phase mit Mustersätzen

### UnterstuetzenTherapie.tsx
- Neue ContentSection **«Erstkontakt mit dem Therapeuten – Musterbrief»**
- Copyable E-Mail-Vorlage in Monospace-Schrift
- Hinweis auf Schweigepflicht + was realistisch möglich ist

### Technisch
- `CalendarDays` Icon zu UnterstuetzenKrise imports hinzugefügt
- `Mail` war bereits in UnterstuetzenTherapie importiert
- Lint ✅ Build ✅