### PR TITLE
Add audits and improve resource/search behavior (debounce, rAF-throttle, RAF cancellation, timeout cleanup)

### DIFF
--- a/_dev/AUDIT-REPORT-2026-04-20.md
+++ b/_dev/AUDIT-REPORT-2026-04-20.md
@@ -1,0 +1,66 @@
+# Audit-Report (20.04.2026)
+
+## Scope
+
+Technischer Schnell-Audit des aktuellen Repositories mit Fokus auf:
+
+- statische Qualität (Lint + TypeScript),
+- Teststabilität,
+- Produktions-Build,
+- Dependency-Sicherheitsprüfung.
+
+## Durchgeführte Checks
+
+1. `pnpm lint`
+2. `pnpm typecheck`
+3. `pnpm test`
+4. `pnpm build`
+5. `pnpm audit --audit-level=moderate`
+
+## Ergebnisse
+
+### ✅ Linting
+
+- `pnpm lint` erfolgreich.
+- Hinweis aus Tooling: `baseline-browser-mapping` ist älter als zwei Monate.
+
+### ✅ Typecheck
+
+- `pnpm typecheck` erfolgreich.
+- Keine TypeScript-Fehler.
+
+### ✅ Tests
+
+- `pnpm test` erfolgreich (5/5 Tests grün).
+- Beobachtung: React-Warnung im Testlauf
+  - `React does not recognize the whileInView prop on a DOM element.`
+  - Das deutet auf ein Prop-Forwarding-Problem in einer Test-/Mock-Konstellation hin (Framer-Motion Props gelangen auf ein natives DOM-Element).
+
+### ✅ Build
+
+- `pnpm build` erfolgreich.
+- Frontend und Server-Bundle wurden ohne Fehler erzeugt.
+
+### ⚠️ Security-Dependency-Audit
+
+- `pnpm audit --audit-level=moderate` konnte nicht ausgeführt werden.
+- NPM Audit Endpoint antwortet mit `403 Forbidden`.
+- Damit liegt aktuell kein verwertbares, automatisiertes Vulnerability-Ergebnis aus diesem Lauf vor.
+
+## Festgestellte Risiken / Follow-ups
+
+1. **Test-Warnung zu `whileInView` beheben**
+   - Priorität: Mittel.
+   - Empfehlung: Testsetup/Mock für Framer Motion prüfen, damit Motion-Props nicht auf native DOM-Elemente durchgereicht werden.
+
+2. **Tooling-Hinweis `baseline-browser-mapping` aktualisieren**
+   - Priorität: Niedrig.
+   - Empfehlung: Dev-Dependency aktualisieren (`npm i baseline-browser-mapping@latest -D`) und Regression kurz gegenprüfen.
+
+3. **Audit-Endpoint-Zugriff für Security-Audits klären**
+   - Priorität: Mittel.
+   - Empfehlung: Registry-/Auth-/Policy-Konfiguration prüfen, damit `pnpm audit` im CI/CD wieder nutzbar ist.
+
+## Kurzfazit
+
+Der Codebestand ist in diesem Audit-Lauf **buildbar**, **typisiert korrekt** und **testbar**. Es bestehen derzeit keine harten Blocker aus Lint/Typecheck/Test/Build. Offene Punkte betreffen primär die auditierbare Sicherheits-Transparenz (403 bei `pnpm audit`) und eine nicht-blockierende React-Testwarnung.

