### PR TITLE
[codex] Fix CTA semantics and smoke test mock

### DIFF
--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -11,6 +11,28 @@ import { Router } from "wouter";
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
 // framer-motion: Animationen nicht benötigt in Tests
+const MOTION_PROPS = new Set([
+  "animate",
+  "exit",
+  "initial",
+  "layout",
+  "layoutId",
+  "onAnimationComplete",
+  "onUpdate",
+  "transition",
+  "variants",
+  "viewport",
+  "whileHover",
+  "whileInView",
+  "whileTap",
+]);
+
+function stripMotionProps(props: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(props).filter(([key]) => !MOTION_PROPS.has(key))
+  );
+}
+
 vi.mock("framer-motion", () => ({
   motion: new Proxy(
     {},
@@ -24,7 +46,11 @@ vi.mock("framer-motion", () => ({
           children?: React.ReactNode;
         }) => {
           const Tag = tag as React.ElementType;
-          return <Tag {...(props as object)}>{children}</Tag>;
+          return (
+            <Tag {...stripMotionProps(props as Record<string, unknown>)}>
+              {children}
+            </Tag>
+          );
         },
     }
   ),

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -203,25 +203,23 @@ export default function Layout({ children }: LayoutProps) {
 
       {/* Mobile Soforthilfe-FAB: auf allen Seiten ausser /soforthilfe selbst */}
       {location !== "/soforthilfe" && (
-        <Link
-          href="/soforthilfe"
-          className="sm:hidden fixed z-50"
+        <Button
+          asChild
+          variant="default"
+          className="sm:hidden fixed z-50 h-12 px-4 rounded-full bg-alert hover:bg-alert/85 text-white shadow-lg gap-2 text-sm font-semibold"
           style={{
             bottom: "calc(4.5rem + env(safe-area-inset-bottom, 0px))",
             right: "1rem",
           }}
-          aria-label="Soforthilfe \u2013 Notfallnummern und Krisenberatung"
         >
-          <Button
-            variant="default"
-            className="h-12 px-4 rounded-full bg-alert hover:bg-alert/85 text-white shadow-lg gap-2 text-sm font-semibold"
-            tabIndex={-1}
-            aria-hidden="true"
+          <Link
+            href="/soforthilfe"
+            aria-label="Soforthilfe \u2013 Notfallnummern und Krisenberatung"
           >
             <Phone className="w-4 h-4" />
             Soforthilfe
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       )}
 
       {/* Search Modal */}

--- a/client/src/components/Selbsttest.tsx
+++ b/client/src/components/Selbsttest.tsx
@@ -411,11 +411,15 @@ export default function Selbsttest() {
               </p>
               <div className="flex flex-wrap gap-2">
                 {result.secondaryLinks.map((link, i) => (
-                  <Link key={i} href={link.href}>
-                    <Button variant="outline" size="sm" className="bg-white/50">
-                      {link.text}
-                    </Button>
-                  </Link>
+                  <Button
+                    key={i}
+                    asChild
+                    variant="outline"
+                    size="sm"
+                    className="bg-white/50"
+                  >
+                    <Link href={link.href}>{link.text}</Link>
+                  </Button>
                 ))}
               </div>
             </div>

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -99,20 +99,20 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               <SearchIcon className="w-5 h-5" />
             </button>
 
-            <Link
-              href="/soforthilfe"
-              aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
+            <Button
+              asChild
+              variant="default"
+              size="sm"
+              className="bg-alert hover:bg-alert/85 text-white hidden sm:flex"
             >
-              <Button
-                variant="default"
-                size="sm"
-                className="bg-alert hover:bg-alert/85 text-white hidden sm:flex"
-                tabIndex={-1}
+              <Link
+                href="/soforthilfe"
+                aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
               >
                 <Phone className="w-4 h-4 lg:mr-0 xl:mr-2" />
                 <span className="hidden xl:inline">Soforthilfe</span>
-              </Button>
-            </Link>
+              </Link>
+            </Button>
 
             <button
               type="button"

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -175,15 +175,18 @@ export default function Kommunizieren() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/unterstuetzen/uebersicht">
-                <Button variant="ghost">← Unterstützen</Button>
-              </Link>
-              <Link href="/grenzen">
-                <Button className="bg-terracotta hover:bg-terracotta-mid text-white">
+              <Button asChild variant="ghost">
+                <Link href="/unterstuetzen/uebersicht">← Unterstützen</Link>
+              </Button>
+              <Button
+                asChild
+                className="bg-terracotta hover:bg-terracotta-mid text-white"
+              >
+                <Link href="/grenzen">
                   Weiter: Grenzen setzen
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -340,15 +340,18 @@ export default function Selbstfuersorge() {
               viewport={{ once: true }}
               className="flex justify-between items-center pt-8 border-t border-border"
             >
-              <Link href="/grenzen">
-                <Button variant="ghost">← Grenzen setzen</Button>
-              </Link>
-              <Link href="/materialien">
-                <Button className="bg-terracotta hover:bg-terracotta-mid text-white">
+              <Button asChild variant="ghost">
+                <Link href="/grenzen">← Grenzen setzen</Link>
+              </Button>
+              <Button
+                asChild
+                className="bg-terracotta hover:bg-terracotta-mid text-white"
+              >
+                <Link href="/materialien">
                   Alle Materialien
                   <ArrowRight className="w-4 h-4 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -428,12 +428,17 @@ export default function Verstehen() {
                         klarer, wie Sie hilfreicher reagieren, Grenzen besser
                         halten und die eigene Belastung ernster nehmen können.
                       </p>
-                      <Link href="/unterstuetzen/uebersicht">
-                        <Button variant="outline" size="sm" className="gap-2">
+                      <Button
+                        asChild
+                        variant="outline"
+                        size="sm"
+                        className="gap-2"
+                      >
+                        <Link href="/unterstuetzen/uebersicht">
                           <ArrowRight className="w-4 h-4" />
                           Weiter zu: Unterstützen
-                        </Button>
-                      </Link>
+                        </Link>
+                      </Button>
                     </div>
                   </div>
                 </CardContent>
@@ -450,15 +455,16 @@ export default function Verstehen() {
                 Als Nächstes geht es darum, wie Unterstützung tragfähig bleiben
                 kann, ohne dass Sie sich selbst verlieren.
               </p>
-              <Link href="/unterstuetzen/uebersicht">
-                <Button
-                  size="lg"
-                  className="bg-terracotta hover:bg-terracotta-mid text-white"
-                >
+              <Button
+                asChild
+                size="lg"
+                className="bg-terracotta hover:bg-terracotta-mid text-white"
+              >
+                <Link href="/unterstuetzen/uebersicht">
                   Weiter zu: Unterstützen
                   <ArrowRight className="w-5 h-5 ml-2" />
-                </Button>
-              </Link>
+                </Link>
+              </Button>
             </motion.div>
           </div>
         </div>

--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -135,9 +135,9 @@ export default function KommunizierenMaterialsSection() {
       </div>
 
       <div className="text-center">
-        <Link href="/materialien">
-          <Button variant="outline">Alle Materialien ansehen</Button>
-        </Link>
+        <Button asChild variant="outline">
+          <Link href="/materialien">Alle Materialien ansehen</Link>
+        </Button>
       </div>
     </motion.div>
   );

--- a/client/src/sections/MaterialienLibrarySection.tsx
+++ b/client/src/sections/MaterialienLibrarySection.tsx
@@ -352,26 +352,18 @@ export default function MaterialienLibrarySection() {
                   die Hauptseiten oft der bessere Einstieg.
                 </p>
                 <div className="flex flex-wrap gap-2">
-                  <Link href="/verstehen">
-                    <Button variant="outline" size="sm">
-                      Verstehen
-                    </Button>
-                  </Link>
-                  <Link href="/kommunizieren">
-                    <Button variant="outline" size="sm">
-                      Kommunizieren
-                    </Button>
-                  </Link>
-                  <Link href="/grenzen">
-                    <Button variant="outline" size="sm">
-                      Grenzen
-                    </Button>
-                  </Link>
-                  <Link href="/selbstfuersorge">
-                    <Button variant="outline" size="sm">
-                      Selbstfürsorge
-                    </Button>
-                  </Link>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href="/verstehen">Verstehen</Link>
+                  </Button>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href="/kommunizieren">Kommunizieren</Link>
+                  </Button>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href="/grenzen">Grenzen</Link>
+                  </Button>
+                  <Button asChild variant="outline" size="sm">
+                    <Link href="/selbstfuersorge">Selbstfürsorge</Link>
+                  </Button>
                 </div>
               </CardContent>
             </Card>

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -127,9 +127,9 @@ export default function VerstehenInfografikenSection() {
       </div>
 
       <div className="mt-6 text-center">
-        <Link href="/materialien">
-          <Button variant="outline">Alle Materialien anzeigen</Button>
-        </Link>
+        <Button asChild variant="outline">
+          <Link href="/materialien">Alle Materialien anzeigen</Link>
+        </Button>
       </div>
     </motion.div>
   );

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -131,9 +131,9 @@ export default function VerstehenMaterialsSection() {
       </div>
 
       <div className="mt-6 text-center">
-        <Link href="/materialien">
-          <Button variant="outline">Alle Materialien anzeigen</Button>
-        </Link>
+        <Button asChild variant="outline">
+          <Link href="/materialien">Alle Materialien anzeigen</Link>
+        </Button>
       </div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- replace nested `Link` + `Button` CTAs with `Button asChild` across the audited navigation and materials flows
- fix the mobile and header Soforthilfe CTAs so they render as a single interactive element
- filter motion-only props in the smoke-test framer-motion mock to remove the noisy `whileInView` React warning

## Why
The main-branch audit found two recurring cleanup issues:
1. several CTAs rendered invalid interactive nesting (`<a><button>…</button></a>`), which is brittle for accessibility and browser behavior
2. the smoke test mock forwarded motion props to real DOM elements, which created warning noise and made it harder to spot genuine rendering problems

## Impact
- cleaner, more reliable CTA semantics for keyboard users and assistive technologies
- no more false-positive React warning from the smoke suite when rendering animated pages
- small isolated cleanup with no content or routing changes

## Validation
- `npm test`
- `npm run check`
- `npm run build`
- `npm run lint`