### PR TITLE
[codex] Fix remote material downloads

### DIFF
--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -18,6 +18,23 @@ describe("MaterialienLibrarySection", () => {
     expect(
       screen.getByText("Genesung in Zahlen – Was die Forschung zeigt")
     ).toBeInTheDocument();
+    const remoteDownloadLink = screen.getByRole("link", {
+      name: /Der Leuchtturm – Ihre Rolle als Angehörige\/r herunterladen/i,
+    });
+    expect(remoteDownloadLink).toHaveAttribute(
+      "href",
+      "/api/material-download/leuchtturm"
+    );
+    expect(remoteDownloadLink).toHaveAttribute("download", "");
+
+    const localDownloadLink = screen.getByRole("link", {
+      name: /Notfallkarte Zürich – Psychische Krise herunterladen/i,
+    });
+    expect(localDownloadLink).toHaveAttribute(
+      "href",
+      "/Notfallkarte-Zuerich-Psychische-Krise.pdf"
+    );
+    expect(localDownloadLink).toHaveAttribute("download", "");
 
     fireEvent.click(screen.getByRole("button", { name: /Genesung\s*\(1\)/ }));
 

--- a/client/src/content/materialien.ts
+++ b/client/src/content/materialien.ts
@@ -27,6 +27,13 @@ export interface MaterialItem {
   priority?: "core" | "secondary";
 }
 
+export interface ResolvedMaterialDownload {
+  id: string;
+  title: string;
+  fileName: string;
+  sourceUrl: string;
+}
+
 export const materials: MaterialItem[] = [
   {
     id: "notfallkarte-zuerich",
@@ -222,6 +229,45 @@ export const materials: MaterialItem[] = [
     priority: "secondary",
   },
 ];
+
+const MATERIAL_DOWNLOAD_PATH_PREFIX = "/api/material-download";
+const REMOTE_ASSET_RE = /^https?:\/\//i;
+
+export function buildMaterialDownloadPath(id: string) {
+  return `${MATERIAL_DOWNLOAD_PATH_PREFIX}/${encodeURIComponent(id)}`;
+}
+
+export function getMaterialDownloadHref(item: MaterialItem) {
+  const sourceUrl = item.pdfUrl ?? item.downloadUrl;
+  if (!sourceUrl) {
+    return null;
+  }
+
+  return REMOTE_ASSET_RE.test(sourceUrl)
+    ? buildMaterialDownloadPath(item.id)
+    : sourceUrl;
+}
+
+export function resolveMaterialDownload(
+  id: string
+): ResolvedMaterialDownload | null {
+  const item = materials.find(entry => entry.id === id);
+  if (!item) {
+    return null;
+  }
+
+  const sourceUrl = item.pdfUrl ?? item.downloadUrl;
+  if (!sourceUrl || !REMOTE_ASSET_RE.test(sourceUrl)) {
+    return null;
+  }
+
+  return {
+    id: item.id,
+    title: item.title,
+    fileName: `${item.id}.pdf`,
+    sourceUrl,
+  };
+}
 
 export const categoryMeta = [
   { id: "alle", label: "Alle", icon: "filter" },

--- a/client/src/sections/MaterialienLibrarySection.tsx
+++ b/client/src/sections/MaterialienLibrarySection.tsx
@@ -18,6 +18,7 @@ import { Link } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
+  getMaterialDownloadHref,
   categoryMeta,
   materials,
   quickStarts,
@@ -59,11 +60,7 @@ function MaterialCard({
 }) {
   const previewSrc = item.isHtml ? (item.previewUrl ?? item.url) : item.url;
   const openHref = item.downloadUrl ?? item.url;
-  const downloadHref = item.pdfUrl ?? item.downloadUrl;
-  const isCrossOriginDownload =
-    !!downloadHref &&
-    /^https?:\/\//i.test(downloadHref) &&
-    !downloadHref.startsWith(window.location.origin);
+  const downloadHref = getMaterialDownloadHref(item);
 
   return (
     <Card className="h-full hover:shadow-lg transition-all hover:border-sage-mid/30 overflow-hidden">
@@ -102,6 +99,7 @@ function MaterialCard({
             href={openHref}
             target="_blank"
             rel="noopener noreferrer"
+            aria-label={`${item.title} öffnen`}
             className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 bg-sage-dark hover:bg-sage-dark/90 text-white transition-colors"
           >
             <ExternalLink className="w-4 h-4" />
@@ -110,7 +108,8 @@ function MaterialCard({
           {downloadHref ? (
             <a
               href={downloadHref}
-              download={isCrossOriginDownload ? undefined : ""}
+              download=""
+              aria-label={`${item.title} herunterladen`}
               className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 border border-sage-dark text-sage-dark hover:bg-sage-light/40 transition-colors"
             >
               <Download className="w-4 h-4" />

--- a/netlify/functions/material-download.ts
+++ b/netlify/functions/material-download.ts
@@ -1,0 +1,20 @@
+import { createMaterialDownloadResponse } from "../../server/material-download";
+
+type MaterialDownloadContext = {
+  params?: {
+    id?: string;
+  };
+};
+
+export default async (_req: Request, context: MaterialDownloadContext) => {
+  const id = context.params?.id;
+  if (!id) {
+    return new Response("Material nicht gefunden.", { status: 404 });
+  }
+
+  return createMaterialDownloadResponse(id);
+};
+
+export const config = {
+  path: "/api/material-download/:id",
+};

--- a/server/index.ts
+++ b/server/index.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { createServer } from "http";
 import path from "path";
 import { fileURLToPath } from "url";
+import { createMaterialDownloadResponse } from "./material-download";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -31,6 +32,11 @@ async function startServer() {
     next();
   });
 
+  app.get("/api/material-download/:id", async (req, res) => {
+    const response = await createMaterialDownloadResponse(req.params.id);
+    await sendResponse(res, response);
+  });
+
   // Serve static files from dist/public in production
   const staticPath =
     process.env.NODE_ENV === "production"
@@ -54,3 +60,13 @@ async function startServer() {
 }
 
 startServer().catch(console.error);
+
+async function sendResponse(res: express.Response, response: Response) {
+  res.status(response.status);
+  response.headers.forEach((value, key) => {
+    res.setHeader(key, value);
+  });
+
+  const body = Buffer.from(await response.arrayBuffer());
+  res.end(body);
+}

--- a/server/material-download.ts
+++ b/server/material-download.ts
@@ -1,0 +1,52 @@
+import { resolveMaterialDownload } from "../client/src/content/materialien";
+
+export async function createMaterialDownloadResponse(id: string) {
+  const download = resolveMaterialDownload(id);
+  if (!download) {
+    return new Response("Material nicht gefunden.", { status: 404 });
+  }
+
+  try {
+    const upstream = await fetch(download.sourceUrl, {
+      headers: {
+        Accept: "application/pdf,application/octet-stream;q=0.9,*/*;q=0.1",
+      },
+    });
+
+    if (!upstream.ok || !upstream.body) {
+      return new Response("Download derzeit nicht verfügbar.", { status: 502 });
+    }
+
+    const headers = new Headers();
+    headers.set(
+      "Content-Type",
+      upstream.headers.get("content-type") ?? "application/pdf"
+    );
+    headers.set(
+      "Cache-Control",
+      upstream.headers.get("cache-control") ?? "public, max-age=31536000"
+    );
+    headers.set(
+      "Content-Disposition",
+      attachmentDisposition(download.fileName)
+    );
+    headers.set("X-Content-Type-Options", "nosniff");
+
+    const contentLength = upstream.headers.get("content-length");
+    if (contentLength) {
+      headers.set("Content-Length", contentLength);
+    }
+
+    return new Response(upstream.body, {
+      status: 200,
+      headers,
+    });
+  } catch {
+    return new Response("Download derzeit nicht verfügbar.", { status: 502 });
+  }
+}
+
+function attachmentDisposition(fileName: string) {
+  const encodedName = encodeURIComponent(fileName);
+  return `attachment; filename="${fileName}"; filename*=UTF-8''${encodedName}`;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { defineConfig, type Plugin, type ViteDevServer } from "vite";
 import { vitePluginManusRuntime } from "vite-plugin-manus-runtime";
+import { createMaterialDownloadResponse } from "./server/material-download";
 
 // =============================================================================
 // Manus Debug Collector - Vite Plugin
@@ -98,6 +99,30 @@ function vitePluginManusDebugCollector(): Plugin {
     },
 
     configureServer(server: ViteDevServer) {
+      server.middlewares.use(
+        "/api/material-download",
+        async (req, res, next) => {
+          if (req.method !== "GET") {
+            return next();
+          }
+
+          const requestUrl = new URL(req.url ?? "/", "http://localhost");
+          const id = decodeURIComponent(
+            requestUrl.pathname.replace(/^\/+/, "")
+          );
+          if (!id) {
+            return next();
+          }
+
+          const response = await createMaterialDownloadResponse(id);
+          const headers = Object.fromEntries(response.headers.entries());
+          const body = Buffer.from(await response.arrayBuffer());
+
+          res.writeHead(response.status, headers);
+          res.end(body);
+        }
+      );
+
       // POST /__manus__/logs: Browser sends logs (written directly to files)
       server.middlewares.use("/__manus__/logs", (req, res, next) => {
         if (req.method !== "POST") {


### PR DESCRIPTION
## Was sich ändert
- leitet Remote-PDF-Downloads aus der Materialbibliothek über einen same-origin Download-Endpunkt um
- liefert diese Dateien serverseitig mit `Content-Disposition: attachment` aus, statt auf das wirkungslose Cross-Origin-`download`-Attribut zu vertrauen
- ergänzt einen Test, der zwischen Remote- und lokalen Downloads unterscheidet

## Warum
In der Materialbibliothek waren die meisten "Herunterladen"-CTAs auf Cross-Origin-PDFs bei `files.manuscdn.com` gerichtet. Browser ignorieren dort das `download`-Attribut in der Regel, sodass Nutzer:innen statt eines Downloads oft nur eine PDF-Navigation im selben Tab bekommen haben.

## Wirkung
- der CTA "Herunterladen" verhält sich für die Remote-Materialien wieder wie versprochen
- lokale PDF-Downloads bleiben unverändert
- der Downloadpfad funktioniert sowohl lokal als auch auf Netlify

## Validierung
- `npm test`
- `npm run check`
- `npm run build`
- `npm run lint`