--- a/_dev/RESOURCE-MANAGEMENT-AUDIT-2026-04-20.md
+++ b/_dev/RESOURCE-MANAGEMENT-AUDIT-2026-04-20.md
@@ -1,0 +1,105 @@
+# Ressourcen-Management Audit (20.04.2026)
+
+## Ziel
+
+Audit der Laufzeit-Ressourcenverwaltung im Frontend/Server mit Fokus auf:
+
+- Listener/Timer/Animation-Cleanup,
+- unnötige Re-Render- und Scroll-Kosten,
+- Bundle-/Code-Splitting-Indikatoren,
+- Risikoabschätzung für CPU/Memory auf Mobile.
+
+## Prüfumfang
+
+- Statischer Code-Review in `client/src` und `server/index.ts`.
+- Build-Lauf zur Größen- und Chunk-Orientierung.
+- Testlauf zur Laufzeit-Warnungsprüfung.
+
+## Durchgeführte Checks
+
+1. `rg -n "setInterval|setTimeout|addEventListener|removeEventListener|IntersectionObserver|MutationObserver|ResizeObserver|requestAnimationFrame|cancelAnimationFrame|localStorage|sessionStorage|clearInterval|clearTimeout" client/src server/index.ts`
+2. `pnpm build`
+3. `pnpm test`
+
+## Befunde
+
+### 1) `useCountUp`: fehlende `requestAnimationFrame`-Cancellation beim Unmount (Mittel)
+
+**Beleg:** `client/src/hooks/useCountUp.ts:73-85, 93`
+
+- Der Hook startet `requestAnimationFrame(step)`, hält aber kein `rafId` und ruft beim Cleanup nur `observer.disconnect()`.
+- Bei Unmount während laufender Animation kann `setDisplayValue(...)` noch auf einen bereits unmounteten Tree feuern (unnötige Arbeit, potenziell Warnungen in Debug-Szenarien).
+
+**Empfehlung:**
+
+- `rafId` in `useRef<number | null>` speichern.
+- Im Cleanup `cancelAnimationFrame(rafId)` ausführen.
+- Optional: `isMountedRef` Guard für zusätzliche Robustheit.
+
+---
+
+### 2) `Search`-Modal: Fokus-`setTimeout` ohne Cleanup (Niedrig)
+
+**Beleg:** `client/src/components/Search.tsx:24-28`
+
+- Beim Öffnen wird ein Timeout gesetzt, aber nicht gecleart.
+- Bei schnellem Open/Close oder Routewechsel kann der Callback verspätet laufen.
+
+**Empfehlung:**
+
+- Timeout-ID speichern und im Effect-Cleanup `clearTimeout(...)` ausführen.
+
+---
+
+### 3) Inhaltsverzeichnis: doppelte Scroll-Listener + per-Scroll Layout-Messungen (Mittel)
+
+**Beleg:** `client/src/components/UXEnhancements.tsx:240-277` und `:290-295`
+
+- In `TableOfContents` laufen zwei Scroll-Listener parallel.
+- Einer davon traversiert bei jedem Scroll-Event alle Headings und ruft `getBoundingClientRect()` auf.
+- Das ist funktional korrekt, aber bei langen Seiten und schwachen Geräten potentiell kostenintensiv.
+
+**Empfehlung:**
+
+- Zusammenführung in einen Scroll-Handler oder zentralen Scroll-Store.
+- Passive Listener bleiben gut; zusätzlich Throttling (`requestAnimationFrame`-Throttle) prüfen.
+- Optional zurück auf `IntersectionObserver` für aktive Sektion, um Layout-Reads zu reduzieren.
+
+---
+
+### 4) Suchlogik: vollständiges Filtern/Sortieren bei jedem Keystroke ohne Debounce (Niedrig–Mittel)
+
+**Beleg:** `client/src/components/Search.tsx:47-79`
+
+- Für jede Eingabe wird `searchableContent` komplett gescannt und anschließend sortiert.
+- Bei aktuellem Umfang vermutlich unkritisch, aber bei Wachstum der Indexmenge steigt CPU-Last linear.
+
+**Empfehlung:**
+
+- Debounce (z. B. 120–200 ms) einführen.
+- Vor-normalisierten Suchtext cachen (`useMemo`) statt pro Item pro Keystroke neu zu joinen/lowercasen.
+
+---
+
+## Positive Befunde
+
+1. **Konsequentes Code-Splitting über Route-Lazy-Loading**
+   - `client/src/app/routes.ts:10-41` lädt Seiten lazy.
+   - Ressourcenschonend für Initial Load.
+
+2. **Event-Listener-Cleanup überwiegend sauber implementiert**
+   - Beispielhaft in `Search`, `UXEnhancements`, `useComposition`, `useRessourcenMenuA11y` werden Listener/Timer i. d. R. entfernt bzw. gecleart.
+
+3. **Build-Artefakte zeigen sinnvolle Chunk-Aufteilung**
+   - Route-Chunks vorhanden; große Vendor-Chunks (`vendor-motion`, `vendor-utils`, `vendor-radix`) sind erwartbar für die verwendeten Bibliotheken.
+
+## Priorisierte Maßnahmen (Backlog-Vorschlag)
+
+1. **P1 (kurz):** `useCountUp` um `cancelAnimationFrame` ergänzen.
+2. **P2 (kurz):** `Search` Fokus-Timeout cleanupen.
+3. **P2 (mittel):** TOC-Scroll-Logik throttlen/vereinheitlichen.
+4. **P3 (mittel):** Suchindex-Vorverarbeitung + Debounce.
+
+## Kurzfazit
+
+Das Projekt ist insgesamt solide im Ressourcen-Management (insb. Lazy Loading und Cleanup-Hygiene). Die Haupthebel liegen in kleinen, gezielten Verbesserungen bei Animation-Cleanup, Scroll-Workload und Such-CPU-Pfaden.

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useMemo } from "react";
 import { useScrollLock } from "@/hooks/useScrollLock";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { Search as SearchIcon, X, ArrowRight } from "lucide-react";
