### PR TITLE
fix: Fallback-Text nutzerfreundlich formuliert

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -112,13 +112,11 @@
               Sie können helfen, ohne sich selbst zu verlieren.
             </h1>
             <p class="fallback-lead">
-              Diese Startseite enthält einen robusten Direkt-Fallback für
-              normale Nutzer:innen. Wenn die App nicht sofort lädt, bleiben die
-              wichtigsten Einstiege, Notfallkontakte und Rechtsseiten trotzdem
-              erreichbar.
+              Die Seite lädt gleich. Alle wichtigen Inhalte, Notfallnummern und
+              Anlaufstellen sind direkt unten erreichbar.
             </p>
           </div>
-          <p class="fallback-note">Robuste Direkt-Auslieferung</p>
+          <p class="fallback-note">Unterstützung für Angehörige</p>
         </header>
 
         <section class="fallback-grid">


### PR DESCRIPTION
## P1.1 aus Release Gate Audit

Die Fallback-Shell in `index.html` zeigte bei langsamen Verbindungen (mobil, NoJS) Entwickler-Jargon, den gestresste Angehörige sehen würden:

**Alt:**
> "Diese Startseite enthält einen robusten Direkt-Fallback für normale Nutzer:innen..."
> Badge: "Robuste Direkt-Auslieferung"

**Neu:**
> "Die Seite lädt gleich. Alle wichtigen Inhalte, Notfallnummern und Anlaufstellen sind direkt unten erreichbar."
> Badge: "Unterstützung für Angehörige"