### PR TITLE
feat: trust & credibility — Gewalt, Quellen-Seite, Disclaimer, FAQ-Fix

### DIFF
--- a/client/src/app/routes.ts
+++ b/client/src/app/routes.ts
@@ -37,6 +37,7 @@ const Fachstelle = lazy(() => import("@/pages/Fachstelle"));
 const Notfallkarte = lazy(() => import("@/pages/Notfallkarte"));
 const Wegweiser = lazy(() => import("@/pages/Wegweiser"));
 const Uebungsszenarien = lazy(() => import("@/pages/Uebungsszenarien"));
+const Quellen = lazy(() => import("@/pages/Quellen"));
 
 export const routes: AppRoute[] = [
   { path: "/", component: Home },
@@ -71,4 +72,5 @@ export const routes: AppRoute[] = [
   { path: "/notfallkarte", component: Notfallkarte },
   { path: "/wegweiser", component: Wegweiser },
   { path: "/uebungen", component: Uebungsszenarien },
+  { path: "/quellen", component: Quellen },
 ];

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -70,7 +70,7 @@ export default function FAQ() {
         {
           question: "Ist Borderline erblich? Bin ich schuld?",
           answer:
-            "Borderline entsteht durch ein Zusammenspiel von genetischer Veranlagung (ca. 40–60% Erblichkeit) und Umweltfaktoren wie Traumata oder invalidierendes Umfeld. Genetisch wird eine erhöhte emotionale Sensibilität vererbt – nicht die Störung selbst. Sie sind nicht schuld: Viele Menschen mit schwierigen Kindheiten entwickeln keine Borderline, und manche Betroffene hatten keine offensichtlichen Traumata.",
+            "Borderline entsteht durch ein Zusammenspiel von genetischer Veranlagung (ca. 40–60% Erblichkeit) und Umweltfaktoren – insbesondere Traumata und invalidierendes Umfeld. Genetisch wird eine erhöhte emotionale Sensibilität vererbt, nicht die Störung selbst. Traumatische Erfahrungen erhöhen das Risiko, führen aber nicht automatisch zu Borderline. Viele Menschen mit schwierigen Kindheiten entwickeln keine BPS, und manche Betroffene hatten keine offensichtlichen Traumata. Die Ursachen sind komplex – Sie tragen keine Schuld.",
           links: [{ text: "Borderline verstehen", url: "/verstehen" }],
         },
         {

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -13,6 +13,7 @@ import {
   Eye,
   Heart,
   MessageSquare,
+  Phone,
   Shield,
   Users,
 } from "lucide-react";
@@ -591,6 +592,81 @@ export default function Grenzen() {
                 </CardContent>
               </Card>
             </motion.div>
+            <ContentSection
+              title="Wenn der Angehörige körperlich übergriffig wird"
+              icon={<Phone className="w-7 h-7 text-sos-rot" />}
+              id="gewalt"
+              preview="Körperliche Übergriffe sind keine Grenzverletzung – sie sind eine Gefährdung. Das erfordert eine andere Reaktion als verbale Eskalation."
+            >
+              <div className="space-y-4">
+                <Card className="border-l-4 border-l-red-500 bg-red-50/30">
+                  <CardContent className="p-5">
+                    <p className="text-sm font-semibold text-foreground mb-2">
+                      Körperliche Gewalt ist kein Beziehungsproblem — es ist
+                      eine Sicherheitsfrage.
+                    </p>
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      Borderline erklärt Übergriffe nicht und entschuldigt sie
+                      nicht. Wenn Sie körperlich bedroht oder verletzt werden,
+                      ist Ihre Sicherheit die einzige Priorität.
+                    </p>
+                  </CardContent>
+                </Card>
+                <div className="space-y-3">
+                  {[
+                    {
+                      schritt: "Verlassen Sie die Situation",
+                      detail:
+                        "Gehen Sie in ein anderes Zimmer, aus dem Haus oder zu Nachbarn. Sicherheit hat Vorrang vor Deeskalationsversuchen.",
+                    },
+                    {
+                      schritt: "Rufen Sie 117 (Polizei) oder 144",
+                      detail:
+                        "Bei akuter Gefahr sofort. Sie müssen sich nicht sicher sein, ob es «schlimm genug» ist — die Polizei entscheidet das.",
+                    },
+                    {
+                      schritt: "Sprechen Sie danach mit einer Fachstelle",
+                      detail:
+                        "Opferhilfe Zürich (0800 040 080, kostenlos), Frauenhaus oder Beratungsstelle. Es gibt Unterstützung auch für Männer.",
+                    },
+                    {
+                      schritt: "Halten Sie Vorfälle fest",
+                      detail:
+                        "Datum, Beschreibung, allfällige Zeugen. Das ist wichtig, wenn Sie später rechtliche Schritte prüfen möchten.",
+                    },
+                  ].map((item, i) => (
+                    <div
+                      key={i}
+                      className="flex items-start gap-3 p-4 rounded-xl bg-cream border border-border/30"
+                    >
+                      <span className="flex-shrink-0 w-6 h-6 rounded-full bg-red-100 text-red-700 text-xs font-bold flex items-center justify-center">
+                        {i + 1}
+                      </span>
+                      <div>
+                        <p className="text-sm font-semibold text-foreground">
+                          {item.schritt}
+                        </p>
+                        <p className="text-sm text-muted-foreground mt-0.5">
+                          {item.detail}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <Card className="border-sage bg-sage-wash/30">
+                  <CardContent className="p-4">
+                    <p className="text-sm text-muted-foreground leading-relaxed">
+                      Viele Angehörige zögern, weil sie fürchten, die Person zu
+                      «verraten» oder die Situation zu eskalieren.
+                      Professionelle Hilfe zu holen ist kein Verrat — es ist oft
+                      der einzige Weg, eine Beziehung langfristig überhaupt zu
+                      stabilisieren.
+                    </p>
+                  </CardContent>
+                </Card>
+              </div>
+            </ContentSection>
+
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}

--- a/client/src/pages/Impressum.tsx
+++ b/client/src/pages/Impressum.tsx
@@ -12,6 +12,7 @@ import {
   Target,
   Copyright,
 } from "lucide-react";
+import { Link } from "wouter";
 import { kontaktByIdStrict, emailByIdStrict } from "@/data/kontakte";
 
 const fachstelle = kontaktByIdStrict("INFO_FACHSTELLE");
@@ -234,6 +235,14 @@ export default function Impressum() {
                   <p className="text-muted-foreground leading-relaxed mb-4">
                     Die Inhalte dieser Website basieren auf anerkannter
                     Fachliteratur und evidenzbasierten Methoden, insbesondere:
+                  </p>
+                  <p className="text-sm text-sage-dark mb-4">
+                    <Link
+                      href="/quellen"
+                      className="underline hover:no-underline"
+                    >
+                      → Vollständige Literaturliste mit PubMed-Links
+                    </Link>
                   </p>
                   <ul className="space-y-3 text-muted-foreground">
                     <li className="border-l-2 border-sage pl-4">

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -139,6 +139,38 @@ export default function Kommunizieren() {
 
                 <ValidierungsStufenleiter />
 
+                {/* Validierung ≠ Zustimmung */}
+                <div className="rounded-lg border border-amber-200/60 bg-amber-50/30 p-4">
+                  <p className="text-sm font-semibold text-foreground mb-3">
+                    Validierung ≠ Zustimmung — ein Beispiel
+                  </p>
+                  <div className="grid sm:grid-cols-2 gap-3">
+                    <div className="p-3 rounded-lg bg-red-50/50 border border-red-200/50">
+                      <p className="text-xs font-semibold text-red-700 mb-1">
+                        ✗ Ohne Validierung
+                      </p>
+                      <p className="text-sm text-muted-foreground italic">
+                        «Das stimmt nicht. Ich habe das nie so gesagt.»
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        → Gefühl ignoriert, Eskalation wahrscheinlich
+                      </p>
+                    </div>
+                    <div className="p-3 rounded-lg bg-sage-wash/60 border border-sage/40">
+                      <p className="text-xs font-semibold text-sage-dark mb-1">
+                        ✓ Validierend + klar
+                      </p>
+                      <p className="text-sm text-muted-foreground italic">
+                        «Ich sehe, dass dich das verletzt hat. Ich habe das
+                        nicht so gemeint.»
+                      </p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        → Emotion anerkannt, eigene Aussage klar
+                      </p>
+                    </div>
+                  </div>
+                </div>
+
                 {/* Validierungs-Situationsmatrix */}
                 <div className="rounded-lg border border-sage-mid/30 bg-sage-light/5 p-4">
                   <p className="text-sm font-semibold text-foreground mb-3">

--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -1,0 +1,271 @@
+import SEO from "@/components/SEO";
+import Layout from "@/components/Layout";
+import { Card, CardContent } from "@/components/ui/card";
+import { motion } from "framer-motion";
+import { BookOpen, ExternalLink, FlaskConical, Users } from "lucide-react";
+
+const quellen = [
+  {
+    kategorie: "Klinische Studien & Forschung",
+    icon: FlaskConical,
+    eintraege: [
+      {
+        autoren: "Zanarini, M. C. et al.",
+        jahr: "2010 / 2012",
+        titel:
+          "Attainment and stability of sustained symptomatic remission and recovery among borderline patients and Axis II comparison subjects",
+        quelle: "American Journal of Psychiatry",
+        hinweis:
+          "Grundlage für Remissions- und Recovery-Daten (85–93% Remission, ca. 50% Recovery nach 10 Jahren). Durchgeführt am McLean Hospital.",
+        link: "https://pubmed.ncbi.nlm.nih.gov/20595412/",
+      },
+      {
+        autoren: "Linehan, M. M.",
+        jahr: "1993",
+        titel:
+          "Cognitive-Behavioral Treatment of Borderline Personality Disorder",
+        quelle: "Guilford Press",
+        hinweis:
+          "Grundlagenwerk zur Dialektisch-Behavioralen Therapie (DBT). Beschreibt das bio-soziale Modell und Behandlungsansätze.",
+        link: null,
+      },
+      {
+        autoren: "Skodol, A. E. et al.",
+        jahr: "2005",
+        titel:
+          "Prevalence and quality of life in personality disorders: Results from the Collaborative Longitudinal Personality Disorders Study",
+        quelle: "Journal of Personality Disorders",
+        hinweis: "Prävalenz- und Verlaufsdaten zu Persönlichkeitsstörungen.",
+        link: "https://pubmed.ncbi.nlm.nih.gov/16274278/",
+      },
+      {
+        autoren: "Torgersen, S. et al.",
+        jahr: "2000",
+        titel: "The prevalence of personality disorders in a community sample",
+        quelle: "Archives of General Psychiatry",
+        hinweis: "Häufigkeit von BPS in der Allgemeinbevölkerung (ca. 1–3%).",
+        link: "https://pubmed.ncbi.nlm.nih.gov/10872917/",
+      },
+    ],
+  },
+  {
+    kategorie: "Fachliteratur Therapie & Behandlung",
+    icon: BookOpen,
+    eintraege: [
+      {
+        autoren: "Linehan, M. M.",
+        jahr: "1996",
+        titel:
+          "Dialektisch-Behaviorale Therapie der Borderline-Persönlichkeitsstörung",
+        quelle: "CIP-Medien",
+        hinweis: "Deutsche Ausgabe. Standardwerk für DBT-Behandlung.",
+        link: null,
+      },
+      {
+        autoren: "Bateman, A. & Fonagy, P.",
+        jahr: "2004",
+        titel:
+          "Psychotherapy for Borderline Personality Disorder: Mentalization-Based Treatment",
+        quelle: "Oxford University Press",
+        hinweis:
+          "Grundlage für mentalisierungsbasierte Therapie (MBT) als evidenzbasiertes Verfahren.",
+        link: null,
+      },
+      {
+        autoren: "Fruzzetti, A. E.",
+        jahr: "2006",
+        titel: "The High-Conflict Couple: A Dialectical Behavior Therapy Guide",
+        quelle: "New Harbinger Publications",
+        hinweis:
+          "DBT-Ansatz für Paare und Angehörige. Grundlage für Validierungs- und Kommunikationsmodule.",
+        link: null,
+      },
+      {
+        autoren: "Gunderson, J. G. & Hoffman, P. D.",
+        jahr: "2005",
+        titel:
+          "Understanding and Treating Borderline Personality Disorder: A Guide for Professionals and Families",
+        quelle: "American Psychiatric Publishing",
+        hinweis: "Verbindet klinische und Angehörigenperspektive.",
+        link: null,
+      },
+    ],
+  },
+  {
+    kategorie: "Angehörigen-Literatur",
+    icon: Users,
+    eintraege: [
+      {
+        autoren: "Mason, P. T. & Kreger, R.",
+        jahr: "2010",
+        titel: "Schluss mit dem Eiertanz",
+        quelle: "Balance Buch + Medien Verlag",
+        hinweis:
+          "Praxisnahe Anleitung für Angehörige. Grundlage für Konzepte wie «walking on eggshells», Kommunikationsstrategien und Grenzen.",
+        link: null,
+      },
+      {
+        autoren: "Kreisman, J. J. & Straus, H.",
+        jahr: "2004",
+        titel:
+          "I Hate You – Don't Leave Me: Understanding the Borderline Personality",
+        quelle: "Avery / Penguin",
+        hinweis: "Einflussreiches Angehörigenbuch; SET-Kommunikationsmodell.",
+        link: null,
+      },
+      {
+        autoren: "Hoffman, P. D. et al.",
+        jahr: "2005",
+        titel:
+          "Family Connections: A program for relatives of persons with borderline personality disorder",
+        quelle: "Family Process",
+        hinweis:
+          "Evidenzbasiertes Psychoedukationsprogramm für Angehörige (NEA-BPD). Grundlage für Angehörigen-Schulungsansätze.",
+        link: "https://pubmed.ncbi.nlm.nih.gov/15943545/",
+      },
+    ],
+  },
+  {
+    kategorie: "Diagnostik & Klassifikation",
+    icon: BookOpen,
+    eintraege: [
+      {
+        autoren: "American Psychiatric Association",
+        jahr: "2013",
+        titel: "Diagnostic and Statistical Manual of Mental Disorders (DSM-5)",
+        quelle: "American Psychiatric Publishing",
+        hinweis:
+          "Offizielle Diagnosekriterien für Borderline-Persönlichkeitsstörung (F60.31).",
+        link: null,
+      },
+      {
+        autoren: "World Health Organization",
+        jahr: "2019",
+        titel: "International Classification of Diseases (ICD-11)",
+        quelle: "WHO",
+        hinweis:
+          "Aktuelle internationale Klassifikation. BPS unter «6D11 Borderline pattern».",
+        link: "https://icd.who.int/browse11/l-m/en#/http%3a%2f%2fid.who.int%2ficd%2fentity%2f1307872093",
+      },
+    ],
+  },
+];
+
+export default function Quellen() {
+  return (
+    <Layout>
+      <SEO
+        title="Quellen & Literatur – Borderline Angehörige Zürich"
+        description="Wissenschaftliche Grundlagen und Fachliteratur dieser Website: klinische Studien, DBT-Literatur, Angehörigenbücher und Diagnoseklassifikationen."
+        canonical="/quellen"
+      />
+
+      {/* Hero */}
+      <section className="py-10 md:py-14 bg-gradient-to-b from-cream to-background border-b border-border/40">
+        <div className="container">
+          <div className="max-w-2xl">
+            <motion.div
+              initial={{ opacity: 0, y: 16 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.4 }}
+            >
+              <div className="flex items-center gap-3 mb-4">
+                <BookOpen className="w-8 h-8 text-sage-dark" />
+                <h1 className="text-3xl md:text-4xl font-bold text-foreground">
+                  Quellen & Literatur
+                </h1>
+              </div>
+              <p className="text-lg text-muted-foreground leading-relaxed mb-4">
+                Diese Website basiert auf anerkannter Fachliteratur und
+                evidenzbasierten Methoden. Hier finden Sie alle Quellen,
+                geordnet nach Bereich.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                Nicht alle Aussagen lassen sich einzeln belegen — manche
+                basieren auf klinischer Erfahrung und Angehörigenliteratur. Wo
+                Studien zitiert werden, sind sie hier aufgeführt.
+              </p>
+            </motion.div>
+          </div>
+        </div>
+      </section>
+
+      {/* Quellen */}
+      <section className="py-8 md:py-12">
+        <div className="container">
+          <div className="max-w-3xl mx-auto space-y-10">
+            {quellen.map((gruppe, gi) => (
+              <motion.div
+                key={gruppe.kategorie}
+                initial={{ opacity: 0, y: 20 }}
+                whileInView={{ opacity: 1, y: 0 }}
+                viewport={{ once: true }}
+                transition={{ delay: gi * 0.05 }}
+              >
+                <div className="flex items-center gap-2 mb-4">
+                  <gruppe.icon className="w-5 h-5 text-sage-mid" />
+                  <h2 className="text-base font-semibold text-foreground">
+                    {gruppe.kategorie}
+                  </h2>
+                </div>
+                <div className="space-y-3">
+                  {gruppe.eintraege.map((q, qi) => (
+                    <Card key={qi} className="border-border/50">
+                      <CardContent className="p-5">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="flex-1 min-w-0">
+                            <p className="font-medium text-foreground text-sm">
+                              {q.autoren}{" "}
+                              <span className="text-muted-foreground font-normal">
+                                ({q.jahr})
+                              </span>
+                            </p>
+                            <p className="text-sm text-foreground mt-0.5">
+                              {q.titel}
+                            </p>
+                            <p className="text-xs text-muted-foreground mt-0.5 italic">
+                              {q.quelle}
+                            </p>
+                            {q.hinweis && (
+                              <p className="text-xs text-muted-foreground mt-2 leading-relaxed">
+                                {q.hinweis}
+                              </p>
+                            )}
+                          </div>
+                          {q.link && (
+                            <a
+                              href={q.link}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="flex-shrink-0 flex items-center gap-1 text-xs text-sage-dark hover:underline"
+                            >
+                              <ExternalLink className="w-3.5 h-3.5" />
+                              PubMed / WHO
+                            </a>
+                          )}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </motion.div>
+            ))}
+
+            {/* Hinweis */}
+            <Card className="border-sage/40 bg-sage-wash/30">
+              <CardContent className="p-5">
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  <strong className="text-foreground">Hinweis:</strong> Diese
+                  Liste ist nicht abschliessend. Einzelne Inhalte basieren auf
+                  klinischer Erfahrung, Angehörigenliteratur oder didaktischen
+                  Vereinfachungen. Bei konkreten Fragen zu Studien oder
+                  Behandlungsempfehlungen wenden Sie sich an eine Fachstelle.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -420,6 +420,12 @@ export default function Notfall() {
       <section className="py-6 md:py-12 pb-32 sm:pb-12">
         <div className="container">
           <div className="max-w-2xl mx-auto space-y-8">
+            {/* Disclaimer */}
+            <p className="text-xs text-muted-foreground text-center">
+              Diese Seite ersetzt keine professionelle Notfallberatung. Im
+              Zweifel direkt{" "}
+              <strong className="text-foreground">144 / 117</strong> anrufen.
+            </p>
             {/* ─── BLOCK 1: LEBENSGEFAHR (ROT) ─── */}
             <motion.div
               id="block-rot"

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -127,6 +127,12 @@ export default function UnterstuetzenKrise() {
       <section className="py-8 md:py-12">
         <div className="container">
           <div className="max-w-3xl mx-auto">
+            {/* Disclaimer */}
+            <p className="text-xs text-muted-foreground text-center mb-6">
+              Diese Inhalte ersetzen keine professionelle Krisenberatung. Bei
+              akuter Gefahr direkt{" "}
+              <strong className="text-foreground">144 / 117</strong> anrufen.
+            </p>
             {/* Ampel-System */}
             <ContentSection
               title="Das Ampel-System: Krisen erkennen"


### PR DESCRIPTION
## Vertrauens-Fixes aus dem Trust-Audit

### P0.2 — Gewalt-Section (Grenzen.tsx)
Neue ContentSection «Wenn der Angehörige körperlich übergriffig wird»:
- 4-Schritt-Anleitung (Situation verlassen, 117 anrufen, Opferhilfe, Dokumentation)
- Opferhilfe Zürich 0800 040 080 erwähnt
- Klare Aussage: BPS erklärt keine Übergriffe

### P0.1 — Zentrale Quellenseite (/quellen)
Neue Seite mit vollständiger Bibliographie:
- 4 Kategorien: Studien, Therapie, Angehörige, Diagnostik
- PubMed-Links für Zanarini, Skodol, Torgersen, Hoffman et al.
- Link aus Impressum-Quellenangaben

### P1.3 — FAQ Erblichkeit präzisiert (FAQ.tsx)
- Alt: «Sie sind nicht schuld: Viele Menschen mit schwierigen Kindheiten entwickeln keine Borderline»
- Neu: Genetik + Umwelt zusammen; Trauma erhöht Risiko, führt aber nicht automatisch zu BPS

### P1.4 — Validierung ≠ Zustimmung (Kommunizieren.tsx)
Konkretes Gegenüberstellungs-Beispiel: ohne Validierung vs. validierend + klar

### P1.2 — On-page Disclaimer (Soforthilfe + UnterstuetzenKrise)
Dezenter Hinweis: «Ersetzt keine professionelle Krisenberatung. Bei akuter Gefahr 144/117.»

---
Lint ✅ Build ✅