### PR TITLE
[codex] Landmark the emergency notice

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -48,7 +48,10 @@ export default function Layout({ children }: LayoutProps) {
 
       <HeaderNav onSearchOpen={() => setSearchOpen(true)} />
 
-      <div className="border-b border-border/40 bg-sage-wash/40">
+      <aside
+        aria-label="Notfallhinweis"
+        className="border-b border-border/40 bg-sage-wash/40"
+      >
         <div className="container py-1.5 text-sm md:text-xs text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1">
           <span className="font-medium text-foreground">
             Notfallkontakte: Schweiz (Kanton Zürich)
@@ -56,7 +59,7 @@ export default function Layout({ children }: LayoutProps) {
           <span className="hidden sm:inline">\u2022</span>
           <span>Für andere Regionen bitte lokale Notrufnummern nutzen.</span>
         </div>
-      </div>
+      </aside>
 
       {/* Breadcrumb Navigation */}
       <Breadcrumbs />


### PR DESCRIPTION
## Was sich ändert

- zeichnet den Notfall-Hinweis unterhalb des Headers in `Layout.tsx` semantisch als `aside` aus
- gibt dem Block mit `aria-label="Notfallhinweis"` eine eigene Landmark

## Warum

Der A11y-Audit hat auf `/` eine Axe-`region`-Violation gezeigt: Der Notfall-Hinweis lag zwischen Header und Main, aber in keiner Landmark. Damit war der Block für Screenreader strukturell schlechter einordenbar als nötig.

## Wirkung

- der Hinweisblock bleibt visuell unverändert
- die Seitenstruktur bekommt eine saubere zusätzliche Landmark für den Krisenhinweis
- der vorherige `region`-Fund aus dem Audit wird gezielt adressiert

## Validierung

- `npm run build`
- `npm run lint`
- `npm run check`
- Herkunft und ursprünglicher Nachweis stammen aus `audit/a11y-interaktion`

## Herkunft

Zweites kleines Produktpaket aus dem A11y-Audit `audit/a11y-interaktion`.
