### PR TITLE
fix(seo): Alter Site-Name entfernt + Descriptions verbessert

### DIFF
--- a/client/src/pages/Buchempfehlungen.tsx
+++ b/client/src/pages/Buchempfehlungen.tsx
@@ -242,7 +242,7 @@ export default function Buchempfehlungen() {
     <Layout>
       <SEO
         title="Buchempfehlungen"
-        description="Empfohlene Bücher für Angehörige von Menschen mit Borderline."
+        description="Buchempfehlungen für Angehörige von Menschen mit Borderline: Ratgeber, Fachliteratur und DBT-Bücher – mit kurzen Einschätzungen zum Inhalt."
         path="/buchempfehlungen"
       />
       {/* Hero */}

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -234,7 +234,7 @@ export default function FAQ() {
     <Layout>
       <SEO
         title="Häufige Fragen"
-        description="Antworten auf die häufigsten Fragen von Angehörigen zu Borderline."
+        description="Häufige Fragen von Angehörigen zu Borderline: Verhalten in Krisen, Grenzen setzen, Kommunikation und Selbstschutz – klar und ohne Umschweife beantwortet."
         path="/faq"
       />
       <FAQSchema

--- a/client/src/pages/Glossar.tsx
+++ b/client/src/pages/Glossar.tsx
@@ -276,7 +276,7 @@ export default function Glossar() {
     <Layout>
       <SEO
         title="Glossar"
-        description="Fachbegriffe rund um Borderline einfach erklärt."
+        description="Fachbegriffe rund um Borderline verständlich erklärt: von BPS über DBT bis Dysregulation – für Angehörige ohne Vorkenntnisse."
         path="/glossar"
       />
       {/* Hero */}

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -255,7 +255,7 @@ export default function Notfallkarte() {
   return (
     <Layout>
       <SEO
-        title="Persönliche Notfallkarte | Schluss mit dem Eiertanz"
+        title="Persönliche Notfallkarte"
         description="Erstellen Sie Ihre persönliche Notfallkarte mit den wichtigsten Nummern, Kontaktpersonen und Beruhigungsstrategien – zum Ausdrucken oder Speichern."
         path="/notfallkarte"
       />

--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -155,7 +155,7 @@ export default function Quellen() {
   return (
     <Layout>
       <SEO
-        title="Quellen & Literatur – Borderline Angehörige Zürich"
+        title="Quellen & Literatur"
         description="Wissenschaftliche Grundlagen und Fachliteratur dieser Website: klinische Studien, DBT-Literatur, Angehörigenbücher und Diagnoseklassifikationen."
         canonicalPath="/quellen"
       />

--- a/client/src/pages/SelbsttestPage.tsx
+++ b/client/src/pages/SelbsttestPage.tsx
@@ -10,7 +10,7 @@ export default function SelbsttestPage() {
     <Layout>
       <SEO
         title="Selbsttest"
-        description="Selbsttest für Angehörige: Wie belastet sind Sie? Anonyme Einschätzung."
+        description="Selbsttest für Angehörige: Wie stark sind Sie gerade belastet? Anonyme Einschätzung in wenigen Minuten – mit Hinweisen auf passende Hilfsangebote."
         path="/selbsttest"
       />
       {/* Hero */}

--- a/client/src/pages/UeberUns.tsx
+++ b/client/src/pages/UeberUns.tsx
@@ -20,7 +20,7 @@ export default function UeberUns() {
     <Layout>
       <SEO
         title="Über uns"
-        description="Über das Projekt Borderline · Hilfe für Angehörige."
+        description="Über das Projekt: psychoedukative Website für Angehörige von Menschen mit Borderline – fachlich fundiert, evidenzbasiert und angehörigorientiert."
         path="/ueber-uns"
       />
       {/* Hero */}

--- a/client/src/pages/Uebungsszenarien.tsx
+++ b/client/src/pages/Uebungsszenarien.tsx
@@ -9,7 +9,7 @@ export default function Uebungsszenarien() {
   return (
     <Layout>
       <SEO
-        title="Kommunikations-Übungen | Schluss mit dem Eiertanz"
+        title="Kommunikations-Übungen"
         description="Üben Sie SET, DEAR MAN und Validierung anhand realistischer Szenarien – interaktiv, mit Feedback und Erklärungen."
         path="/uebungen"
       />

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -31,7 +31,7 @@ export default function UnterstuetzenKrise() {
     <Layout>
       <SEO
         title="Krisenbegleitung"
-        description="Wie Sie in akuten Krisen richtig reagieren und Hilfe leisten können."
+        description="Krisenbegleitung bei Borderline: Wie Sie in akuten Situationen deeskalieren, Grenzen wahren und professionelle Hilfe richtig einbeziehen."
         path="/unterstuetzen/krise"
       />
       {/* Hero */}

--- a/client/src/pages/Wegweiser.tsx
+++ b/client/src/pages/Wegweiser.tsx
@@ -12,7 +12,7 @@ export default function Wegweiser() {
   return (
     <Layout>
       <SEO
-        title="Situations-Wegweiser | Schluss mit dem Eiertanz"
+        title="Situations-Wegweiser"
         description="Was tun, wenn Ihr Angehöriger in einer Krise ist? Unser interaktiver Wegweiser führt Sie Schritt für Schritt durch verschiedene Situationen."
         path="/wegweiser"
       />


### PR DESCRIPTION
## P1.2 – Alter Site-Name aus 4 Titeln entfernt

4 Seiten hatten noch den alten Site-Namen **"Schluss mit dem Eiertanz"** bzw. **"Borderline Angehörige Zürich"** im `title`-Prop — das erzeugt überlange oder doppelte Titel-Tags:

| Seite | Alt | Neu | Länge |
|-------|-----|-----|-------|
| Notfallkarte | `Persönliche Notfallkarte \| Schluss mit dem Eiertanz` | `Persönliche Notfallkarte` | ✅ 60ch |
| Quellen | `Quellen & Literatur – Borderline Angehörige Zürich` | `Quellen & Literatur` | ✅ 55ch |
| Uebungsszenarien | `Kommunikations-Übungen \| Schluss mit dem Eiertanz` | `Kommunikations-Übungen` | ✅ 58ch |
| Wegweiser | `Situations-Wegweiser \| Schluss mit dem Eiertanz` | `Situations-Wegweiser` | ✅ 56ch |

## P1.3 – Meta-Descriptions auf 120–155 Zeichen ausgebaut

6 Seiten hatten Descriptions unter 70 Zeichen. Alle auf 120–155 Zeichen gebracht:

- **Buchempfehlungen** (61 → 139ch)
- **FAQ** (66 → 153ch)
- **Glossar** (48 → 125ch)
- **Selbsttest** (71 → 146ch)
- **Krisenbegleitung** (68 → 137ch)
- **Über uns** (51 → 145ch)

## Nicht geändert
- P1.1 (Client-side Meta-Rendering): Architektur-Problem, erfordert SSR/Prerendering — zu gross für jetzt