### PR TITLE
fix(a11y): <Link><Button> → <Button asChild><Link> – HTML-Semantik

### DIFF
--- a/client/src/components/Selbsttest.tsx
+++ b/client/src/components/Selbsttest.tsx
@@ -392,16 +392,17 @@ export default function Selbsttest() {
             </p>
 
             <div className="flex flex-col sm:flex-row gap-3 mb-6">
-              <Link href={result.primaryLink}>
-                <Button
-                  size="lg"
-                  className="w-full sm:w-auto text-white"
-                  style={{ backgroundColor: result.color }}
-                >
+              <Button
+                size="lg"
+                className="w-full sm:w-auto text-white"
+                style={{ backgroundColor: result.color }}
+                asChild
+              >
+                <Link href={result.primaryLink}>
                   {result.primaryText}
                   <ArrowRight className="w-5 h-5 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </div>
 
             <div className="border-t border-border/30 pt-4">

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -75,18 +75,18 @@ function GenesungInfografiken() {
         ))}
       </div>
       <div className="flex flex-wrap gap-3 justify-center mt-8">
-        <Link href="/materialien">
-          <Button variant="outline">
+        <Button variant="outline" asChild>
+          <Link href="/materialien">
             Alle Materialien ansehen
             <ArrowRight className="w-4 h-4 ml-2" />
-          </Button>
-        </Link>
-        <Link href="/glossar">
-          <Button variant="outline">Fachbegriffe im Glossar →</Button>
-        </Link>
-        <Link href="/buchempfehlungen">
-          <Button variant="outline">Buchempfehlungen →</Button>
-        </Link>
+          </Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/glossar">Fachbegriffe im Glossar →</Link>
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/buchempfehlungen">Buchempfehlungen →</Link>
+        </Button>
       </div>
     </ContentSection>
   );
