### PR TITLE
[codex] Clarify evidence notes and source context

### DIFF
--- a/client/src/__tests__/evidence-note.test.tsx
+++ b/client/src/__tests__/evidence-note.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import EvidenceNote from "@/components/EvidenceNote";
+
+describe("EvidenceNote", () => {
+  it("groups scientific and service sources and renders the review date", () => {
+    render(
+      <EvidenceNote
+        title="Quellenhinweis"
+        reviewDate="24.03.2026"
+        sources={[
+          {
+            label: "APA Practice Guideline",
+            href: "https://example.com/apa",
+            type: "wissenschaft",
+          },
+          {
+            label: "PUK Zürich",
+            href: "https://example.com/puk",
+            type: "versorgung",
+            note: "Regionale Versorgung",
+          },
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Wissenschaftliche Evidenz")).toBeInTheDocument();
+    expect(screen.getByText("Versorgung / Hilfe")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Zuletzt redaktionell geprüft: 24\.03\.2026/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/PUK Zürich/)).toBeInTheDocument();
+    expect(screen.getByText(/Regionale Versorgung/)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/EvidenceNote.tsx
+++ b/client/src/components/EvidenceNote.tsx
@@ -1,14 +1,11 @@
 import { FileText } from "lucide-react";
-
-interface EvidenceSource {
-  label: string;
-  href?: string;
-}
+import type { EvidenceSource } from "@/domain/content-types";
 
 interface EvidenceNoteProps {
   title?: string;
   definition?: string;
   sources: EvidenceSource[];
+  reviewDate?: string;
   className?: string;
 }
 
@@ -16,8 +13,36 @@ export default function EvidenceNote({
   title = "Quellen",
   definition,
   sources,
+  reviewDate,
   className = "",
 }: EvidenceNoteProps) {
+  const scientificSources = sources.filter(
+    source => source.type !== "versorgung"
+  );
+  const serviceSources = sources.filter(source => source.type === "versorgung");
+
+  const renderSources = (items: EvidenceSource[]) => (
+    <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
+      {items.map(source => (
+        <li key={source.label}>
+          {source.href ? (
+            <a
+              href={source.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline decoration-dotted underline-offset-2 hover:text-foreground"
+            >
+              {source.label}
+            </a>
+          ) : (
+            source.label
+          )}
+          {source.note && <span>{` — ${source.note}`}</span>}
+        </li>
+      ))}
+    </ul>
+  );
+
   return (
     <aside
       className={`rounded-lg border border-border/60 bg-muted/20 p-4 ${className}`.trim()}
@@ -30,24 +55,29 @@ export default function EvidenceNote({
           {definition && (
             <p className="mt-1 text-xs text-muted-foreground">{definition}</p>
           )}
-          <ul className="mt-2 space-y-1 text-xs text-muted-foreground">
-            {sources.map(source => (
-              <li key={source.label}>
-                {source.href ? (
-                  <a
-                    href={source.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="underline decoration-dotted underline-offset-2 hover:text-foreground"
-                  >
-                    {source.label}
-                  </a>
-                ) : (
-                  source.label
-                )}
-              </li>
-            ))}
-          </ul>
+          {scientificSources.length > 0 && (
+            <div>
+              {serviceSources.length > 0 && (
+                <p className="mt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Wissenschaftliche Evidenz
+                </p>
+              )}
+              {renderSources(scientificSources)}
+            </div>
+          )}
+          {serviceSources.length > 0 && (
+            <div>
+              <p className="mt-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+                Versorgung / Hilfe
+              </p>
+              {renderSources(serviceSources)}
+            </div>
+          )}
+          {reviewDate && (
+            <p className="mt-3 text-[11px] text-muted-foreground">
+              Zuletzt redaktionell geprüft: {reviewDate}
+            </p>
+          )}
         </div>
       </div>
     </aside>

--- a/client/src/domain/content-types.ts
+++ b/client/src/domain/content-types.ts
@@ -34,10 +34,8 @@ export interface ResourceCard {
 }
 
 export interface EvidenceSource {
-  title: string;
-  authors?: string;
-  year?: number;
-  source: string;
-  url?: string;
+  label: string;
+  href?: string;
+  type?: "wissenschaft" | "versorgung";
   note?: string;
 }

--- a/client/src/pages/UeberUns.tsx
+++ b/client/src/pages/UeberUns.tsx
@@ -14,6 +14,7 @@ import {
   FileText,
 } from "lucide-react";
 import { Link } from "wouter";
+import EvidenceNote from "@/components/EvidenceNote";
 
 export default function UeberUns() {
   return (
@@ -143,6 +144,31 @@ export default function UeberUns() {
                   );
                 })}
               </div>
+              <EvidenceNote
+                title="Wie wir Quellen meinen"
+                definition="Mit «Wir nennen unsere Quellen» meinen wir zweierlei: wissenschaftliche Evidenz für medizinische oder therapeutische Aussagen und konkrete Versorgungsquellen für Hilfen in der Schweiz, vor allem im Raum Zürich."
+                reviewDate="24.03.2026"
+                sources={[
+                  {
+                    label:
+                      "APA Practice Guideline for the Treatment of Patients With Borderline Personality Disorder (2024)",
+                    href: "https://psychiatryonline.org/doi/book/10.1176/appi.books.9780890424896",
+                    type: "wissenschaft",
+                  },
+                  {
+                    label: "NEA-BPD / Family Connections",
+                    href: "https://www.borderlinepersonalitydisorder.org/family-connections/",
+                    type: "versorgung",
+                  },
+                  {
+                    label:
+                      "PUK Zürich – Angehörigenarbeit und Versorgungsangebote",
+                    href: "https://www.pukzh.ch",
+                    type: "versorgung",
+                  },
+                ]}
+                className="mt-5"
+              />
             </ContentSection>
 
             {/* Quellen */}
@@ -198,6 +224,33 @@ export default function UeberUns() {
                   </div>
                 ))}
               </div>
+              <EvidenceNote
+                title="Auswahl der Grundlagen"
+                definition="Die Website stützt sich auf klinische Standardwerke, evidenzbasierte Therapieansätze und Angehörigenprogramme. Die Auswahl ist kuratiert, nicht vollständig bibliografisch."
+                reviewDate="24.03.2026"
+                sources={[
+                  {
+                    label:
+                      "Linehan, Cognitive-Behavioral Treatment of Borderline Personality Disorder",
+                    type: "wissenschaft",
+                  },
+                  {
+                    label: "Mason & Kreger, Stop Walking on Eggshells",
+                    type: "wissenschaft",
+                  },
+                  {
+                    label:
+                      "Kreisman & Straus, Ich hasse dich – verlass mich nicht",
+                    type: "wissenschaft",
+                  },
+                  {
+                    label: "Family Connections (NEA-BPD / Alan Fruzzetti)",
+                    href: "https://www.borderlinepersonalitydisorder.org/family-connections/",
+                    type: "versorgung",
+                  },
+                ]}
+                className="mt-6"
+              />
 
               <p className="text-sm text-muted-foreground mt-6">
                 Eine vollständige Liste unserer Buchempfehlungen finden Sie auf


### PR DESCRIPTION
## Summary

This PR extracts a small evidence-context package from the larger dirty worktree.

It upgrades `EvidenceNote` so source lists can distinguish between scientific evidence and service/help sources, adds an optional review date, and uses that richer source context on the `Über uns` page.

## What Changed

- updated `client/src/components/EvidenceNote.tsx`
  - supports `reviewDate`
  - groups sources into `Wissenschaftliche Evidenz` and `Versorgung / Hilfe`
  - renders optional per-source notes
- updated `client/src/domain/content-types.ts`
  - aligns `EvidenceSource` with the shape already used by existing `EvidenceNote` call sites (`label`, `href`, optional `type`, optional `note`)
- updated `client/src/pages/UeberUns.tsx`
  - adds two evidence/context callouts that clarify how sources are selected and what kind of sources are meant
- added `client/src/__tests__/evidence-note.test.tsx`
  - verifies grouping by source type and rendering of the review date

## Why

The current dirty branch contains a broader content refactor. This PR isolates one coherent, low-risk slice that improves source transparency without dragging in unrelated page restructures.

It also turns the more detailed source model into an explicit, tested component contract.

## Impact

- no routing changes
- no broad page restructure
- improves source clarity and editorial transparency on `Über uns`
- makes `EvidenceNote` more expressive for future evidence/service disclaimers across the site

## Validation

- `npm test -- client/src/__tests__/evidence-note.test.tsx`
- `npm run check`
- `npm run build`