### PR TITLE
fix: fehlende @testing-library/dom Dependency ergänzen

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@eslint/js": "^10.0.1",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.2.2",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/express": "^5.0.6",


### PR DESCRIPTION
## Summary

- `@testing-library/dom` als fehlende Peer-Dependency von `@testing-library/react` ergänzt
- Behebt alle CI-Workflow-Failures auf main und Feature-Branches

## Test plan

- [x] `vitest run` — alle 5 Smoke-Tests bestehen
- [x] `tsc --noEmit` — keine TypeScript-Fehler

https://claude.ai/code/session_012rYNCLrCdSgBReLgAXbd7g