### PR TITLE
fix(stigma): Sprach-P2 – «normal», Last-Begründung, Zeitpräzisierung

### DIFF
--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -74,7 +74,8 @@ export default function FAQ() {
           links: [{ text: "Borderline verstehen", url: "/verstehen" }],
         },
         {
-          question: "Warum verhält sich mein Angehöriger bei anderen «normal»?",
+          question:
+            "Warum verhält sich mein Angehöriger bei anderen regulierter und stabiler?",
           answer:
             "Dieses Phänomen ist häufig und nicht automatisch ein Zeichen von Manipulation. Menschen mit Borderline haben oft die grössten Schwierigkeiten in engen Beziehungen, weil dort die Verlassensangst am stärksten aktiviert wird. Bei Fremden oder in oberflächlichen Kontakten ist diese Angst geringer, daher können sie sich besser regulieren. Es ist paradox: Je wichtiger Sie Ihrem Angehörigen sind, desto intensiver können die Symptome sein. Das ist keine bewusste Entscheidung, sondern ein Muster, das in der Therapie bearbeitet wird.",
           links: [{ text: "Beziehungsmuster verstehen", url: "/verstehen" }],

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -207,8 +207,8 @@ export default function Genesung() {
                       Jahre
                     </div>
                     <p className="text-sm text-muted-foreground">
-                      nicht Wochen: Entwicklung braucht meist viel Zeit und
-                      mehrere Anläufe
+                      nicht Wochen oder Monate – eher mindestens ein bis mehrere
+                      Jahre, oft mit mehreren Anläufen
                     </p>
                   </div>
                 </div>

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -168,7 +168,7 @@ export default function Selbstfuersorge() {
               icon={<Heart className="w-6 h-6 text-sage-mid" />}
               id="selbstfuersorge-warum-wichtig"
               defaultOpen={true}
-              preview="Angehörige tragen eine besondere Last. Selbstfürsorge ist keine Selbstsucht, sondern Selbsterhaltung."
+              preview="Angehörige tragen eine besondere Last – durch emotionale Intensität, dauernde Wachsamkeit und Unvorhersehbarkeit. Selbstfürsorge ist keine Selbstsucht, sondern Selbsterhaltung."
             >
               <div className="prose prose-slate max-w-none">
                 <p className="text-muted-foreground leading-relaxed mb-4">


### PR DESCRIPTION
## Stigma & Ton — P2 Sprachverbesserungen

**FAQ.tsx**: «normal» → «regulierter und stabiler»
**Selbstfuersorge.tsx**: Begründung der besonderen Last direkt im Preview-Text
**Genesung.tsx**: «viel Zeit» → «mindestens ein bis mehrere Jahre»