### PR TITLE
fix(a11y): Fokus-Falle in Dialogen + MobileMenu-Rollen

### DIFF
--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useScrollLock } from "@/hooks/useScrollLock";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { Search as SearchIcon, X, ArrowRight } from "lucide-react";
 import { Link } from "wouter";
 import { motion, AnimatePresence } from "framer-motion";
@@ -17,6 +18,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
   const [activeIndex, setActiveIndex] = useState(-1);
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
+  const dialogRef = useFocusTrap(isOpen);
 
   // Focus input when opened
   useEffect(() => {
@@ -133,6 +135,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
 
           {/* Search Modal */}
           <motion.div
+            ref={dialogRef}
             initial={{ opacity: 0, y: -8 }}
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
@@ -175,6 +178,14 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                     <X className="w-4 h-4 text-muted-foreground" />
                   </button>
                 )}
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="p-1 hover:bg-muted rounded-md transition-colors ml-1 flex-shrink-0"
+                  aria-label="Suche schliessen"
+                >
+                  <X className="w-5 h-5 text-foreground" />
+                </button>
               </div>
 
               {/* Results */}

--- a/client/src/components/layout/MobileMenu.tsx
+++ b/client/src/components/layout/MobileMenu.tsx
@@ -120,7 +120,6 @@ export function MobileMenu({
                   >
                     <div
                       id="mobile-ressourcen-menu"
-                      role="menu"
                       aria-label="Ressourcen-Navigation"
                       className="pl-4 mt-1 flex flex-col gap-0"
                     >
@@ -142,7 +141,6 @@ export function MobileMenu({
                                 <Link
                                   key={item.href}
                                   href={item.href}
-                                  role="menuitem"
                                   onClick={() => {
                                     closeMenu();
                                     setMobileRessourcenOpen(false);

--- a/client/src/hooks/useFocusTrap.ts
+++ b/client/src/hooks/useFocusTrap.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]:not([tabindex="-1"])',
+  'button:not([disabled]):not([tabindex="-1"])',
+  'input:not([disabled]):not([tabindex="-1"])',
+  'select:not([disabled]):not([tabindex="-1"])',
+  'textarea:not([disabled]):not([tabindex="-1"])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+/**
+ * Traps keyboard focus within the referenced element while `active` is true.
+ * Tab wraps from last to first focusable element; Shift+Tab wraps in reverse.
+ */
+export function useFocusTrap(active: boolean) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!active || !ref.current) return;
+    const container = ref.current;
+
+    const handleTab = (e: KeyboardEvent) => {
+      if (e.key !== "Tab") return;
+      const focusable = Array.from(
+        container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)
+      );
+      if (!focusable.length) return;
+
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleTab);
+    return () => document.removeEventListener("keydown", handleTab);
+  }, [active]);
+
+  return ref;
+}

--- a/client/src/pages/Materialien.tsx
+++ b/client/src/pages/Materialien.tsx
@@ -15,6 +15,7 @@ import {
   Shield,
   Sparkles,
   TrendingUp,
+  X,
 } from "lucide-react";
 import { Link } from "wouter";
 import { materials, quickStarts } from "@/content/materials";
@@ -40,11 +41,15 @@ function LightboxOverlay({
   title: string;
   onClose: () => void;
 }) {
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", handleKeyDown);
+    // Focus close button on mount for keyboard accessibility
+    closeButtonRef.current?.focus();
     return () => document.removeEventListener("keydown", handleKeyDown);
   }, [onClose]);
 
@@ -59,9 +64,18 @@ function LightboxOverlay({
       <motion.div
         initial={{ opacity: 0, scale: 0.9 }}
         animate={{ opacity: 1, scale: 1 }}
-        className="max-w-4xl max-h-[90vh] overflow-auto"
+        className="relative max-w-4xl max-h-[90vh] overflow-auto"
         onClick={e => e.stopPropagation()}
       >
+        <button
+          ref={closeButtonRef}
+          type="button"
+          onClick={onClose}
+          className="absolute top-2 right-2 z-10 p-2 rounded-full bg-black/60 hover:bg-black/80 text-white transition-colors"
+          aria-label="Vorschau schliessen"
+        >
+          <X className="w-5 h-5" />
+        </button>
         <img
           src={src}
           alt={`Vorschau: ${title}`}


### PR DESCRIPTION
## Befunde aus Accessibility-Audit

### P1 – Search.tsx: Fokus-Falle + Close-Button
- Neuer `useFocusTrap` Hook: Tab/Shift+Tab bleibt innerhalb des Dialogs
- Sichtbarer Close-Button mit `aria-label="Suche schliessen"` (vorher nur Escape/Backdrop — kein keyboard-accessible Close für Screenreader-Nutzer)

### P1 – Materialien.tsx (LightboxOverlay): Close-Button + Fokus-Management  
- X-Button (absolut positioniert oben rechts) mit `aria-label="Vorschau schliessen"`
- Wird beim Öffnen automatisch fokussiert (`closeButtonRef.current?.focus()`)

### P2 – MobileMenu.tsx: Semantische Rollen bereinigt
- `role="menu"` und `role="menuitem"` entfernt
- ARIA-Menü erwartet Pfeiltasten-Navigation (Arrow Keys) — hier ist es reine Website-Navigation mit Links
- `<nav><a>` ohne menu-Rollen ist die korrekte Semantik

### Neu
- `client/src/hooks/useFocusTrap.ts` — wiederverwendbarer Hook für Fokus-Trapping in modalen Dialogen

### Nicht berührt
- P1.1 Link+Button-Nesting — bereits mit PR #150 behoben