### PR TITLE
fix: CI pnpm version conflict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Problem\n\nCI schlägt fehl mit:\n```\nError: Multiple versions of pnpm specified:\n  - version 10 in the GitHub Action config\n  - version pnpm@10.4.1+sha512... in package.json\n```\n\n## Fix\n\n`version: 10` aus dem Workflow entfernt. `pnpm/action-setup@v4` liest die Version automatisch aus dem `packageManager`-Feld in `package.json`.