### PR TITLE
[codex] Fix fallback link styling bleed

### DIFF
--- a/client/public/fallback.css
+++ b/client/public/fallback.css
@@ -38,7 +38,8 @@ body[data-app-ready="true"] [data-static-fallback="root"] {
   display: none;
 }
 
-a {
+.fallback-page a,
+.fallback-noscript a {
   color: var(--accent-strong);
 }
 


### PR DESCRIPTION
## Was sich ändert

- scope't das globale Link-Styling in `client/public/fallback.css` auf die statischen Fallback-Flächen
- verhindert damit, dass die Fallback-Linkfarbe unbeabsichtigt in die eigentliche SPA hineinwirkt

## Warum

Der A11y-Audit hat gezeigt, dass die unscoped Regel `a { color: var(--accent-strong); }` aus `fallback.css` gegen die App-Oberfläche durchschlagen konnte. Dadurch wurden auf `/` u.a. weisse CTA- und Footer-Links braun dargestellt, obwohl die Komponenten explizit helle Textfarben setzen.

## Wirkung

- statische Fallback-Seiten behalten ihre Linkfarbe
- die SPA bekommt ihre vorgesehenen Linkfarben zurück
- der Kontrast auf dunklen Flächen wird nicht mehr von `fallback.css` unterlaufen

## Validierung

- `npm run build`
- `npm run lint`
- `npm run check`
- ursprünglicher Nachweis stammt aus `audit/a11y-interaktion`

## Herkunft

Erstes kleines Produktpaket aus dem A11y-Audit `audit/a11y-interaktion`.
