### PR TITLE
[codex] Add SEO helper exports and tests

### DIFF
--- a/client/src/__tests__/seo-helpers.test.ts
+++ b/client/src/__tests__/seo-helpers.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildBreadcrumbSchemaData,
+  buildCanonicalUrl,
+  buildFAQSchemaData,
+  buildFullTitle,
+  buildMedicalPageSchemaData,
+  buildMetaDescription,
+  buildWebsiteSchemaData,
+} from "@/components/SEO";
+
+describe("SEO helpers", () => {
+  it("builds the full title for page-specific titles", () => {
+    expect(buildFullTitle("FAQ")).toBe(
+      "FAQ – Borderline · Hilfe für Angehörige"
+    );
+  });
+
+  it("falls back to the base title when no title is passed", () => {
+    expect(buildFullTitle()).toBe(
+      "Borderline · Hilfe für Angehörige – Evidenzbasierte Unterstützung"
+    );
+  });
+
+  it("builds canonical URLs consistently", () => {
+    expect(buildCanonicalUrl("/faq")).toBe(
+      "https://borderline-angehoerige.netlify.app/faq"
+    );
+  });
+
+  it("uses the base description as fallback", () => {
+    expect(buildMetaDescription()).toContain("Evidenzbasierte Unterstützung");
+  });
+
+  it("builds website schema with the expected site URL", () => {
+    const schema = buildWebsiteSchemaData();
+    expect(schema.url).toBe("https://borderline-angehoerige.netlify.app");
+    expect(schema["@type"]).toBe("WebSite");
+  });
+
+  it("builds medical schema with ICD-11 code 6D11", () => {
+    const schema = buildMedicalPageSchemaData({
+      title: "Borderline verstehen",
+      description: "Beschreibung",
+      path: "/verstehen",
+    });
+
+    expect(schema["@type"]).toBe("MedicalWebPage");
+    expect(schema.about.code.code).toBe("6D11");
+    expect(schema.url).toBe(
+      "https://borderline-angehoerige.netlify.app/verstehen"
+    );
+  });
+
+  it("builds breadcrumb schema with correct positions", () => {
+    const schema = buildBreadcrumbSchemaData([
+      { name: "Home", url: "https://example.com/" },
+      { name: "FAQ", url: "https://example.com/faq" },
+    ]);
+
+    expect(schema.itemListElement).toHaveLength(2);
+    expect(schema.itemListElement[0].position).toBe(1);
+    expect(schema.itemListElement[1].name).toBe("FAQ");
+  });
+
+  it("builds FAQ schema entries", () => {
+    const schema = buildFAQSchemaData([
+      { question: "Frage?", answer: "Antwort." },
+    ]);
+
+    expect(schema["@type"]).toBe("FAQPage");
+    expect(schema.mainEntity[0].name).toBe("Frage?");
+    expect(schema.mainEntity[0].acceptedAnswer.text).toBe("Antwort.");
+  });
+});

--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -23,12 +23,120 @@ const MEDICAL_LAST_REVIEWED =
   import.meta.env.VITE_BUILD_DATE ||
   new Date().toISOString().slice(0, 10);
 
+const buildOgImageUrl = (siteUrl = SITE_URL) => `${siteUrl}/og-image.jpg`;
+
 const getSiteUrl = () => {
   if (typeof window !== "undefined" && window.location?.origin) {
     return window.location.origin.replace(/\/+$/, "");
   }
   return SITE_URL;
 };