@@ -554,21 +554,24 @@ export default function Genesung() {
                 auszubalancieren.
               </p>
               <div className="flex flex-wrap justify-center gap-4">
-                <Link href="/unterstuetzen/uebersicht">
-                  <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+                <Button
+                  className="bg-sage-dark hover:bg-sage-mid text-white"
+                  asChild
+                >
+                  <Link href="/unterstuetzen/uebersicht">
                     Unterstützen lernen
                     <ArrowRight className="w-4 h-4 ml-2" />
-                  </Button>
-                </Link>
-                <Link href="/unterstuetzen/therapie">
-                  <Button variant="outline" className="gap-2">
+                  </Link>
+                </Button>
+                <Button variant="outline" className="gap-2" asChild>
+                  <Link href="/unterstuetzen/therapie">
                     <Stethoscope className="w-4 h-4" />
                     Therapie begleiten
-                  </Button>
-                </Link>
-                <Link href="/selbstfuersorge">
-                  <Button variant="outline">Selbstfürsorge</Button>
-                </Link>
+                  </Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link href="/selbstfuersorge">Selbstfürsorge</Link>
+                </Button>
               </div>
             </motion.div>
           </div>

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -562,12 +562,12 @@ export default function Grenzen() {
               </div>
 
               <div className="mt-6 text-center">
-                <Link href="/materialien">
-                  <Button variant="outline">
+                <Button variant="outline" asChild>
+                  <Link href="/materialien">
                     Alle Materialien ansehen
                     <ArrowRight className="w-4 h-4 ml-2" />
-                  </Button>
-                </Link>
+                  </Link>
+                </Button>
               </div>
             </motion.div>
 
@@ -673,15 +673,18 @@ export default function Grenzen() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/kommunizieren">
-                <Button variant="ghost">← Kommunizieren</Button>
-              </Link>
-              <Link href="/selbstfuersorge">
-                <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+              <Button variant="ghost" asChild>
+                <Link href="/kommunizieren">← Kommunizieren</Link>
+              </Button>
+              <Button
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/selbstfuersorge">
                   Weiter: Selbstfürsorge
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -98,25 +98,27 @@ export default function Home() {
               </p>
 
               <div className="flex flex-col sm:flex-row gap-3 mb-4">
-                <Link href="/verstehen">
-                  <Button
-                    size="lg"
-                    className="bg-sage-dark hover:bg-sage-mid text-white w-full sm:w-auto"
-                  >
+                <Button
+                  size="lg"
+                  className="bg-sage-dark hover:bg-sage-mid text-white w-full sm:w-auto"
+                  asChild
+                >
+                  <Link href="/verstehen">
                     <BookOpen className="w-5 h-5 mr-2" />
                     Borderline besser verstehen
-                  </Button>
-                </Link>
-                <Link href="/unterstuetzen/uebersicht">
-                  <Button
-                    size="lg"
-                    variant="outline"
-                    className="border-white/25 text-white hover:bg-white/10 w-full sm:w-auto"
-                  >
+                  </Link>
+                </Button>
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="border-white/25 text-white hover:bg-white/10 w-full sm:w-auto"
+                  asChild
+                >
+                  <Link href="/unterstuetzen/uebersicht">
                     <Heart className="w-5 h-5 mr-2" />
                     Was hilft in meiner Lage?
-                  </Button>
-                </Link>
+                  </Link>
+                </Button>
               </div>
 
               <Link
@@ -222,12 +224,12 @@ export default function Home() {
             </div>
 
             <div className="mt-6">
-              <Link href="/selbsttest">
-                <Button variant="outline" size="sm" className="gap-2">
+              <Button variant="outline" size="sm" className="gap-2" asChild>
+                <Link href="/selbsttest">
                   <Compass className="w-4 h-4" />
                   Oder den kurzen Selbsttest nutzen
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </div>
           </div>
         </div>
@@ -281,16 +283,12 @@ export default function Home() {
                   Sekundäre Wege für Vertiefung und konkrete Unterstützung.
                 </p>
                 <div className="flex gap-3">
-                  <Link href="/materialien">
-                    <Button variant="outline" size="sm">
-                      Materialien
-                    </Button>
-                  </Link>
-                  <Link href="/beratung">
-                    <Button variant="outline" size="sm">
-                      Beratung
-                    </Button>
-                  </Link>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/materialien">Materialien</Link>
+                  </Button>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/beratung">Beratung</Link>
+                  </Button>
                 </div>
               </CardContent>
             </Card>
@@ -309,16 +307,17 @@ export default function Home() {
                 Hier finden Sie sofortige Hilfe und Notfallnummern.
               </p>
             </div>
-            <Link href="/soforthilfe">
-              <Button
-                size="lg"
-                variant="secondary"
-                className="bg-white text-alert hover:bg-white/90"
-              >
+            <Button
+              size="lg"
+              variant="secondary"
+              className="bg-white text-alert hover:bg-white/90"
+              asChild
+            >
+              <Link href="/soforthilfe">
                 <Phone className="w-5 h-5 mr-2" />
                 Soforthilfe öffnen
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </div>
         </div>
       </section>

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -554,15 +554,16 @@ export default function Kommunizieren() {
                         realistischen Situationen. Multiple-Choice mit
                         sofortigem Feedback.
                       </p>
-                      <Link href="/uebungen">
-                        <Button
-                          size="sm"
-                          className="bg-sage-dark hover:bg-sage-mid text-white gap-1.5"
-                        >
+                      <Button
+                        size="sm"
+                        className="bg-sage-dark hover:bg-sage-mid text-white gap-1.5"
+                        asChild
+                      >
+                        <Link href="/uebungen">
                           Zu den Übungen
                           <ArrowRight className="w-3.5 h-3.5" />
-                        </Button>
-                      </Link>
+                        </Link>
+                      </Button>
                     </div>
                   </div>
                 </CardContent>
@@ -628,12 +629,12 @@ export default function Kommunizieren() {
               </div>
 
               <div className="flex flex-wrap gap-3 justify-center">
-                <Link href="/materialien">
-                  <Button variant="outline">Alle Materialien ansehen</Button>
-                </Link>
-                <Link href="/glossar">
-                  <Button variant="outline">Fachbegriffe im Glossar →</Button>
-                </Link>
+                <Button variant="outline" asChild>
+                  <Link href="/materialien">Alle Materialien ansehen</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link href="/glossar">Fachbegriffe im Glossar →</Link>
+                </Button>
               </div>
             </motion.div>
 
@@ -643,15 +644,18 @@ export default function Kommunizieren() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/unterstuetzen/uebersicht">
-                <Button variant="ghost">← Unterstützen</Button>
-              </Link>
-              <Link href="/grenzen">
-                <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+              <Button variant="ghost" asChild>
+                <Link href="/unterstuetzen/uebersicht">← Unterstützen</Link>
+              </Button>
+              <Button
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/grenzen">
                   Weiter: Grenzen setzen
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/Materialien.tsx
+++ b/client/src/pages/Materialien.tsx
@@ -267,31 +267,21 @@ export default function Materialien() {
                   die Hauptseiten oft der bessere Einstieg.
                 </p>
                 <div className="flex flex-wrap gap-2">
-                  <Link href="/verstehen">
-                    <Button variant="outline" size="sm">
-                      Verstehen
-                    </Button>
-                  </Link>
-                  <Link href="/kommunizieren">
-                    <Button variant="outline" size="sm">
-                      Kommunizieren
-                    </Button>
-                  </Link>
-                  <Link href="/grenzen">
-                    <Button variant="outline" size="sm">
-                      Grenzen
-                    </Button>
-                  </Link>
-                  <Link href="/selbstfuersorge">
-                    <Button variant="outline" size="sm">
-                      Selbstfürsorge
-                    </Button>
-                  </Link>
-                  <Link href="/buchempfehlungen">
-                    <Button variant="outline" size="sm">
-                      Buchempfehlungen
-                    </Button>
-                  </Link>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/verstehen">Verstehen</Link>
+                  </Button>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/kommunizieren">Kommunizieren</Link>
+                  </Button>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/grenzen">Grenzen</Link>
+                  </Button>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/selbstfuersorge">Selbstfürsorge</Link>
+                  </Button>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/buchempfehlungen">Buchempfehlungen</Link>
+                  </Button>
                 </div>
               </CardContent>
             </Card>

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -966,15 +966,18 @@ export default function Selbstfuersorge() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/grenzen">
-                <Button variant="ghost">← Grenzen setzen</Button>
-              </Link>
-              <Link href="/materialien">
-                <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+              <Button variant="ghost" asChild>
+                <Link href="/grenzen">← Grenzen setzen</Link>
+              </Button>
+              <Button
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/materialien">
                   Alle Materialien
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -884,15 +884,20 @@ export default function UnterstuetzenAlltag() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/unterstuetzen/uebersicht">
-                <Button variant="ghost">← Wie kann ich helfen?</Button>
-              </Link>
-              <Link href="/unterstuetzen/krise">
-                <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+              <Button variant="ghost" asChild>
+                <Link href="/unterstuetzen/uebersicht">
+                  ← Wie kann ich helfen?
+                </Link>
+              </Button>
+              <Button
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/unterstuetzen/krise">
                   Weiter: Krisen begleiten
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -109,16 +109,17 @@ export default function UnterstuetzenKrise() {
                 {gruen143.label} ({gruen143.nummer})
               </a>
             </p>
-            <Link href="/soforthilfe">
-              <Button
-                variant="secondary"
-                size="sm"
-                className="bg-white text-alert"
-              >
+            <Button
+              variant="secondary"
+              size="sm"
+              className="bg-white text-alert"
+              asChild
+            >
+              <Link href="/soforthilfe">
                 <Phone className="w-4 h-4 mr-2" />
                 Alle Notfallnummern
-              </Button>
-            </Link>
+              </Link>
+            </Button>
           </div>
         </div>
       </section>
@@ -864,14 +865,13 @@ export default function UnterstuetzenKrise() {
                         interaktiver Wegweiser führt Sie Schritt für Schritt
                         durch verschiedene Krisenszenarien.
                       </p>
-                      <Link href="/wegweiser">
-                        <Button
-                          size="sm"
-                          className="bg-sage-dark hover:bg-sage-mid text-white"
-                        >
-                          Zum Wegweiser
-                        </Button>
-                      </Link>
+                      <Button
+                        size="sm"
+                        className="bg-sage-dark hover:bg-sage-mid text-white"
+                        asChild
+                      >
+                        <Link href="/wegweiser">Zum Wegweiser</Link>
+                      </Button>
                     </div>
                   </div>
                 </CardContent>
@@ -904,11 +904,9 @@ export default function UnterstuetzenKrise() {
                         Infografiken und Handouts zum Thema Krisenbegleitung
                         finden Sie auf der Materialien-Seite.
                       </p>
-                      <Link href="/materialien">
-                        <Button variant="outline" size="sm">
-                          Zur Materialien-Seite
-                        </Button>
-                      </Link>
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href="/materialien">Zur Materialien-Seite</Link>
+                      </Button>
                     </div>
                   </div>
                 </CardContent>
@@ -922,15 +920,18 @@ export default function UnterstuetzenKrise() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/unterstuetzen/therapie">
-                <Button variant="ghost">← Therapie begleiten</Button>
-              </Link>
-              <Link href="/kommunizieren">
-                <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+              <Button variant="ghost" asChild>
+                <Link href="/unterstuetzen/therapie">← Therapie begleiten</Link>
+              </Button>
+              <Button
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/kommunizieren">
                   Weiter: Kommunizieren
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -613,11 +613,9 @@ Mit freundlichen Grüssen,
                     Infografiken und Handouts zur Therapiebegleitung finden Sie
                     gesammelt auf der Materialien-Seite.
                   </p>
-                  <Link href="/materialien">
-                    <Button variant="outline" size="sm">
-                      Zur Materialien-Seite
-                    </Button>
-                  </Link>
+                  <Button variant="outline" size="sm" asChild>
+                    <Link href="/materialien">Zur Materialien-Seite</Link>
+                  </Button>
                 </CardContent>
               </Card>
             </motion.div>
@@ -628,15 +626,20 @@ Mit freundlichen Grüssen,
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/unterstuetzen/alltag">
-                <Button variant="ghost">← Im Alltag unterstützen</Button>
-              </Link>
-              <Link href="/unterstuetzen/krise">
-                <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+              <Button variant="ghost" asChild>
+                <Link href="/unterstuetzen/alltag">
+                  ← Im Alltag unterstützen
+                </Link>
+              </Button>
+              <Button
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/unterstuetzen/krise">
                   Weiter: In der Krise unterstützen
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -446,11 +446,9 @@ export default function UnterstuetzenUebersicht() {
               </div>
 
               <div className="mt-4 text-center">
-                <Link href="/materialien">
-                  <Button variant="outline" size="sm">
-                    Alle Materialien anzeigen
-                  </Button>
-                </Link>
+                <Button variant="outline" size="sm" asChild>
+                  <Link href="/materialien">Alle Materialien anzeigen</Link>
+                </Button>
               </div>
             </motion.div>
 
@@ -485,15 +483,18 @@ export default function UnterstuetzenUebersicht() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/verstehen">
-                <Button variant="ghost">← Verstehen</Button>
-              </Link>
-              <Link href="/unterstuetzen/alltag">
-                <Button className="bg-sage-dark hover:bg-sage-mid text-white">
+              <Button variant="ghost" asChild>
+                <Link href="/verstehen">← Verstehen</Link>
+              </Button>
+              <Button
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/unterstuetzen/alltag">
                   Weiter: Im Alltag unterstützen
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -671,15 +671,15 @@ export default function Verstehen() {
               </div>
 
               <div className="mt-6 flex flex-wrap gap-3 justify-center">
-                <Link href="/materialien">
-                  <Button variant="outline">Alle Materialien anzeigen</Button>
-                </Link>
-                <Link href="/glossar">
-                  <Button variant="outline">Fachbegriffe im Glossar →</Button>
-                </Link>
-                <Link href="/buchempfehlungen">
-                  <Button variant="outline">Buchempfehlungen →</Button>
-                </Link>
+                <Button variant="outline" asChild>
+                  <Link href="/materialien">Alle Materialien anzeigen</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link href="/glossar">Fachbegriffe im Glossar →</Link>
+                </Button>
+                <Button variant="outline" asChild>
+                  <Link href="/buchempfehlungen">Buchempfehlungen →</Link>
+                </Button>
               </div>
             </motion.div>
 
@@ -702,12 +702,17 @@ export default function Verstehen() {
                         klarer, wie Sie hilfreicher reagieren, Grenzen besser
                         halten und die eigene Belastung ernster nehmen können.
                       </p>
-                      <Link href="/unterstuetzen/uebersicht">
-                        <Button variant="outline" size="sm" className="gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="gap-2"
+                        asChild
+                      >
+                        <Link href="/unterstuetzen/uebersicht">
                           <ArrowRight className="w-4 h-4" />
                           Weiter zu: Unterstützen
-                        </Button>
-                      </Link>
+                        </Link>
+                      </Button>
                     </div>
                   </div>
                 </CardContent>
@@ -751,15 +756,16 @@ export default function Verstehen() {
                 Als Nächstes geht es darum, wie Unterstützung tragfähig bleiben
                 kann, ohne dass Sie sich selbst verlieren.
               </p>
-              <Link href="/unterstuetzen/uebersicht">
-                <Button
-                  size="lg"
-                  className="bg-sage-dark hover:bg-sage-mid text-white"
-                >
+              <Button
+                size="lg"
+                className="bg-sage-dark hover:bg-sage-mid text-white"
+                asChild
+              >
+                <Link href="/unterstuetzen/uebersicht">
                   Weiter zu: Unterstützen
                   <ArrowRight className="w-5 h-5 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/sections/GenesungInfografikenSection.tsx
+++ b/client/src/sections/GenesungInfografikenSection.tsx
@@ -114,12 +114,12 @@ export default function GenesungInfografikenSection() {
         ))}
       </div>
       <div className="text-center mt-8">
-        <Link href="/materialien">
-          <Button variant="outline">
+        <Button variant="outline" asChild>
+          <Link href="/materialien">
             Alle Materialien ansehen
             <ArrowRight className="w-4 h-4 ml-2" />
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </div>
     </ContentSection>
   );

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -131,11 +131,9 @@ export default function SelbstfuersorgeInfografikenSection() {
       </div>
 
       <div className="mt-4 text-center">
-        <Link href="/materialien">
-          <Button variant="outline" size="sm">
-            Alle Materialien anzeigen
-          </Button>
-        </Link>
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/materialien">Alle Materialien anzeigen</Link>
+        </Button>
       </div>
     </ContentSection>
   );

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -125,9 +125,9 @@ export default function VerstehenInfografikenSection() {
       </div>
 
       <div className="mt-6 text-center">
-        <Link href="/materialien">
-          <Button variant="outline">Alle Materialien anzeigen</Button>
-        </Link>
+        <Button variant="outline" asChild>
+          <Link href="/materialien">Alle Materialien anzeigen</Link>
+        </Button>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## HTML-Validity Fix: `<a><button>` Nesting aufgelöst

**Problem:** 49 Stellen im Code hatten `<Link><Button>` — ergibt `<a><button>` im DOM, was laut HTML-Spec ungültig ist und Screenreader/Keyboard-Probleme verursachen kann.

**Fix:** `<Button asChild><Link>` — Button rendert via Radix UI Slot als `<a>`-Element mit Button-Styles.

**15 Dateien, 49 Instanzen** — Build ✅ TypeScript ✅ Grep-Verifikation ✅