### PR TITLE
content(p1): Komorbidität + Remissions-Kontext

### DIFF
--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -234,6 +234,14 @@ export default function Genesung() {
                     },
                   ]}
                 />
+
+                <p className="text-xs text-muted-foreground mt-4 px-1 leading-relaxed">
+                  <strong>Hinweis:</strong> Diese Zahlen stammen aus
+                  Spezialzentren unter optimalen Bedingungen. Der reale Weg ist
+                  für viele Menschen nicht-linear und braucht länger. Genesung
+                  bleibt das realistische Ziel — aber Rückschritte und lange
+                  Phasen gehören dazu.
+                </p>
               </CardContent>
             </Card>
           </motion.div>

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -600,6 +600,11 @@ export default function Verstehen() {
                       Belastungsfaktoren. Schuldzuweisungen an Betroffene oder
                       Angehörige greifen zu kurz und helfen niemandem.
                     </p>
+                    <p className="text-sm text-muted-foreground leading-relaxed mt-2">
+                      Borderline tritt häufig zusammen mit Depressionen,
+                      Angststörungen oder Traumafolgen auf. Das macht das Bild
+                      komplexer – hilft aber auch, Symptome richtig einzuordnen.
+                    </p>
                   </CardContent>
                 </Card>
               </div>


### PR DESCRIPTION
## Pre-Release P1 Fixes

### Verstehen.tsx — Komorbidität explizit erwähnt
In der bestehenden Karte «Ursachen sind nie monokausal» einen zweiten Absatz ergänzt:
> *«Borderline tritt häufig zusammen mit Depressionen, Angststörungen oder Traumafolgen auf. Das macht das Bild komplexer – hilft aber auch, Symptome richtig einzuordnen.»*

### Genesung.tsx — Remissions-Zahlen kontextualisiert
Kleiner Hinweis nach den Statistiken (85–93%):
> *«Hinweis: Diese Zahlen stammen aus Spezialzentren unter optimalen Bedingungen. Der reale Weg ist für viele Menschen nicht-linear...»*

**Build:** ✅