### PR TITLE
[codex] Keep footer links clear of mobile FAB

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -22,6 +22,7 @@ export default function Layout({ children }: LayoutProps) {
   const [location] = useLocation();
   const [searchOpen, setSearchOpen] = useState(false);
   const floatingMode = _getMobileFloatingMode(location);
+  const hasMobileSoforthilfeFab = location !== "/soforthilfe";
   void floatingMode;
 
   // Keyboard shortcut for search (Ctrl/Cmd + K) + ESC closes dropdown
@@ -158,7 +159,11 @@ export default function Layout({ children }: LayoutProps) {
             </p>
           </div>
 
-          <div className="border-t border-white/10 mt-6 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
+          <div
+            className={`border-t border-white/10 mt-6 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4 ${
+              hasMobileSoforthilfeFab ? "pb-24 sm:pb-0" : ""
+            }`}
+          >
             <p className="text-white/90 text-sm">
               \u00a9 2026 Borderline \u00b7 Hilfe für Angehörige. Alle Rechte
               vorbehalten.
@@ -206,7 +211,7 @@ export default function Layout({ children }: LayoutProps) {
       </footer>
 
       {/* Mobile Soforthilfe-FAB: auf allen Seiten ausser /soforthilfe selbst */}
-      {location !== "/soforthilfe" && (
+      {hasMobileSoforthilfeFab && (
         <Button
           asChild
           variant="default"


### PR DESCRIPTION
## Summary
- add a mobile-only footer clearance when the floating Soforthilfe CTA is present
- reuse the same route guard for the mobile Soforthilfe FAB and the footer spacing
- keep the change scoped to the real footer/FAB overlap instead of touching sticky-header behavior

## Verification
- npm run build
- npm run lint
- npm run check
- rerun `qa/scripts/interaction-overlap.mjs` against a fresh `origin/main` build on `4174`
- rerun `qa/scripts/click-reachability.mjs` against the same build

## Measured result
- overlap findings blocked by `Soforthilfe` dropped from `3` to `1`
- the remaining `Soforthilfe` blocker is the desktop header CTA overlapping another CTA near the top edge, not the mobile footer conflict
- click reachability stayed at `191` checked targets and `0` failures
