### PR TITLE
fix(ia): /quellen in Ressourcen-Nav + Breadcrumbs vervollständigt

### DIFF
--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -23,7 +23,7 @@ vi.mock("framer-motion", () => ({
         }: React.HTMLAttributes<HTMLElement> & {
           children?: React.ReactNode;
         }) => {
-          const Tag = tag as keyof JSX.IntrinsicElements;
+          const Tag = tag as React.ElementType;
           return <Tag {...(props as object)}>{children}</Tag>;
         },
     }

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -80,6 +80,11 @@ const pageNames: Record<string, string> = {
   "/glossar": "Glossar",
   "/buchempfehlungen": "Buchempfehlungen",
   "/feedback": "Feedback",
+  "/wegweiser": "Situations-Wegweiser",
+  "/notfallkarte": "Persönliche Notfallkarte",
+  "/uebungen": "Kommunikations-Übungen",
+  "/quellen": "Quellen & Literatur",
+  "/fachstelle": "Fachstelle Angehörigenarbeit",
 };
 
 // Kontextbezogene Elternseite bestimmen

--- a/client/src/domain/navigation.ts
+++ b/client/src/domain/navigation.ts
@@ -6,6 +6,7 @@ import {
   Compass,
   Download,
   FileText,
+  FlaskConical,
   Heart,
   HelpCircle,
   MessageCircle,
@@ -73,6 +74,12 @@ export const resourceNavigationItems: NavigationItem[] = [
     href: "/buchempfehlungen",
     label: "Buchempfehlungen",
     icon: BookOpen,
+    group: "Wissen & Materialien",
+  },
+  {
+    href: "/quellen",
+    label: "Quellen & Literatur",
+    icon: FlaskConical,
     group: "Wissen & Materialien",
   },
   // Gruppe: Beratung & Netzwerke


### PR DESCRIPTION
## P1.1 – /quellen in Ressourcen-Navigation

Die Quellen-Seite war praktisch unauffindbar — einziger Link war im Impressum versteckt. Für eine psychoedukative Website ist die Evidenz-/Quellenseite ein wichtiges Vertrauenselement.

**Änderung:** `/quellen` als `Quellen & Literatur` in die Ressourcen-Navigation (Gruppe: Wissen & Materialien) aufgenommen.

## P2.1 – Breadcrumb-Mapping vollständig

5 Seiten hatten keinen expliziten Breadcrumb-Eintrag; der Fallback (URL-Segment → lesbar) kann uneinheitliche Labels erzeugen:

| Pfad | Neu |
|------|-----|
| `/wegweiser` | Situations-Wegweiser |
| `/notfallkarte` | Persönliche Notfallkarte |
| `/uebungen` | Kommunikations-Übungen |
| `/quellen` | Quellen & Literatur |
| `/fachstelle` | Fachstelle Angehörigenarbeit |

## Nicht umgesetzt
- P1.2 Alias-Verwirrung: kein echtes UX-Problem, Redirect ist technisch korrekt
- P2.2 Info-Dichte Ressourcen-Nav: Meinungssache, kein klarer Bug

## Bonus-Fix
- `smoke.test.tsx`: Pre-existing TS-Fehler behoben (`keyof JSX.IntrinsicElements` → `React.ElementType`)