@@ -19,12 +19,39 @@ export default function Search({ isOpen, onClose }: SearchProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const resultsRef = useRef<HTMLDivElement>(null);
   const dialogRef = useFocusTrap(isOpen);
+  const focusTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const normalizedSearchIndex = useMemo(
+    () =>
+      searchableContent.map(item => ({
+        item,
+        searchText: [
+          item.title,
+          item.description,
+          ...item.keywords,
+          item.section,
+        ]
+          .join(" ")
+          .toLowerCase(),
+      })),
+    []
+  );
 
   // Focus input when opened
   useEffect(() => {
     if (isOpen && inputRef.current) {
-      setTimeout(() => inputRef.current?.focus(), 100);
+      focusTimeoutRef.current = setTimeout(
+        () => inputRef.current?.focus(),
+        100
+      );
     }
+    return () => {
+      if (focusTimeoutRef.current) {
+        clearTimeout(focusTimeoutRef.current);
+        focusTimeoutRef.current = null;
+      }
+    };
   }, [isOpen]);
 
   // Close on Escape
@@ -45,44 +72,49 @@ export default function Search({ isOpen, onClose }: SearchProps) {
 
   // Search logic
   useEffect(() => {
+    if (debounceTimeoutRef.current) {
+      clearTimeout(debounceTimeoutRef.current);
+      debounceTimeoutRef.current = null;
+    }
+
     if (query.length < 2) {
       setResults([]);
       return;
     }
 
-    const searchTerms = query
-      .toLowerCase()
-      .split(" ")
-      .filter(t => t.length > 1);
-
-    const matches = searchableContent.filter(item => {
-      const searchText = [
-        item.title,
-        item.description,
-        ...item.keywords,
-        item.section,
-      ]
-        .join(" ")
-        .toLowerCase();
-
-      return searchTerms.every(term => searchText.includes(term));
-    });
-
-    // Sort by relevance (title matches first)
-    matches.sort((a, b) => {
-      const aTitle = a.title.toLowerCase();
-      const bTitle = b.title.toLowerCase();
+    debounceTimeoutRef.current = setTimeout(() => {
       const queryLower = query.toLowerCase();
+      const searchTerms = queryLower.split(" ").filter(t => t.length > 1);
 
-      if (aTitle.includes(queryLower) && !bTitle.includes(queryLower))
-        return -1;
-      if (!aTitle.includes(queryLower) && bTitle.includes(queryLower)) return 1;
-      return 0;
-    });
+      const matches = normalizedSearchIndex
+        .filter(({ searchText }) =>
+          searchTerms.every(term => searchText.includes(term))
+        )
+        .map(({ item }) => item);
 
-    setResults(matches.slice(0, 8));
-    setActiveIndex(-1);
-  }, [query]);
+      // Sort by relevance (title matches first)
+      matches.sort((a, b) => {
+        const aTitle = a.title.toLowerCase();
+        const bTitle = b.title.toLowerCase();
+
+        if (aTitle.includes(queryLower) && !bTitle.includes(queryLower))
+          return -1;
+        if (!aTitle.includes(queryLower) && bTitle.includes(queryLower))
+          return 1;
+        return 0;
+      });
+
+      setResults(matches.slice(0, 8));
+      setActiveIndex(-1);
+    }, 150);
+
+    return () => {
+      if (debounceTimeoutRef.current) {
+        clearTimeout(debounceTimeoutRef.current);
+        debounceTimeoutRef.current = null;
+      }
+    };
+  }, [normalizedSearchIndex, query]);
 
   const handleResultClick = () => {
     setQuery("");

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -180,6 +180,7 @@ export function TableOfContents() {
   const floatingMode = getMobileFloatingMode(location);
   // Scroll-basierte aktive Markierung (kein IntersectionObserver nötig)
   const activeNavRef = useRef<HTMLButtonElement | null>(null);
+  const scrollRafRef = useRef<number | null>(null);
 
   // Headings scannen
   useEffect(() => {
@@ -228,10 +229,12 @@ export function TableOfContents() {
 
   // Scroll-basierte aktive Markierung
   useEffect(() => {
-    if (headings.length === 0) return;
+    const updateOnScroll = () => {
+      setShowFloatingButton(window.scrollY > 280);
 
-    // Scroll-basierte Erkennung: Welcher Abschnitt ist am nächsten am oberen Viewport-Rand?
-    const handleScroll = () => {
+      if (headings.length === 0) return;
+
+      // Scroll-basierte Erkennung: Welcher Abschnitt ist am nächsten am oberen Viewport-Rand?
       const headerHeight = 80;
       let bestId = headings[0]?.id || "";
       let bestDistance = -Infinity;
@@ -269,11 +272,23 @@ export function TableOfContents() {
       }
     };
 
+    const handleScroll = () => {
+      if (scrollRafRef.current !== null) return;
+      scrollRafRef.current = requestAnimationFrame(() => {
+        scrollRafRef.current = null;
+        updateOnScroll();
+      });
+    };
+
+    updateOnScroll(); // Initial ausführen
     window.addEventListener("scroll", handleScroll, { passive: true });
-    handleScroll(); // Initial ausführen
 
     return () => {
       window.removeEventListener("scroll", handleScroll);
+      if (scrollRafRef.current !== null) {
+        cancelAnimationFrame(scrollRafRef.current);
+        scrollRafRef.current = null;
+      }
     };
   }, [headings]);
 
@@ -286,13 +301,6 @@ export function TableOfContents() {
       });
     }
   }, [activeId]);
-
-  useEffect(() => {
-    const onScroll = () => setShowFloatingButton(window.scrollY > 280);
-    onScroll();
-    window.addEventListener("scroll", onScroll, { passive: true });
-    return () => window.removeEventListener("scroll", onScroll);
-  }, []);
 
   // Body-Scroll-Lock für Mobile-Drawer
   useScrollLock(isOpen);

--- a/client/src/hooks/useCountUp.ts
+++ b/client/src/hooks/useCountUp.ts
@@ -55,6 +55,7 @@ export function useCountUp({
 
   // 4. useRef
   const ref = useRef<HTMLDivElement>(null);
+  const rafIdRef = useRef<number | null>(null);
 
   // 5. useEffect – IntersectionObserver
   useEffect(() => {
@@ -78,11 +79,11 @@ export function useCountUp({
               const currentValue = easedProgress * end;
               setDisplayValue(formatValue(currentValue));
               if (progress < 1) {
-                requestAnimationFrame(step);
+                rafIdRef.current = requestAnimationFrame(step);
               }
             };
 
-            requestAnimationFrame(step);
+            rafIdRef.current = requestAnimationFrame(step);
           }
         });
       },
@@ -90,7 +91,13 @@ export function useCountUp({
     );
 
     observer.observe(element);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+    };
   }, [hasAnimated, formatValue, duration, end]);
 
   return { ref, displayValue };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.2.2(vite@7.3.1(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@testing-library/dom':
+        specifier: ^10.4.1
+        version: 10.4.1
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -237,10 +240,6 @@ packages:
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.27.1':
-    resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
@@ -3245,8 +3244,6 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
-  '@babel/helper-validator-identifier@7.27.1': {}
-
   '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-option@7.27.1': {}
@@ -3297,7 +3294,7 @@ snapshots:
   '@babel/types@7.28.4':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@babel/types@7.29.0':
     dependencies:


### PR DESCRIPTION
### Motivation

- Add audit artifacts and address runtime inefficiencies found during a resources audit. 
- Reduce unnecessary work on scroll and typing events to improve mobile/low-power performance and avoid potential unmount warnings from ongoing animations or delayed timeouts.

### Description

- Add audit outputs under `_dev/` with a technical quick-audit (`AUDIT-REPORT-2026-04-20.md`) and a resources-management audit (`RESOURCE-MANAGEMENT-AUDIT-2026-04-20.md`).
- Improve `Search` component by memoizing a normalized search index with `useMemo`, adding a 150ms debounce for filtering, and cleaning up both the focus `setTimeout` and the debounce timeout using refs.
- Throttle TOC scroll processing in `TableOfContents` by coalescing scroll handling into a `requestAnimationFrame` loop stored in `scrollRafRef`, removing the duplicate floating-button listener, and cancelling any pending RAF on cleanup.
- Harden `useCountUp` by storing the RAF id in `rafIdRef` and calling `cancelAnimationFrame` during effect cleanup to prevent work after unmount.

### Testing

- Ran `pnpm lint` which completed successfully. 
- Ran `pnpm typecheck` which completed with no TypeScript errors. 
- Ran `pnpm test` which completed successfully (5/5 tests green) but surfaced a non-blocking React test warning about a forwarded `whileInView` prop. 
- Ran `pnpm build` which produced successful frontend and server bundles. 
- Ran `pnpm audit --audit-level=moderate` but the audit step failed with `403 Forbidden`, so no automated vulnerability report was produced from this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69cc88340854833289446a256368f7b6)