### PR TITLE
fix(a11y): Kontrast P1+P2 – Notfallkarte, Soforthilfe, Layout

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -42,7 +42,7 @@ export default function Layout({ children }: LayoutProps) {
       <HeaderNav onSearchOpen={() => setSearchOpen(true)} />
 
       <div className="border-b border-border/40 bg-sage-wash/40">
-        <div className="container py-1.5 text-xs text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1">
+        <div className="container py-1.5 text-sm md:text-xs text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1">
           <span className="font-medium text-foreground">
             Notfallkontakte: Schweiz (Kanton Zürich)
           </span>
@@ -79,7 +79,7 @@ export default function Layout({ children }: LayoutProps) {
                   Borderline \u00b7 Hilfe für Angehörige
                 </span>
               </Link>
-              <p className="text-white/70 text-sm leading-relaxed">
+              <p className="text-white/80 text-sm leading-relaxed">
                 Psychoedukatives Informationsangebot für Angehörige von Menschen
                 mit Borderline-Muster.
               </p>
@@ -95,7 +95,7 @@ export default function Layout({ children }: LayoutProps) {
                   <li key={item.href}>
                     <Link
                       href={item.href}
-                      className="text-white/70 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
+                      className="text-white/80 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
                     >
                       {item.label}
                     </Link>
@@ -114,7 +114,7 @@ export default function Layout({ children }: LayoutProps) {
                   <li key={item.href}>
                     <Link
                       href={item.href}
-                      className="text-white/70 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
+                      className="text-white/80 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
                     >
                       {item.label}
                     </Link>
@@ -128,7 +128,7 @@ export default function Layout({ children }: LayoutProps) {
               <h3 className="font-semibold text-white mb-4 text-base">
                 Hinweis
               </h3>
-              <p className="text-white/70 text-sm leading-relaxed">
+              <p className="text-white/80 text-sm leading-relaxed">
                 Diese Website ersetzt keine professionelle Beratung oder
                 Therapie. Bei akuten Krisen wenden Sie sich bitte an die
                 Notfallnummern.
@@ -142,45 +142,45 @@ export default function Layout({ children }: LayoutProps) {
               Herausgegeben von der Fachstelle Angehörigenarbeit der
               Psychiatrischen Universitätsklinik Zürich (PUK).
             </p>
-            <p className="text-xs text-white/70 mt-1 leading-relaxed">
+            <p className="text-xs text-white/80 mt-1 leading-relaxed">
               Redaktionell eigenständiges Informationsangebot der Fachstelle
               Angehörigenarbeit innerhalb der PUK Zürich.
             </p>
           </div>
 
           <div className="border-t border-white/10 mt-6 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
-            <p className="text-white/70 text-sm">
+            <p className="text-white/80 text-sm">
               \u00a9 2026 Borderline \u00b7 Hilfe für Angehörige. Alle Rechte
               vorbehalten.
             </p>
             <div className="flex flex-wrap gap-x-4 gap-y-1">
               <Link
                 href="/fachstelle"
-                className="text-white/70 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="text-white/80 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Fachstelle
               </Link>
               <Link
                 href="/ueber-uns"
-                className="text-white/70 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="text-white/80 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Über uns
               </Link>
               <Link
                 href="/impressum"
-                className="text-white/70 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="text-white/80 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Impressum
               </Link>
               <Link
                 href="/datenschutz"
-                className="text-white/70 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="text-white/80 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Datenschutz
               </Link>
               <Link
                 href="/feedback"
-                className="text-white/70 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="text-white/80 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Feedback
               </Link>

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -457,7 +457,7 @@ export default function Notfallkarte() {
             <div className="space-y-2">
               {data.calmingStrategies.map((s, i) => (
                 <div key={s.id} className="flex items-center gap-2">
-                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--color-sage-wash)] text-[var(--color-sage-dark)] text-xs font-medium flex items-center justify-center print:bg-gray-100">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-[var(--color-sage-wash)] text-[var(--color-sage-darker,var(--color-sage-dark))] text-xs font-bold flex items-center justify-center print:bg-gray-100">
                     {i + 1}
                   </span>
                   <input
@@ -503,7 +503,7 @@ export default function Notfallkarte() {
         </Card>
 
         {/* Info box */}
-        <div className="bg-[var(--color-sage-wash)] rounded-xl p-5 text-sm text-muted-foreground leading-relaxed print:hidden">
+        <div className="bg-[var(--color-sage-wash)] rounded-xl p-5 text-sm text-foreground/75 leading-relaxed print:hidden">
           <p className="font-medium text-foreground mb-1">
             Ihre Daten bleiben bei Ihnen
           </p>

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -317,7 +317,7 @@ export default function Notfall() {
               Notfallnummern und Anlaufstellen für akute Krisen in der Schweiz –
               wenn sofortiges Handeln erforderlich ist.
             </p>
-            <p className="inline-flex items-center gap-1.5 text-sm text-muted-foreground mb-5 bg-muted/40 px-3 py-1.5 rounded-full border border-border/50">
+            <p className="inline-flex items-center gap-1.5 text-sm text-muted-foreground mb-5 bg-muted/60 px-3 py-1.5 rounded-full border border-border/50">
               <Info className="w-3.5 h-3.5 shrink-0" />
               Gilt für die <strong className="text-foreground">
                 Schweiz
@@ -359,7 +359,7 @@ export default function Notfall() {
       </section>
 
       {/* ═══ TRIAGE ═══ */}
-      <section className="bg-muted/30 border-y border-border/40 py-4 print:hidden">
+      <section className="bg-muted/50 border-y border-border/40 py-4 print:hidden">
         <div className="container">
           <div className="max-w-2xl mx-auto">
             <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-3">
@@ -510,7 +510,7 @@ export default function Notfall() {
                   ].map(item => (
                     <div
                       key={item.nr}
-                      className="flex items-start gap-3 p-3 rounded-lg bg-white/10"
+                      className="flex items-start gap-3 p-3 rounded-lg bg-white/20"
                     >
                       <span className="flex-shrink-0 w-5 h-5 rounded-full bg-white/20 text-white text-xs font-bold flex items-center justify-center">
                         {item.nr}


### PR DESCRIPTION
## Lesbarkeits-Audit P1+P2 Fixes

**P1 – Grenzfälle behoben:**
- Notfallkarte Info-Box: text-muted-foreground → text-foreground/75 auf bg-sage-wash
- Notfallkarte Strategie-Badge: text-sage-dark → text-sage-darker + font-bold
- Soforthilfe Schweiz-Pill: bg-muted/40 → bg-muted/60
- Soforthilfe Triage-Section: bg-muted/30 → bg-muted/50

**P2 – Kleinere Optimierungen:**
- Soforthilfe Telefon-Schritte: bg-white/10 → bg-white/20 auf Rot-Hintergrund
- Layout Footer: text-white/70 → text-white/80 (11 Stellen)
- Layout Info-Banner: text-xs → text-sm md:text-xs (Mobile-Lesbarkeit)