### PR TITLE
[codex] Add fallback page landmarks

### DIFF
--- a/client/public/materialien/index.html
+++ b/client/public/materialien/index.html
@@ -66,6 +66,17 @@
             </ul>
           </article>
         </section>
+
+        <footer class="fallback-meta">
+          <nav aria-label="Direktnavigation">
+            <ul class="fallback-inline-list">
+              <li><a href="/">Startseite</a></li>
+              <li><a href="/impressum">Impressum</a></li>
+              <li><a href="/datenschutz">Datenschutz</a></li>
+              <li><a href="/fachstelle">Fachstelle</a></li>
+            </ul>
+          </nav>
+        </footer>
       </div>
     </main>
   </body>

--- a/client/public/soforthilfe/index.html
+++ b/client/public/soforthilfe/index.html
@@ -136,12 +136,14 @@
         </section>
 
         <footer class="fallback-meta">
-          <ul class="fallback-inline-list">
-            <li><a href="/">Startseite</a></li>
-            <li><a href="/impressum">Impressum</a></li>
-            <li><a href="/datenschutz">Datenschutz</a></li>
-            <li><a href="/fachstelle">Fachstelle</a></li>
-          </ul>
+          <nav aria-label="Direktnavigation">
+            <ul class="fallback-inline-list">
+              <li><a href="/">Startseite</a></li>
+              <li><a href="/impressum">Impressum</a></li>
+              <li><a href="/datenschutz">Datenschutz</a></li>
+              <li><a href="/fachstelle">Fachstelle</a></li>
+            </ul>
+          </nav>
         </footer>
       </div>
     </main>


### PR DESCRIPTION
## Summary
- add a direct-navigation landmark to the static `/soforthilfe` fallback page footer
- add a footer with direct-navigation links to the static `/materialien` fallback page
- keep the change scoped to semantic structure on the fallback surfaces without changing app navigation

## Testing
- npm run build
- npm run lint
- npm run check