+
+export function buildFullTitle(title?: string) {
+  return title
+    ? `${title} – ${SITE_NAME}`
+    : `${SITE_NAME} – Evidenzbasierte Unterstützung`;
+}
+
+export function buildMetaDescription(description?: string) {
+  return description || BASE_DESCRIPTION;
+}
+
+export function buildCanonicalUrl(path = "/", siteUrl = SITE_URL) {
+  return `${siteUrl}${path}`;
+}
+
+export function buildWebsiteSchemaData(siteUrl = SITE_URL) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    alternateName: "Borderline Angehörige",
+    url: siteUrl,
+    description: BASE_DESCRIPTION,
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      logo: {
+        "@type": "ImageObject",
+        url: buildOgImageUrl(siteUrl),
+      },
+    },
+    inLanguage: "de-CH",
+  };
+}
+
+export function buildMedicalPageSchemaData({
+  title,
+  description,
+  path,
+  siteUrl = SITE_URL,
+}: {
+  title: string;
+  description: string;
+  path: string;
+  siteUrl?: string;
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "MedicalWebPage",
+    name: title,
+    description,
+    url: buildCanonicalUrl(path, siteUrl),
+    inLanguage: "de",
+    about: {
+      "@type": "MedicalCondition",
+      name: "Persönlichkeitsstörung mit Borderline-Muster",
+      alternateName: ["Borderline-Muster", "Borderline pattern"],
+      code: {
+        "@type": "MedicalCode",
+        code: "6D11",
+        codingSystem: "ICD-11",
+      },
+    },
+    audience: {
+      "@type": "PeopleAudience",
+      audienceType: "Angehörige von Menschen mit Borderline-Muster",
+    },
+    lastReviewed: MEDICAL_LAST_REVIEWED,
+    medicalAudience: {
+      "@type": "MedicalAudience",
+      audienceType: "Caregiver",
+    },
+  };
+}
+
+export function buildBreadcrumbSchemaData(
+  items: { name: string; url: string }[]
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+export function buildFAQSchemaData(
+  questions: { question: string; answer: string }[]
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: questions.map(question => ({
+      "@type": "Question",
+      name: question.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: question.answer,
+      },
+    })),
+  };
+}
 
 export default function SEO({
   title,
@@ -37,15 +145,14 @@ export default function SEO({
   type = "website",
   canonicalPath,
 }: SEOProps) {
-  const fullTitle = title
-    ? `${title} \u2013 ${SITE_NAME}`
-    : `${SITE_NAME} \u2013 Evidenzbasierte Unterst\u00fctzung`;
-  const metaDescription = description || BASE_DESCRIPTION;
+  const fullTitle = buildFullTitle(title);
+  const metaDescription = buildMetaDescription(description);
 
   useEffect(() => {
     const siteUrl = getSiteUrl();
     const canonicalOrPath = canonicalPath || path;
-    const ogImage = `${siteUrl}/og-image.jpg`;
+    const canonicalUrl = buildCanonicalUrl(canonicalOrPath, siteUrl);
+    const ogImage = buildOgImageUrl(siteUrl);
 
     // Update document title
     document.title = fullTitle;
@@ -66,7 +173,7 @@ export default function SEO({
     updateMeta("og:title", fullTitle, true);
     updateMeta("og:description", metaDescription, true);
     updateMeta("og:type", type, true);
-    updateMeta("og:url", `${siteUrl}${canonicalOrPath}`, true);
+    updateMeta("og:url", canonicalUrl, true);
     updateMeta("og:image", ogImage, true);
     updateMeta("twitter:card", "summary_large_image");
     updateMeta("twitter:title", fullTitle);
@@ -82,7 +189,7 @@ export default function SEO({
       canonical.rel = "canonical";
       document.head.appendChild(canonical);
     }
-    canonical.href = `${siteUrl}${canonicalOrPath}`;
+    canonical.href = canonicalUrl;
   }, [canonicalPath, fullTitle, metaDescription, path, type]);
 
   return null;
@@ -92,23 +199,7 @@ export default function SEO({
 export function WebsiteSchema() {
   useEffect(() => {
     const siteUrl = getSiteUrl();
-    const schema = {
-      "@context": "https://schema.org",
-      "@type": "WebSite",
-      name: SITE_NAME,
-      alternateName: "Borderline Angeh\u00f6rige",
-      url: siteUrl,
-      description: BASE_DESCRIPTION,
-      publisher: {
-        "@type": "Organization",
-        name: SITE_NAME,
-        logo: {
-          "@type": "ImageObject",
-          url: `${siteUrl}/og-image.jpg`,
-        },
-      },
-      inLanguage: "de-CH",
-    };
+    const schema = buildWebsiteSchemaData(siteUrl);
 
     let el = document.querySelector('script[data-schema="website"]');
     if (!el) {
@@ -138,33 +229,7 @@ export function MedicalPageSchema({
 }) {
   const siteUrl = getSiteUrl();
   const schema = useMemo(
-    () => ({
-      "@context": "https://schema.org",
-      "@type": "MedicalWebPage",
-      name: title,
-      description: description,
-      url: `${siteUrl}${path}`,
-      inLanguage: "de",
-      about: {
-        "@type": "MedicalCondition",
-        name: "Pers\u00f6nlichkeitsst\u00f6rung mit Borderline-Muster",
-        alternateName: ["Borderline-Muster", "Borderline pattern"],
-        code: {
-          "@type": "MedicalCode",
-          code: "6D11",
-          codingSystem: "ICD-11",
-        },
-      },
-      audience: {
-        "@type": "PeopleAudience",
-        audienceType: "Angeh\u00f6rige von Menschen mit Borderline-Muster",
-      },
-      lastReviewed: MEDICAL_LAST_REVIEWED,
-      medicalAudience: {
-        "@type": "MedicalAudience",
-        audienceType: "Caregiver",
-      },
-    }),
+    () => buildMedicalPageSchemaData({ title, description, path, siteUrl }),
     [description, path, siteUrl, title]
   );
 
@@ -191,19 +256,7 @@ export function BreadcrumbSchema({
 }: {
   items: { name: string; url: string }[];
 }) {
-  const schema = useMemo(
-    () => ({
-      "@context": "https://schema.org",
-      "@type": "BreadcrumbList",
-      itemListElement: items.map((item, i) => ({
-        "@type": "ListItem",
-        position: i + 1,
-        name: item.name,
-        item: item.url,
-      })),
-    }),
-    [items]
-  );
+  const schema = useMemo(() => buildBreadcrumbSchemaData(items), [items]);
 
   useEffect(() => {
     const key = items.map(i => i.url).join("-");
@@ -229,21 +282,7 @@ export function FAQSchema({
 }: {
   questions: { question: string; answer: string }[];
 }) {
-  const schema = useMemo(
-    () => ({
-      "@context": "https://schema.org",
-      "@type": "FAQPage",
-      mainEntity: questions.map(q => ({
-        "@type": "Question",
-        name: q.question,
-        acceptedAnswer: {
-          "@type": "Answer",
-          text: q.answer,
-        },
-      })),
-    }),
-    [questions]
-  );
+  const schema = useMemo(() => buildFAQSchemaData(questions), [questions]);
 
   useEffect(() => {
     let el = document.querySelector('script[data-schema="faq"]');


### PR DESCRIPTION
## Summary
- extract reusable SEO builder helpers from `client/src/components/SEO.tsx`
- cover title, canonical URL, metadata, and schema builders with a focused unit test
- keep the runtime SEO component behavior aligned by reusing the same helper functions internally

## Why
During the audit of the remaining dirty worktree, the only test candidate with real new coverage was the SEO helper test. On current `main`, that test was not independently extractable because the pure builder functions were not exported yet. This PR makes that API explicit so the SEO behavior can be validated directly instead of only through component side effects.

## Impact
- gives us stable unit coverage for canonical URL and schema generation
- reduces duplication inside `SEO.tsx` by routing component behavior through shared builders
- keeps the package small and isolated to the SEO surface

## Validation
- `npm test`
- `npm run check`
- `npm run build`