### PR TITLE
fix(ts): canonical → canonicalPath in Quellen.tsx

### DIFF
--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -157,7 +157,7 @@ export default function Quellen() {
       <SEO
         title="Quellen & Literatur – Borderline Angehörige Zürich"
         description="Wissenschaftliche Grundlagen und Fachliteratur dieser Website: klinische Studien, DBT-Literatur, Angehörigenbücher und Diagnoseklassifikationen."
-        canonical="/quellen"
+        canonicalPath="/quellen"
       />
 
       {/* Hero */}


### PR DESCRIPTION
TypeScript-Fehler behoben: SEOProps kennt nur `canonicalPath`, nicht `canonical`. Blockierte Typecheck.