### PR TITLE
fix(a11y): P0 Kontrast – Soforthilfe Rot-Hintergrund

### DIFF
--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -92,7 +92,7 @@ function StickyAmpelLeiste() {
                 <span className="font-semibold leading-tight text-center">
                   {item.label}
                 </span>
-                <span className="text-white/80 text-[10px] sm:text-xs leading-tight">
+                <span className="text-white text-[10px] sm:text-xs leading-tight">
                   {item.sub}
                 </span>
               </button>
@@ -442,7 +442,7 @@ export default function Notfall() {
                     Lebensgefahr – sofort handeln
                   </h2>
                 </div>
-                <p className="text-white/85 text-sm leading-snug ml-9">
+                <p className="text-white text-sm leading-snug ml-9">
                   Bei akuter Suizidgefahr, schwerer Selbstverletzung, Gewalt
                   oder unmittelbarer Bedrohung.
                 </p>
@@ -515,7 +515,7 @@ export default function Notfall() {
                       <span className="flex-shrink-0 w-5 h-5 rounded-full bg-white/20 text-white text-xs font-bold flex items-center justify-center">
                         {item.nr}
                       </span>
-                      <p className="text-white/90 text-sm leading-snug">
+                      <p className="text-white text-sm leading-snug">
                         {item.text}
                       </p>
                     </div>


### PR DESCRIPTION
## WCAG P0 Kontrast-Fixes – Soforthilfe

3 Verstösse auf der Notfall-Seite behoben (Rot-Hintergrund):

| Element | Vorher | Nachher | Kontrast vorher |
|---------|--------|---------|-----------------|
| Ampel-Button Sub-Text | text-white/80 | text-white | 3.39:1 ❌ |
| Lebensgefahr-Header Subtext | text-white/85 | text-white | 3.84:1 ❌ |
| Telefon-Leitfaden Schritte | text-white/90 | text-white | 4.34:1 ❌ |

WCAG AA erfordert 4.5:1 für normalen Text. Alle drei Stellen lagen darunter – ausgerechnet auf der Notfall-Seite.