### PR TITLE
audit(sec): Security-Audit auf aktuelles main heben

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -51,23 +51,14 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="stylesheet" href="/print.css" media="print" />
-    <script>
-      document.documentElement.dataset.routePrerender =
-        window.location.pathname === "/" ? "home" : "none";
-    </script>
+    <script src="/route-prerender.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
-      media="print"
-      onload="this.media = 'all'"
     />
-    <noscript
-      ><link
-        href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600;700&display=swap"
-        rel="stylesheet"
-    /></noscript>
+    <link rel="stylesheet" href="/fallback.css" />
     <style>
       #route-prerender {
         display: none;
@@ -212,24 +203,6 @@
         }
       }
 
-      /* Font metric override to prevent CLS from font loading */
-      @font-face {
-        font-family: "Inter fallback";
-        src: local("Arial");
-        ascent-override: 90.49%;
-        descent-override: 22.56%;
-        line-gap-override: 0%;
-        size-adjust: 107.06%;
-      }
-      @font-face {
-        font-family: "DM Serif Display fallback";
-        src: local("Georgia");
-        ascent-override: 95%;
-        descent-override: 25%;
-        line-gap-override: 0%;
-        size-adjust: 105%;
-      }
-
       #startup-fallback {
         display: none;
         padding: 1rem;
@@ -365,14 +338,7 @@
       </div>
     </main>
     <noscript>
-      <div
-        style="
-          padding: 2rem;
-          text-align: center;
-          font-family: system-ui, sans-serif;
-          color: #333;
-        "
-      >
+      <div class="fallback-noscript">
         <h1>Interaktive Version eingeschränkt</h1>
         <p>
           Die wichtigsten Inhalte und Notfallkontakte sind oben direkt
@@ -381,45 +347,7 @@
         </p>
       </div>
     </noscript>
-    <script>
-      (function () {
-        const hasHomePrerender =
-          document.documentElement?.dataset.routePrerender === "home";
-
-        const revealFallback = () => {
-          if (hasHomePrerender) return;
-          if (document.body?.dataset.appReady === "true") return;
-          document.body?.setAttribute("data-startup-fallback-visible", "true");
-        };
-
-        const startupTimer = window.setTimeout(revealFallback, 2500);
-
-        window.addEventListener("error", revealFallback, { once: true });
-        window.addEventListener("unhandledrejection", revealFallback, {
-          once: true,
-        });
-        window.addEventListener(
-          "app-ready",
-          () => {
-            window.clearTimeout(startupTimer);
-          },
-          { once: true }
-        );
-      })();
-    </script>
+    <script src="/startup-fallback.js"></script>
     <script type="module" src="/src/main.tsx"></script>
-    <script type="module">
-      // Umami Analytics – nur laden wenn optionale Env-Variablen gesetzt sind
-      const endpoint = import.meta.env.VITE_ANALYTICS_ENDPOINT?.trim();
-      const websiteId = import.meta.env.VITE_ANALYTICS_WEBSITE_ID?.trim();
-
-      if (endpoint && websiteId) {
-        const s = document.createElement("script");
-        s.defer = true;
-        s.src = `${endpoint}/umami`;
-        s.setAttribute("data-website-id", websiteId);
-        document.head.appendChild(s);
-      }
-    </script>
   </body>
 </html>

--- a/client/public/fallback.css
+++ b/client/public/fallback.css
@@ -38,9 +38,35 @@ body[data-app-ready="true"] [data-static-fallback="root"] {
   display: none;
 }
 
+/* Font metric overrides to reduce CLS during webfont loading */
+@font-face {
+  font-family: "Inter fallback";
+  src: local("Arial");
+  ascent-override: 90.49%;
+  descent-override: 22.56%;
+  line-gap-override: 0%;
+  size-adjust: 107.06%;
+}
+
+@font-face {
+  font-family: "DM Serif Display fallback";
+  src: local("Georgia");
+  ascent-override: 95%;
+  descent-override: 25%;
+  line-gap-override: 0%;
+  size-adjust: 105%;
+}
+
 .fallback-page a,
 .fallback-noscript a {
   color: var(--accent-strong);
+}
+
+.fallback-noscript {
+  padding: 2rem;
+  text-align: center;
+  font-family: system-ui, sans-serif;
+  color: #333;
 }
 
 .fallback-page {

--- a/client/public/notfallkarte.html
+++ b/client/public/notfallkarte.html
@@ -390,7 +390,7 @@
             Für Angehörige · PUK Zürich · v06 · 2026-03-10
           </div>
           <div class="header-actions">
-            <button onclick="window.print()" class="header-btn">
+            <button type="button" id="print-notfallkarte" class="header-btn">
               🖨 Drucken / PDF
             </button>
             <a
@@ -631,19 +631,6 @@
     </div>
     <!-- .page-wrapper -->
 
-    <script>
-      function scaleToFit() {
-        const pw = document.getElementById("pw");
-        if (!pw) return;
-        const pageW = 210 * 3.7795; // mm to px at 96dpi
-        const available = window.innerWidth - 40;
-        const scale = available < pageW ? available / pageW : 1;
-        pw.style.transform = `scale(${scale})`;
-        pw.style.marginBottom =
-          scale < 1 ? `${297 * 3.7795 * scale - 297 * 3.7795}px` : "0";
-      }
-      scaleToFit();
-      window.addEventListener("resize", scaleToFit);
-    </script>
+    <script src="/notfallkarte.js"></script>
   </body>
 </html>

--- a/client/public/notfallkarte.js
+++ b/client/public/notfallkarte.js
@@ -1,0 +1,24 @@
+(function () {
+  function scaleToFit() {
+    const pageWrapper = document.getElementById("pw");
+    if (!pageWrapper) return;
+
+    const pageWidth = 210 * 3.7795; // mm to px at 96dpi
+    const availableWidth = window.innerWidth - 40;
+    const scale = availableWidth < pageWidth ? availableWidth / pageWidth : 1;
+
+    pageWrapper.style.transform = `scale(${scale})`;
+    pageWrapper.style.marginBottom =
+      scale < 1 ? `${297 * 3.7795 * scale - 297 * 3.7795}px` : "0";
+  }
+
+  const printButton = document.getElementById("print-notfallkarte");
+  if (printButton) {
+    printButton.addEventListener("click", () => {
+      window.print();
+    });
+  }
+
+  scaleToFit();
+  window.addEventListener("resize", scaleToFit);
+})();

--- a/client/public/route-prerender.js
+++ b/client/public/route-prerender.js
@@ -1,0 +1,2 @@
+document.documentElement.dataset.routePrerender =
+  window.location.pathname === "/" ? "home" : "none";

--- a/client/public/startup-fallback.js
+++ b/client/public/startup-fallback.js
@@ -1,0 +1,24 @@
+(function () {
+  const hasHomePrerender =
+    document.documentElement?.dataset.routePrerender === "home";
+
+  const revealFallback = () => {
+    if (hasHomePrerender) return;
+    if (document.body?.dataset.appReady === "true") return;
+    document.body?.setAttribute("data-startup-fallback-visible", "true");
+  };
+
+  const startupTimer = window.setTimeout(revealFallback, 2500);
+
+  window.addEventListener("error", revealFallback, { once: true });
+  window.addEventListener("unhandledrejection", revealFallback, {
+    once: true,
+  });
+  window.addEventListener(
+    "app-ready",
+    () => {
+      window.clearTimeout(startupTimer);
+    },
+    { once: true }
+  );
+})();

--- a/client/src/bootstrap/analytics.ts
+++ b/client/src/bootstrap/analytics.ts
@@ -1,0 +1,18 @@
+export function initAnalytics() {
+  const endpoint = import.meta.env.VITE_ANALYTICS_ENDPOINT?.trim();
+  const websiteId = import.meta.env.VITE_ANALYTICS_WEBSITE_ID?.trim();
+
+  if (!endpoint || !websiteId) {
+    return;
+  }
+
+  if (document.querySelector(`script[data-website-id="${websiteId}"]`)) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.defer = true;
+  script.src = `${endpoint.replace(/\/+$/, "")}/umami`;
+  script.setAttribute("data-website-id", websiteId);
+  document.head.appendChild(script);
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,5 +1,6 @@
 import { createRoot } from "react-dom/client";
 import App from "./App";
+import { initAnalytics } from "./bootstrap/analytics";
 import "./index.css";
 
 const root = document.getElementById("root");
@@ -9,6 +10,7 @@ if (!root) {
   throw new Error("#root element not found");
 }
 createRoot(root).render(<App />);
+initAnalytics();
 
 document.body.setAttribute("data-app-ready", "true");
 document.body.removeAttribute("data-startup-fallback-visible");

--- a/client/src/sections/MaterialienLibrarySection.tsx
+++ b/client/src/sections/MaterialienLibrarySection.tsx
@@ -69,7 +69,7 @@ function MaterialCard({
         className="relative aspect-[4/3] bg-muted overflow-hidden group w-full"
         onClick={() => {
           if (item.isHtml) {
-            window.open(openHref, "_blank");
+            window.open(openHref, "_blank", "noopener,noreferrer");
           } else {
             onPreview(item.url, item.title);
           }

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -93,7 +93,9 @@ export default function VerstehenInfografikenSection() {
             <button
               type="button"
               className="aspect-[3/4] bg-muted cursor-pointer w-full"
-              onClick={() => window.open(item.webpUrl, "_blank")}
+              onClick={() =>
+                window.open(item.webpUrl, "_blank", "noopener,noreferrer")
+              }
               aria-label={`${item.alt} – Vorschau öffnen`}
             >
               <img

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -97,7 +97,9 @@ export default function VerstehenMaterialsSection() {
             <button
               type="button"
               className="aspect-[3/4] bg-muted cursor-pointer w-full"
-              onClick={() => window.open(item.webpUrl, "_blank")}
+              onClick={() =>
+                window.open(item.webpUrl, "_blank", "noopener,noreferrer")
+              }
               aria-label={`${item.alt} – Vorschau öffnen`}
             >
               <img

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,7 +25,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(self)"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
 
 [[redirects]]
   from = "/notfallkarte.html"

--- a/qa/README.md
+++ b/qa/README.md
@@ -1,0 +1,46 @@
+# Codex Audit Setup
+
+Dieses Verzeichnis hält die repo-spezifische Audit-Arbeitsweise für
+`borderline-angehoerige`.
+
+## Grundregeln
+
+- Audits laufen nie im bestehenden dirty Haupt-Worktree.
+- Vor jedem Audit wird ein frischer Temp-Worktree von `origin/main` angelegt.
+- Phase 1 und Phase 2 bleiben read-only fuer Produktcode.
+- Audit-Artefakte duerfen in `qa/` und `qa/scripts/` entstehen.
+- Die Standard-Verifikation fuer dieses Repo ist:
+  - `npm test`
+  - `npm run check`
+  - `npm run build`
+  - `npm run lint`
+
+## Empfohlene Reihenfolge
+
+1. `sicherheit`
+2. `a11y-interaktion`
+3. `content-sprache`
+4. `css-hygiene`
+5. `performance`
+
+## Content-Zielgruppe
+
+Fuer den Content-Audit gilt explizit:
+
+`Angehoerige von Menschen mit Borderline-Persoenlichkeitsstoerung in der Schweiz`
+
+## Nutzung
+
+- Repo-spezifische Prompt-Sammlung: [codex-audit-prompts.md](./codex-audit-prompts.md)
+- Audit-Worktree-Helfer: [`_dev/create-audit-worktree.sh`](../_dev/create-audit-worktree.sh)
+
+Beispiel:
+
+```sh
+_dev/create-audit-worktree.sh sicherheit
+_dev/create-audit-worktree.sh a11y-interaktion
+```
+
+Der Helper kopiert `qa/README.md` und `qa/codex-audit-prompts.md` in jeden
+neu angelegten Audit-Worktree, damit jeder Audit-Lauf fuer sich
+selbstbeschreibend bleibt.

--- a/qa/audit-sicherheit.md
+++ b/qa/audit-sicherheit.md
@@ -413,7 +413,7 @@ Vorschlag:
 
 - Analytics-Bootstrap in modulare Client-Datei verschieben
 - Font-Stylesheet nicht mehr ueber Inline-`onload` schalten
-- dadurch `script-src 'unsafe-inline'` in CSP entfernbAR machen
+- dadurch `script-src 'unsafe-inline'` in CSP entfernbar machen
 
 Begruendung:
 

--- a/qa/audit-sicherheit.md
+++ b/qa/audit-sicherheit.md
@@ -1,0 +1,660 @@
+# audit/sicherheit
+
+## Meta
+
+- Repo: `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige`
+- Worktree: `/tmp/borderline-sicherheit.q1oaog`
+- Branch: `audit/sicherheit`
+- Basis: `origin/main`
+- Prompt-Sammlung: `/tmp/borderline-sicherheit.q1oaog/qa/codex-audit-prompts.md`
+- Audit-Datum: `2026-04-21`
+
+## Status
+
+- Phase 1: abgeschlossen
+- Phase 2: abgeschlossen
+- Phase 3: abgeschlossen
+- Phase 4: abgeschlossen
+
+## Notizen
+
+- Produktcode blieb in Phase 1 read-only.
+- Audit-Artefakte liegen unter `qa/`.
+- Fuer Vulnerability-Checks wurde wegen `pnpm-lock.yaml` statt `package-lock.json`
+  zusaetzlich `npm exec pnpm audit` verwendet. `npm audit` allein ist in diesem
+  Repo technisch nicht das passende Werkzeug.
+
+## Sofortmeldung
+
+- Keine echten Secrets im aktuellen Tree gefunden.
+- Keine echten `.env`-Dateien, Zertifikate oder Schluesseldateien im Repo
+  gefunden; nur `.env.example`.
+
+## Zusammenfassung
+
+Gesamtrisiko Phase 1: **hoch**
+
+Hauptgruende:
+
+1. Die Live-Site antwortet aktuell auf `/` und `/soforthilfe` mit `HTTP 503`
+   und JSON-Body `{"error":"usage_exceeded",...}` statt mit der Website.
+2. `main` ist weder klassisch branch-protected noch durch Rulesets abgesichert.
+3. Die aktuell konfigurierte CSP muss `unsafe-inline` fuer Skripte und Styles
+   erlauben, weil mehrere Inline-Skripte, Inline-Handler und Inline-Styles
+   vorhanden sind.
+
+## 1.1 Secret-Scan
+
+### Aktueller Tree
+
+- Treffer im aktuellen Tree waren nur erwartbare Platzhalter oder rein
+  textuelle Nennungen:
+  - `.github/workflows/auto-merge-claude.yml` nutzt
+    `${{ secrets.GITHUB_TOKEN }}` wie erwartet
+  - `.env.example` enthaelt nur leere Platzhalter
+  - die Audit-Prompt-Sammlung nennt Suchmuster nur dokumentarisch
+- Keine realen Tokens vom Typ `sk-`, `ghp_`, `nfp_` gefunden.
+- Keine URLs mit eingebetteten Credentials gefunden.
+
+### Dateien mit Secret-Relevanz
+
+- Nur `.env.example` ist vorhanden und historisch versioniert.
+- Keine `.env`, `.env.local`, `.pem`, `.key`, `.crt`, `.p12`, `.cer`
+  gefunden.
+
+### Git-History
+
+- `origin/main` enthaelt Historie fuer `.env.example`, aber keine Hinweise auf
+  eingecheckte echte `.env`-Dateien.
+- Suchlaeufe auf `origin/main` nach
+  `VITE_FRONTEND_FORGE_API_KEY`, `VITE_ANALYTICS_ENDPOINT`,
+  `VITE_ANALYTICS_WEBSITE_ID`, `ghp_`, `sk-`, `nfp_`, `password=` ergaben:
+  - Treffer fuer Variablennamen und Platzhalter in `.env.example`
+  - keine belegten echten Secret-Werte
+
+### Relevante Stellen
+
+- [.env.example](/tmp/borderline-sicherheit.q1oaog/.env.example:1)
+- [Map.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/components/Map.tsx:89)
+
+## 1.2 .gitignore-Pruefung
+
+`.gitignore` ist insgesamt solide.
+
+Vorhanden:
+
+- `.env`, `.env.local`, `.env.development.local`, `.env.test.local`,
+  `.env.production.local`
+- `node_modules`, `dist`, `build`, Logs, temporäre Dateien
+- zusaetzlich `package-lock.json`
+
+Keine offenkundig versehentlich versionierten sensitiven Dateien im aktuellen
+Tree.
+
+Referenz:
+
+- [.gitignore](/tmp/borderline-sicherheit.q1oaog/.gitignore:1)
+
+## 1.3 HTTP-Security-Headers
+
+### Code-Konfiguration
+
+Im Code sind die wichtigsten Security-Header sowohl in Netlify als auch im
+Express-Server gesetzt:
+
+- `X-Content-Type-Options: nosniff`
+- `X-Frame-Options: DENY`
+- `Referrer-Policy: strict-origin-when-cross-origin`
+- `Permissions-Policy`
+- `Strict-Transport-Security`
+- `Content-Security-Policy`
+
+Referenzen:
+
+- [netlify.toml](/tmp/borderline-sicherheit.q1oaog/netlify.toml:20)
+- [server/index.ts](/tmp/borderline-sicherheit.q1oaog/server/index.ts:14)
+
+### Live-Site
+
+Die Live-Site war waehrend des Audits nicht normal verfuegbar:
+
+- `curl -I https://borderline-angehoerige.netlify.app` -> `HTTP 503`
+- `curl -I https://borderline-angehoerige.netlify.app/soforthilfe` ->
+  `HTTP 503`
+- `curl https://borderline-angehoerige.netlify.app` -> JSON:
+  `{"error":"usage_exceeded","message":"Usage exceeded",...}`
+
+Dadurch liessen sich die produktiven, an die App ausgelieferten Header nicht
+vollstaendig gegen die eigentliche Seite verifizieren. Sichtbar im Netlify
+Fehler-Response war nur:
+
+- `Strict-Transport-Security`
+
+### CSP-Bewertung
+
+Die vorhandene CSP ist brauchbar, aber nicht streng, weil sie fuer Skripte und
+Styles `unsafe-inline` zulaesst:
+
+- [netlify.toml](/tmp/borderline-sicherheit.q1oaog/netlify.toml:28)
+- [server/index.ts](/tmp/borderline-sicherheit.q1oaog/server/index.ts:21)
+
+Diese Ausnahme ist aktuell real noetig, weil das Projekt Inline-Code enthaelt:
+
+- `onload="this.media = 'all'"` fuer Font-Stylesheet
+  in [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:71)
+- Inline-`<style>` fuer Font-Metrics
+  in [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:82)
+- Inline-`style="..."` im `noscript`-Fallback
+  in [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:179)
+- Inline-Analytics-`<script type="module">`
+  in [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:196)
+- `onclick="window.print()"` in
+  [client/public/notfallkarte.html](/tmp/borderline-sicherheit.q1oaog/client/public/notfallkarte.html:393)
+- Inline-`<script>` fuer `scaleToFit()` in
+  [client/public/notfallkarte.html](/tmp/borderline-sicherheit.q1oaog/client/public/notfallkarte.html:634)
+
+Folge: Eine strikte CSP ohne `unsafe-inline` ist aktuell nicht moeglich.
+
+## 1.4 Dependency-Vulnerabilities
+
+### Werkzeughinweis
+
+`npm audit` ist in diesem Repo nicht direkt nutzbar, weil kein
+`package-lock.json` vorliegt:
+
+- Ergebnis: `ENOLOCK`
+
+Da das Repo `pnpm-lock.yaml` nutzt, wurde der passende Audit-Lauf ueber
+`npm exec pnpm audit` durchgefuehrt.
+
+### Ergebnis
+
+`pnpm audit` ergab:
+
+- `critical: 0`
+- `high: 0`
+- `moderate: 0`
+- `low: 0`
+
+Artefakt:
+
+- `qa/pnpm-audit.json`
+
+## 1.5 Inline-Scripts und Event-Handler
+
+Gefunden:
+
+- Inline-`onload` in [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:75)
+- Inline-`<style>` in [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:82)
+- Inline-`style="..."` im `noscript`-Block in
+  [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:179)
+- Inline-Analytics-`<script type="module">` in
+  [client/index.html](/tmp/borderline-sicherheit.q1oaog/client/index.html:196)
+- Inline-`onclick` in
+  [client/public/notfallkarte.html](/tmp/borderline-sicherheit.q1oaog/client/public/notfallkarte.html:393)
+- Inline-`<script>` in
+  [client/public/notfallkarte.html](/tmp/borderline-sicherheit.q1oaog/client/public/notfallkarte.html:634)
+
+Bewertung:
+
+- Kein unmittelbarer XSS-Beweis
+- aber klare CSP-Haertebremse
+- insbesondere fuer ein Sicherheitsziel mit strenger CSP ein
+  **mittel-hoher Hygienebefund**
+
+## 1.6 Formulare und User-Input
+
+### Formulare / Eingabeflaechen
+
+Gefunden wurden lokale UI-Eingaben, aber keine serverseitig verarbeiteten
+Formulare im eigentlichen Sinn:
+
+- Glossar-Suche
+- globales Such-Overlay
+- Notfallkarte-Editor
+- `Feedback` ist ein `mailto:`-Flow, kein POST-Formular
+
+Bewertung:
+
+- klassischer CSRF-Angriffsvektor aktuell niedrig
+- serverseitige Input-Validierung ist kaum relevant, weil praktisch kein
+  serverseitiger User-Input verarbeitet wird
+
+### XSS-Risiken
+
+- Kein `dangerouslySetInnerHTML` gefunden
+- Keine direkte `innerHTML = ...`-Nutzung gefunden
+- Keine serverseitige HTML-Ausgabe aus User-Input gefunden
+
+### Storage-Nutzung
+
+Gefunden:
+
+- Theme-Preference in
+  [ThemeContext.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/contexts/ThemeContext.tsx:23)
+- Notfallkarten-Daten in
+  [Notfallkarte.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/pages/Notfallkarte.tsx:41)
+
+Bewertung:
+
+- Theme ist unkritisch
+- `notfallkarte-data` speichert potenziell sensible Inhalte lokal im Browser:
+  - persoenliche Kontakte
+  - Telefonnummern
+  - Notizen
+- Das ist kein klassischer Secret-Leak, aber ein **Privacy-/Shared-Device-Risiko
+  mittlerer Schwere**, weil Gesundheits-/Krisenkontext betroffen sein kann
+
+## 1.7 Deployment-Konfiguration
+
+### Netlify / Build
+
+Die Netlify-Konfiguration ist grundsaetzlich konsistent:
+
+- Build: `npx vite build`
+- Publish: `dist/public`
+
+Referenz:
+
+- [netlify.toml](/tmp/borderline-sicherheit.q1oaog/netlify.toml:1)
+
+### Live-Deployment
+
+Der groesste operative Befund ist die aktuelle Nichtverfuegbarkeit der Live-Site:
+
+- `HTTP 503`
+- Body: `usage_exceeded`
+
+Das ist in erster Linie ein Deployment-/Kontingent- oder Plattformproblem,
+nicht ein Quellcode-Problem, aber fuer Deployment-Hygiene hoch relevant.
+
+### GitHub-Repo-Hygiene
+
+API-Pruefungen ergaben:
+
+- klassische Branch Protection fuer `main`: nicht gesetzt (`404 Branch not protected`)
+- branch rules fuer `main`: `[]`
+- rulesets: `[]`
+- `delete_branch_on_merge`: `false`
+- `allow_auto_merge`: `false`
+
+Bewertung:
+
+- Fehlende Schutzregeln fuer `main` sind ein **hoher Hygienebefund**
+- vorhandene CI-Workflows pruefen zwar `main` und PRs, sind aber ohne
+  Branch-Protection nur beratend, nicht erzwungen
+
+Referenzen:
+
+- [.github/workflows/ci.yml](/tmp/borderline-sicherheit.q1oaog/.github/workflows/ci.yml:1)
+- [.github/workflows/auto-merge-claude.yml](/tmp/borderline-sicherheit.q1oaog/.github/workflows/auto-merge-claude.yml:1)
+
+### Dev-/Debug-Endpunkte
+
+In der Vite-Dev-Umgebung existiert ein Debug-Collector:
+
+- `POST /__manus__/logs`
+- nur innerhalb `configureServer(...)` des Vite-Dev-Servers
+
+Referenz:
+
+- [vite.config.ts](/tmp/borderline-sicherheit.q1oaog/vite.config.ts:101)
+
+Bewertung:
+
+- in Produktion voraussichtlich nicht aktiv
+- fuer Dev okay, aber ein Punkt fuer Wachsamkeit, falls Vite-Dev jemals
+  oeffentlich exponiert werden sollte
+
+## 1.8 Weitere sicherheitsrelevante Beobachtungen
+
+### Potenziell client-exponierter API-Key
+
+Die Google-Maps-Integration liest einen `VITE_`-konfigurierten API-Key direkt
+im Client:
+
+- [Map.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/components/Map.tsx:89)
+- [.env.example](/tmp/borderline-sicherheit.q1oaog/.env.example:1)
+
+Bewertung:
+
+- `VITE_` bedeutet bei Vite: Wert ist fuer den Browser-Bundle bestimmt
+- wenn dieser Key nur ein oeffentlich vorgesehener Browser-/Proxy-Key ist,
+  ist das okay
+- wenn dahinter ein eigentlich geheimer Dienstschluessel steckt, waere das ein
+  Designproblem
+
+Status in Phase 1:
+
+- **zu validieren**, nicht als bestatigter Leak gewertet
+
+### `window.open(..., "_blank")` ohne `noopener`
+
+Gefunden:
+
+- [MaterialienLibrarySection.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/sections/MaterialienLibrarySection.tsx:72)
+- [VerstehenInfografikenSection.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/sections/VerstehenInfografikenSection.tsx:96)
+- [VerstehenMaterialsSection.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/sections/VerstehenMaterialsSection.tsx:100)
+
+Bewertung:
+
+- kein Akutproblem
+- aber unnötige Security-Hygiene-Luecke gegenueber der sonst sauberen Nutzung
+  von `rel="noopener noreferrer"` bei normalen Links
+
+## 1.9 Nicht-Befunde / positive Punkte
+
+- Keine echten Secrets im aktuellen Tree
+- Keine echten `.env`-Dateien oder Schluesseldateien im Repo
+- `.gitignore` deckt typische Sensitive-Dateien gut ab
+- `pnpm audit` aktuell ohne bekannte Vulnerabilities
+- Keine direkte Nutzung von `dangerouslySetInnerHTML`
+- `server/material-download.ts` nutzt keinen frei vom User bestimmbaren Upstream,
+  sondern ein festes Mapping ueber `resolveMaterialDownload(id)`; damit aktuell
+  kein offensichtlicher SSRF-Pfad
+
+## 1.10 Uebersichtstabelle
+
+| Bereich                                     | Ergebnis                                 |
+| ------------------------------------------- | ---------------------------------------- |
+| Exponierte Secrets im aktuellen Tree        | 0                                        |
+| Echte `.env`-Dateien im Repo                | 0                                        |
+| Zertifikate/Private Keys im Repo            | 0                                        |
+| `pnpm audit`                                | 0 critical / 0 high / 0 moderate / 0 low |
+| Live-Site-Verfuegbarkeit                    | `HTTP 503 usage_exceeded`                |
+| Klassische Branch-Protection fuer `main`    | nicht gesetzt                            |
+| Rulesets fuer `main`                        | keine                                    |
+| Inline-Skripte / Inline-Handler             | ja                                       |
+| CSP ohne `unsafe-inline` moeglich           | derzeit nein                             |
+| localStorage mit potenziell sensiblen Daten | ja, Notfallkarte                         |
+
+## Phase-1-Fazit
+
+Die groessten Phase-1-Befunde liegen nicht bei klassischen Dependency-Leaks
+oder Secrets, sondern bei **Deployment-Hygiene und Sicherheits-Haerte**:
+
+1. Live-Site aktuell nicht verfuegbar (`503 usage_exceeded`)
+2. `main` ohne erzwungene Schutzregeln
+3. CSP durch Inline-Code nicht haertbar
+4. lokale Speicherung sensibler Notfallkarten-Daten
+5. zu validierende Client-Exposition eines Maps-/Forge-Keys
+
+## Phase 2 - Triage und Massnahmenkatalog
+
+### 2.1 Sofort-Fix im Repo
+
+#### A. `window.open(..., "_blank")` um `noopener,noreferrer` haerten
+
+- Schwere: niedrig
+- Aufwand: klein
+- Risiko: sehr niedrig
+- Status: **Phase 3**
+
+Vorschlag:
+
+- Alle programmatischen `window.open`-Aufrufe mit drittem Argument
+  `noopener,noreferrer` ausstatten
+- alternativ, wo sinnvoll, auf normale `<a target="_blank" rel="noopener
+noreferrer">`-Navigation zurueckbauen
+
+Begruendung:
+
+- schneller Hygienefix
+- keine inhaltliche Verhaltensaenderung noetig
+
+#### B. Inline-JavaScript aus `client/index.html` entfernen
+
+- Schwere: mittel
+- Aufwand: mittel
+- Risiko: niedrig bis mittel
+- Status: **Phase 3**
+
+Vorschlag:
+
+- Analytics-Bootstrap in modulare Client-Datei verschieben
+- Font-Stylesheet nicht mehr ueber Inline-`onload` schalten
+- dadurch `script-src 'unsafe-inline'` in CSP entfernbAR machen
+
+Begruendung:
+
+- unmittelbarer Sicherheitsgewinn durch strengere `script-src`
+- klar lokalisierter Eingriff ohne externe Abhaengigkeiten
+
+#### C. Inline-JavaScript aus `client/public/notfallkarte.html` entfernen
+
+- Schwere: mittel
+- Aufwand: mittel
+- Risiko: niedrig bis mittel
+- Status: **Phase 3**
+
+Vorschlag:
+
+- `onclick="window.print()"` auf normalen Button mit externer Script-Bindung
+  umstellen
+- `scaleToFit()` in separate `notfallkarte.js` auslagern
+
+Begruendung:
+
+- reduziert Inline-Skript-Flaeche
+- hilft direkt bei CSP-Haertung
+
+### 2.2 Follow-up-Ticket im Repo
+
+#### D. Inline-CSS systematisch auslagern, damit CSP auch bei `style-src` haertbar wird
+
+- Schwere: mittel
+- Aufwand: mittel bis hoch
+- Risiko: mittel
+- Status: **Follow-up-Ticket**
+
+Vorschlag:
+
+- grosse Inline-Style-Bloecke aus `client/public/notfallkarte.html`
+  in eine statische CSS-Datei verschieben
+- Font-Fallback-Regeln aus `client/index.html` in regulare Stylesheets
+  ueberfuehren
+- `noscript`-Fallback mit CSS-Klasse statt Inline-`style`
+
+Begruendung:
+
+- fuer eine wirklich strikte CSP braucht es auch ein Ende von
+  `style-src 'unsafe-inline'`
+- wegen moeglicher visueller Nebenwirkungen besser als eigenes Paket
+
+#### E. Privacy-Haertung fuer die Notfallkarte entscheiden
+
+- Schwere: mittel
+- Aufwand: mittel
+- Risiko: produkt-/UX-abhaengig
+- Status: **Follow-up-Ticket**
+
+Vorschlag:
+
+- mindestens Transparenzhinweis direkt an der Eingabeoberflaeche:
+  Daten werden lokal auf diesem Geraet gespeichert
+- optional: klarer "Daten loeschen"-CTA, Session-only-Variante oder
+  export-/print-orientierter Flow ohne dauerhafte Speicherung
+
+Begruendung:
+
+- technischer Defekt ist das nicht, aber im Gesundheits- und Krisenkontext
+  ein relevanter Shared-Device-/Privatsphaere-Befund
+- braucht Produktentscheidung, nicht nur Code-Aktion
+
+#### F. Maps-/Forge-Key-Modell validieren
+
+- Schwere: mittel
+- Aufwand: klein bis mittel
+- Risiko: unklar bis hoch, falls eigentlich geheimer Key
+- Status: **Follow-up-Ticket**
+
+Vorschlag:
+
+- bestaetigen, dass `VITE_FRONTEND_FORGE_API_KEY` bewusst ein oeffentlicher
+  Browser-/Proxy-Key ist
+- falls nein: auf serverseitigen Proxy oder restriktiv gebundenen Public-Key
+  umstellen
+
+Begruendung:
+
+- Phase 1 zeigte kein bestaetigtes Secret-Leak, aber ein klares
+  Architektur-Pruefzeichen
+
+### 2.3 Externe Sofortmassnahmen ausserhalb des Repos
+
+#### G. Live-Deployment `503 usage_exceeded` beheben
+
+- Schwere: hoch
+- Aufwand: unbekannt, vermutlich klein bis mittel
+- Risiko: hoch
+- Status: **extern sofort**
+
+Vorschlag:
+
+- Netlify-/Host-Kontingent, Billing oder Plattformsperre pruefen
+- nach Freischaltung produktive Header noch einmal live gegenpruefen
+
+Begruendung:
+
+- aktuell ist die Seite operativ nicht verfuegbar
+- das blockiert reale Nutzung staerker als jeder Repo-Hygienefund
+
+#### H. Branch-Protection / Rulesets fuer `main` aktivieren
+
+- Schwere: hoch
+- Aufwand: klein
+- Risiko: niedrig
+- Status: **extern sofort**
+
+Vorschlag:
+
+- mindestens Require PR, Require passing checks, linear/geschuetzter Merge-Pfad
+- optional zusaetzlich auto-delete merged branches aktivieren
+
+Begruendung:
+
+- vorhandene CI ist ohne erzwungene Schutzregeln nicht verbindlich
+
+### 2.4 Akzeptiert / bewusst belassen
+
+- Keine Phase-1-Befunde wurden derzeit als "akzeptiert" eingeordnet.
+
+### 2.5 Priorisierung
+
+- **P1:** Live-Deployment `503 usage_exceeded` beheben
+- **P1:** Branch-Protection fuer `main` aktivieren
+- **P1:** Inline-JavaScript entfernen und `script-src` haerten
+- **P2:** `window.open`-Hygiene fixen
+- **P2:** Privacy-Hinweis / Loeschstrategie fuer Notfallkarte entscheiden
+- **P3:** Inline-CSS auslagern und `style-src` weiter haerten
+- **P3:** Maps-/Forge-Key-Modell formell validieren
+
+### 2.6 Arbeitsentscheidung fuer Phase 3
+
+In Phase 3 werden nur die klar repo-seitig loesbaren und risikoarmen Pakete
+umgesetzt:
+
+1. `window.open` haerten
+2. Inline-JavaScript aus `client/index.html` entfernen
+3. Inline-JavaScript aus `client/public/notfallkarte.html` entfernen
+
+Externe Plattform-Themen und produktstrategische Entscheidungen bleiben bewusst
+ausserhalb dieser Umsetzungsrunde.
+
+## Phase 3 - Umsetzung
+
+Umgesetzt wurden die drei fuer diese Runde vorgesehenen Repo-Pakete:
+
+1. `window.open`-Hygiene gehaertet
+2. Inline-JavaScript aus `client/index.html` entfernt
+3. Inline-JavaScript aus `client/public/notfallkarte.html` entfernt
+
+### 3.1 App-Bootstrap statt Inline-Analytics
+
+Der bisherige Inline-Analytics-Block in `client/index.html` wurde in regulären
+Client-Code verschoben:
+
+- neuer Bootstrap:
+  [client/src/bootstrap/analytics.ts](/tmp/borderline-sicherheit.q1oaog/client/src/bootstrap/analytics.ts:1)
+- Initialisierung in
+  [client/src/main.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/main.tsx:1)
+
+Zusätzlich wurden die verbliebenen kleinen Inline-JS-Reste im App-Shell-Markup
+entfernt:
+
+- Font-Stylesheet ohne Inline-`onload`
+- `noscript`-Fallback ueber CSS-Klasse statt Inline-`style`
+- Font-Fallback-Regeln nach
+  [client/public/fallback.css](/tmp/borderline-sicherheit.q1oaog/client/public/fallback.css:1)
+
+### 3.2 Notfallkarte-JavaScript ausgelagert
+
+Die statische Notfallkarte nutzt kein Inline-JavaScript mehr:
+
+- Print-Button jetzt ohne `onclick` in
+  [client/public/notfallkarte.html](/tmp/borderline-sicherheit.q1oaog/client/public/notfallkarte.html:393)
+- neues externes Script:
+  [client/public/notfallkarte.js](/tmp/borderline-sicherheit.q1oaog/client/public/notfallkarte.js:1)
+
+### 3.3 `window.open` gehaertet und CSP verschärft
+
+Die programmatischen neuen Tabs wurden auf `noopener,noreferrer` gehaertet:
+
+- [MaterialienLibrarySection.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/sections/MaterialienLibrarySection.tsx:72)
+- [VerstehenInfografikenSection.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/sections/VerstehenInfografikenSection.tsx:97)
+- [VerstehenMaterialsSection.tsx](/tmp/borderline-sicherheit.q1oaog/client/src/sections/VerstehenMaterialsSection.tsx:101)
+
+Dadurch konnte `script-src 'unsafe-inline'` aus beiden Header-Definitionen
+entfernt werden:
+
+- [netlify.toml](/tmp/borderline-sicherheit.q1oaog/netlify.toml:28)
+- [server/index.ts](/tmp/borderline-sicherheit.q1oaog/server/index.ts:21)
+
+## Phase 4 - Verifikation
+
+### Code-Checks
+
+Erfolgreich ausgefuehrt:
+
+- `npm run lint`
+- `npm run build`
+- `npm run check`
+
+### Sicherheits-Re-Checks
+
+- Keine Inline-Event-Handler oder Inline-`<script>`-Bloecke ohne `src` mehr in
+  `client/` und `server/` gefunden
+- `pnpm audit` aus Phase 1 bleibt bei `0 critical / 0 high / 0 moderate / 0 low`
+- `script-src 'unsafe-inline'` ist im Repo-Header-Stand nicht mehr noetig
+
+### Rest-Risiken nach Umsetzung
+
+Nicht durch diese Repo-Runde geloest:
+
+1. Live-Site weiterhin extern als `503 usage_exceeded` zu behandeln
+2. `main` weiterhin ohne erzwungene Branch-Protection/Rulesets zu behandeln
+3. `style-src 'unsafe-inline'` bleibt vorerst noetig, solange grosse
+   Inline-CSS-Bloecke, insbesondere in `client/public/notfallkarte.html`,
+   bewusst nicht ausgelagert wurden
+4. Privacy-Risiko der lokal gespeicherten Notfallkarten-Daten bleibt offen
+5. Maps-/Forge-Key-Modell bleibt fachlich zu validieren
+
+## Phase-4-Fazit
+
+Der Repo-Code ist nach dieser Runde **messbar haerter**:
+
+- keine Inline-Skripte/Event-Handler mehr im geprueften App-/Server-Bereich
+- `script-src` ohne `unsafe-inline`
+- neue Tabs programmatisch gehaertet
+- Build, Lint und Typecheck gruen
+
+Die **Gesamtrisiko-Einstufung bleibt dennoch hoch**, weil die zwei gravierendsten
+Punkte ausserhalb des Codes liegen:
+
+1. aktuelles Live-Deployment nicht verfuegbar
+2. fehlende Schutzregeln auf `main`
+
+Naechster sinnvoller Schritt nach diesem Audit:
+
+- externe Behebung von Netlify/Hosting und GitHub-Branch-Protection
+- danach Audit 1 in frischem `origin/main`-basiertem Temp-Worktree

--- a/qa/codex-audit-prompts.md
+++ b/qa/codex-audit-prompts.md
@@ -1,0 +1,296 @@
+# Codex Audit Prompts fuer borderline-angehoerige
+
+Diese Prompts sind auf das Repo
+`/Users/christaegger/Documents/Webprojekte/borderline-angehoerige`
+zugeschnitten.
+
+## Gemeinsame Vorbemerkung
+
+- Arbeite fuer jedes Audit in einem frischen `origin/main`-basierten
+  Temp-Worktree.
+- Nutze dafuer bevorzugt `_dev/create-audit-worktree.sh <slug>`.
+- Phase 1 und Phase 2 bleiben read-only fuer `client/src`, `server`,
+  `client/public`, `netlify.toml` und produktive Konfigurationsdateien.
+- Audit-Artefakte unter `qa/` und `qa/scripts/` sind in Phase 1 und 2 erlaubt.
+
+## Audit 1 - Accessibility und Interaktions-Integritaet
+
+```text
+# Audit: Accessibility und Interaktions-Integritaet (Codex / borderline-angehoerige)
+
+## Kontext
+Pruefe das Projekt `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige` systematisch auf Barrierefreiheit und interaktive Integritaet. Arbeite autonom, aber stoppe nach Phase 1 und Phase 2.
+
+## Repo-spezifische Regeln
+- Arbeite NICHT im bestehenden dirty Worktree.
+- Erstelle zuerst einen frischen main-basierten Temp-Worktree von `origin/main`.
+- Audit-Branch im Temp-Worktree: `audit/a11y-interaktion`
+- Bericht: `qa/audit-a11y-interaktion.md`
+- Audit-Artefakte unter `qa/` und `qa/scripts/` sind in Phase 1/2 erlaubt.
+- Keine Aenderungen an `client/src`, `server`, `client/public`, `netlify.toml` in Phase 1/2.
+- Falls noetig, installiere audit-only Tools im Temp-Worktree: `playwright`, `@playwright/test`, `lighthouse`, `pa11y`, `axe-core`, `@axe-core/playwright`.
+- Nutze `npm run build` + `npm run preview` fuer lokale Browser-Pruefungen.
+
+## Phase 1 - Inventur
+- Pruefe mindestens diese Routen: `/`, `/soforthilfe`, `/materialien`, `/verstehen`.
+- Ermittle Lighthouse Accessibility-Scores und liste alle nicht perfekten A11y-Audits auf.
+- Fuehre zusaetzlich `axe-core` oder `pa11y` gegen dieselben Routen aus.
+- Mache manuelle Spotchecks zu Heading-Hierarchie, Landmarks, Alt-Texten, Link-/Button-Labels, Formular-Labels, Kontrast-Risiken, Fokus-Reihenfolge, Fokus-Sichtbarkeit, Esc-Verhalten und `prefers-reduced-motion`.
+- Richte die manuellen Checks besonders auf diese repo-spezifischen Hotspots aus: Such-Overlay, Mobile-Menue, sticky Soforthilfe-Leiste, Material-Vorschau/Modal, Dropdown-/Sheet-Komponenten aus `client/src/components/ui/`.
+- Schreibe `qa/scripts/interaction-overlap.mjs`, das fuer alle interaktiven Elemente in 4 Viewports (`375`, `768`, `1280`, `1920`) per `document.elementFromPoint()` prueft, ob die Mitte des Elements wirklich beim Element selbst landet.
+- Schreibe `qa/scripts/click-reachability.mjs`, aber nutze repo-taugliche Heuristiken statt "alle erwarteten Aktionen automatisch erkennen":
+  - Links: Navigation/Target erreichbar
+  - `tel:`-Links: als vorhanden und klickbar markieren
+  - Buttons mit `aria-expanded`, `aria-controls`, Dialog-/Sheet-Triggern: Toggle/Oeffnung pruefen
+  - Unklare Interaktionen als `manual-needed` klassifizieren statt falsch zu raten
+- Schreibe `qa/scripts/z-stack.mjs`, das Elemente mit `position: absolute|fixed|sticky` oder explizitem `z-index` inventarisiert und Anomalien markiert.
+- Erstelle eine Zusammenfassungstabelle im Bericht.
+
+STOPP nach Phase 1. Warte auf Freigabe.
+
+## Phase 2 - Triage
+- Ordne jeden Befund ein in `Sofort-Fix`, `Follow-up-Ticket` oder `Akzeptiert`.
+- Gib eine Release-Readiness-Stufe A/B/C.
+- Halte Risiken fuer Search, Navigation, Modal/Overlay und Soforthilfe separat fest.
+
+STOPP nach Phase 2. Warte auf Freigabe.
+
+## Phase 3 - Fixes
+- Nur nach Freigabe.
+- Pro Fix eigener Commit: `audit(a11y): fix <was>`
+
+## Phase 4 - Verifikation
+- `npm test`
+- `npm run check`
+- `npm run build`
+- `npm run lint`
+- Lighthouse-Re-Run
+- Alle drei `qa/scripts/*` erneut ausfuehren
+- Finale Release-Readiness-Aussage
+```
+
+## Audit 2 - Performance und Bundle-Hygiene
+
+```text
+# Audit: Performance und Bundle-Hygiene (Codex / borderline-angehoerige)
+
+## Kontext
+Pruefe `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige` auf Performance-Probleme und Bundle-Hygiene. Arbeite in frischem main-basiertem Temp-Worktree von `origin/main`.
+
+## Constraints
+- Branch: `audit/performance`
+- Bericht: `qa/audit-performance.md`
+- Audit-Artefakte unter `qa/` sind erlaubt, keine funktionalen Aenderungen in Phase 1/2.
+- Verwende die echten Repo-Kommandos: `npm run build`, `npm test`, `npm run check`, `npm run lint`.
+- Falls noetig, installiere audit-only Tools wie Lighthouse oder einen Vite-Bundle-Analyzer nur im Temp-Worktree.
+
+## Phase 1 - Inventur
+- Pruefe mindestens diese Routen auf Desktop und Mobile: `/`, `/materialien`, `/soforthilfe`.
+- Ermittle pro Route Lighthouse Performance, LCP, CLS, TBT/INP, FCP und Speed Index.
+- Dokumentiere die Build-Ausgabe von `npm run build` und schluessel die erzeugten Chunks nach Dateiname, raw size, gzip size und vermuteter Funktion auf.
+- Identifiziere die Top-5 groessten JS-Chunks und die groessten CSS-/Asset-Treiber.
+- Lies `package.json` und pruefe Dependencies auf tatsaechliche Importe, doppelte Funktionalitaet und offensichtliche Altlasten.
+- Fuehre `npm audit` aus und dokumentiere Findings getrennt von reiner Performance.
+- Inventarisiere Bilder in `client/public/` und externe Bildnutzung in den Pages/Sections.
+- Pruefe speziell:
+  - Hero-Bilder und `srcSet`/`sizes`
+  - `fetchPriority`
+  - `loading="lazy"`
+  - Bilder, die groesser geladen werden als angezeigt
+- Pruefe Lazy-Loading und Code-Splitting anhand von `client/src/app/routes.ts`:
+  - Routen sind bereits lazy-loaded
+  - bewerte deshalb zusaetzlich grosse, eager geladene Komponenten innerhalb der Route-Chunks
+- Suche Layout-Shift-Quellen: fehlende Dimensionen, Font-Loading, sticky UI, dynamisch eingeblendete Overlays.
+
+STOPP nach Phase 1. Warte auf Freigabe.
+
+## Phase 2 - Massnahmenkatalog
+- Formuliere pro Hot-Spot einen konkreten Vorschlag mit erwartetem Gewinn, Aufwand und Risiko.
+- Priorisierung in `P1`, `P2`, `P3`.
+- Halte bundle-bezogene und asset-bezogene Massnahmen getrennt.
+
+STOPP nach Phase 2. Warte auf Freigabe.
+
+## Phase 3 - Umsetzung
+- Pro Massnahme eigener Commit: `audit(perf): <was>`
+
+## Phase 4 - Verifikation
+- Lighthouse-Vergleich vorher/nachher
+- Vergleich der Build-/Chunk-Groessen
+- `npm test`
+- `npm run check`
+- `npm run build`
+- `npm run lint`
+```
+
+## Audit 3 - Content-Qualitaet und Sprache
+
+```text
+# Audit: Content-Qualitaet und Sprache (Codex / borderline-angehoerige)
+
+## Kontext
+Pruefe die Textinhalte dieser Website sprachlich und redaktionell. Zielgruppe: Angehoerige von Menschen mit Borderline-Persoenlichkeitsstoerung in der Schweiz. Sprache: Deutsch, Schweizer Orthografie (`ss` statt `ß`).
+
+## Constraints
+- Arbeite in frischem main-basiertem Temp-Worktree von `origin/main`
+- Branch: `audit/content-sprache`
+- Bericht: `qa/audit-content-sprache.md`
+- In Phase 1/2 nur Audit-Artefakte unter `qa/`; keine Aenderungen an Produktcode
+- Fachliche Aussagen nie eigenmaechtig "korrigieren", sondern als `zu validieren` markieren
+
+## Phase 1 - Inventur
+- Erstelle ein Content-Inventar aus:
+  - `client/src/content/**/*.ts`
+  - `client/src/data/**/*.ts`
+  - relevanten Texten in `client/src/pages/**/*.tsx`
+  - relevanten Metadaten in `client/src/components/SEO.tsx`
+- Schaetze die Gesamtwortmenge.
+- Pruefe Anrede-Konsistenz (`Sie`, `Du`, unpersoenlich, Passiv) mit Datei- und Zeilenbezug.
+- Liste Fachbegriffe auf, die fuer Angehoerige ohne Erklaerung schwer verstaendlich sind; gleiche gegen Glossar und Kontext ab.
+- Pruefe sprachliche Qualitaet stichprobenartig auf Satzlaenge, Passiv-Anteil, Nominalstil, Floskeln und Tonalitaet.
+- Pruefe Quellentransparenz:
+  - Welche Claims sind belegt?
+  - Welche empirischen Aussagen wirken veraltet oder unbelegt?
+  - Was gehoert in `zu validieren` statt in `falsch`
+- Pruefe externe Links per HTTP-Status und dokumentiere tote Links mit Datei, Linktext und Ziel.
+- Fuehre einen Stigma- und Sensibilitaets-Check durch, besonders zu Krisen, Kindesschutz, KESB, Zwang, Schuld und problematischem Framing.
+- Beruecksichtige, dass dieses Projekt warm, entlastend und psychoedukativ fuer Angehoerige formuliert sein soll, nicht klinisch-kalt und nicht paternalistisch.
+
+STOPP nach Phase 1. Warte auf Freigabe.
+
+## Phase 2 - Diagnose
+- Ordne Befunde in `Sofort-Fix`, `redaktionelles Ticket`, `Akzeptiert`.
+- Gib pro Befund einen konkreten Formulierungsvorschlag, aber aendere ohne Freigabe keine fachlichen Kernaussagen.
+- Halte SEO-/Meta-Texte und sichtbare Seitentexte getrennt.
+
+STOPP nach Phase 2. Warte auf Freigabe.
+
+## Phase 3 - Umsetzung
+- Pro Aenderung eigener Commit: `audit(content): <was>`
+- Nur Formulierungs- und Konsistenz-Fixes ohne Aenderung fachlicher Substanz
+
+## Phase 4 - Verifikation
+- Anrede-Konsistenz erneut pruefen
+- Link-Rot erneut pruefen
+- Vorher/Nachher-Metriken fuer Ton, Passiv und Floskeln dokumentieren
+```
+
+## Audit 4 - Design-Token- und CSS-Hygiene
+
+```text
+# Audit: Design-Token- und CSS-Hygiene (Codex / borderline-angehoerige)
+
+## Kontext
+Pruefe das Styling-System dieses Projekts auf Konsistenz, Token-Nutzung und Wartbarkeit. Dieses Repo ist kein klassisches SCSS-Projekt, sondern primaer Tailwind v4 + CSS-Variablen in `client/src/index.css`, plus einzelne statische Sonderfaelle in `client/public/`.
+
+## Constraints
+- Arbeite in frischem main-basiertem Temp-Worktree von `origin/main`
+- Branch: `audit/css-hygiene`
+- Bericht: `qa/audit-css-hygiene.md`
+- Keine visuellen Aenderungen in Phase 1/2
+- Farbidentitaet hat Vorrang: kein `close enough`
+- Audit-Artefakte unter `qa/` sind erlaubt
+
+## Phase 1 - Inventur
+- Erfasse das Token-System aus `client/src/index.css`:
+  - Farben
+  - Spacing-/Radius-/Typography-Tokens
+  - Light/Dark-Definitionen
+  - semantische Sonderfaelle wie Soforthilfe-Farbskala
+- Suche hardcodierte Werte nicht nur in CSS, sondern auch in:
+  - Tailwind arbitrary values in `className`
+  - Inline `style={{ ... }}`
+  - statischen Dateien `client/public/fallback.css` und `client/public/notfallkarte.html`
+- Dokumentiere pro Fund: Datei, Zeile, Wert, passender Token oder `neuer Token noetig`.
+- Analysiere Token-Nutzung:
+  - welche Tokens sind stark genutzt
+  - welche wirken ungenutzt
+  - welche Regeln umgehen das Tokensystem
+- Pruefe CSS-/Style-Struktur:
+  - `client/src/index.css`
+  - Utility-Klassen in `client/src/**/*.tsx`
+  - statische Sonderfaelle in `client/public/`
+- Suche tote Regeln, redundante Muster und problematische `z-*`, `shadow-*`, `top-*`, `text-[...]`, `rounded-[...]`-Werte.
+- Behandle `client/public/notfallkarte.html` und `client/public/fallback.css` separat von der App-Oberflaeche.
+
+STOPP nach Phase 1. Warte auf Freigabe.
+
+## Phase 2 - Massnahmenkatalog
+- Entscheide pro Hardcode zwischen:
+  - `T1` bestehenden Token angleichen
+  - `T2` neuen Token einfuehren
+  - `T3` zu bestehendem Token migrieren
+  - `T4` Sonderfall belassen
+- Schlage Buendelungen fuer Spacing-, Radius- und Shadow-Migrationen vor.
+
+STOPP nach Phase 2. Warte auf Freigabe.
+
+## Phase 3 - Umsetzung
+- Pro Massnahme eigener Commit: `audit(css): <was>`
+
+## Phase 4 - Verifikation
+- `npm run build`
+- `npm run lint`
+- visueller Vergleich auf mindestens `/`, `/soforthilfe`, `/materialien`
+- Token-Coverage vorher/nachher dokumentieren
+```
+
+## Audit 5 - Sicherheit und Deployment-Hygiene
+
+```text
+# Audit: Sicherheit und Deployment-Hygiene (Codex / borderline-angehoerige)
+
+## Kontext
+Pruefe `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige` auf Sicherheitsrisiken und Deployment-Hygiene. Nutze sowohl den Code als auch, falls erreichbar, die Live-Site `https://borderline-angehoerige.netlify.app`.
+
+## Constraints
+- Arbeite in frischem main-basiertem Temp-Worktree von `origin/main`
+- Branch: `audit/sicherheit`
+- Bericht: `qa/audit-sicherheit.md`
+- Gefundene echte Secrets SOFORT melden
+- In Phase 1/2 keine funktionalen Aenderungen
+- Audit-Artefakte unter `qa/` sind erlaubt
+
+## Phase 1 - Inventur
+- Fuehre einen Secret-Scan ueber Repo und Git-History aus:
+  - Muster wie `sk-`, `ghp_`, `nfp_`, `apiKey`, `secret`, `token`, `password=`
+  - `.env*`, private Keys, Zertifikate, Credentials in URLs, Base64-Verdachtsfaelle
+- Pruefe `.gitignore` gegen reale Repo-Inhalte und gegen gaengige Sensitive-Patterns.
+- Pruefe Security-Headers sowohl in der Live-Site als auch im Code:
+  - `netlify.toml`
+  - `server/index.ts`
+  - falls relevant `client/public/_headers` oder aehnliche Dateien
+- Pruefe CSP-Qualitaet und erklaere konkret, wofuer aktuelle Ausnahmen wie `'unsafe-inline'` noetig sind oder nicht.
+- Fuehre `npm audit` aus und gruppiere nach Schweregrad.
+- Suche inline Scripts, inline Event-Handler und andere CSP-Hindernisse in `client/public/` und im generierten App-Pattern.
+- Pruefe Formulare und User-Input:
+  - Validierung
+  - XSS-Risiken
+  - CSRF-Relevanz
+  - Storage-Nutzung (`localStorage`, `sessionStorage`)
+- Pruefe Deployment-Konfiguration:
+  - `netlify.toml`
+  - Build-/Publish-Pfade
+  - Environment-Variable-Nutzung
+  - Debug-/Dev-Endpunkte in `vite.config.ts` oder `server/`
+- Falls moeglich, pruefe per `gh` oder GitHub-App zusaetzlich Branch-Protection fuer `main`.
+
+STOPP nach Phase 1. Warte auf Freigabe.
+
+## Phase 2 - Massnahmenkatalog
+- Pro Befund: Schwere, Aufwand, konkreter Fix
+- Kritische Punkte wie echte Secrets oder bekannte High/Critical-Vulnerabilities sind nicht verhandelbar
+- Trenne klar zwischen `Code-Fix`, `Infra-/Netlify-Fix`, `GitHub-/Repo-Setting`, `manuelle Secret-Revocation`
+
+STOPP nach Phase 2. Warte auf Freigabe.
+
+## Phase 3 - Umsetzung
+- Pro Fix eigener Commit: `audit(sec): <was>`
+
+## Phase 4 - Verifikation
+- `npm audit` ohne critical/high
+- keine Secrets im Code oder in der History
+- Security-Headers in Code und Live-Site konsistent
+- `npm run build`
+- `npm run lint`
+```

--- a/qa/pnpm-audit.json
+++ b/qa/pnpm-audit.json
@@ -1,0 +1,408 @@
+{
+  "actions": [
+    {
+      "action": "update",
+      "resolves": [
+        {
+          "id": 1113515,
+          "path": ".>vite>rollup",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ],
+      "module": "rollup",
+      "target": "4.60.2",
+      "depth": 3
+    },
+    {
+      "action": "update",
+      "resolves": [
+        {
+          "id": 1115551,
+          "path": ".>lint-staged>picomatch",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1115554,
+          "path": ".>lint-staged>picomatch",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ],
+      "module": "picomatch",
+      "target": "4.0.4",
+      "depth": 3
+    },
+    {
+      "action": "review",
+      "module": "esbuild",
+      "resolves": [
+        {
+          "id": 1102341,
+          "path": ".>vitest>vite>esbuild",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    },
+    {
+      "action": "review",
+      "module": "vite",
+      "resolves": [
+        {
+          "id": 1109131,
+          "path": ".>vitest>vite",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1116229,
+          "path": ".>vitest>vite",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1116230,
+          "path": ".>vite",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1116232,
+          "path": ".>vite",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        },
+        {
+          "id": 1116235,
+          "path": ".>vite",
+          "dev": false,
+          "optional": false,
+          "bundled": false
+        }
+      ]
+    }
+  ],
+  "advisories": {
+    "1102341": {
+      "findings": [
+        {
+          "version": "0.21.5",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/evanw/esbuild/security/advisories/GHSA-67mh-4wv8-2f99\n- https://github.com/evanw/esbuild/commit/de85afd65edec9ebc44a11e245fd9e9a2e99760d\n- https://github.com/advisories/GHSA-67mh-4wv8-2f99",
+      "created": "2025-02-10T17:48:07.000Z",
+      "id": 1102341,
+      "npm_advisory_id": null,
+      "overview": "### Summary\n\nesbuild allows any websites to send any request to the development server and read the response due to default CORS settings.\n\n### Details\n\nesbuild sets `Access-Control-Allow-Origin: *` header to all requests, including the SSE connection, which allows any websites to send any request to the development server and read the response.\n\nhttps://github.com/evanw/esbuild/blob/df815ac27b84f8b34374c9182a93c94718f8a630/pkg/api/serve_other.go#L121\nhttps://github.com/evanw/esbuild/blob/df815ac27b84f8b34374c9182a93c94718f8a630/pkg/api/serve_other.go#L363\n\n**Attack scenario**:\n\n1. The attacker serves a malicious web page (`http://malicious.example.com`).\n1. The user accesses the malicious web page.\n1. The attacker sends a `fetch('http://127.0.0.1:8000/main.js')` request by JS in that malicious web page. This request is normally blocked by same-origin policy, but that's not the case for the reasons above.\n1. The attacker gets the content of `http://127.0.0.1:8000/main.js`.\n\nIn this scenario, I assumed that the attacker knows the URL of the bundle output file name. But the attacker can also get that information by\n\n- Fetching `/index.html`: normally you have a script tag here\n- Fetching `/assets`: it's common to have a `assets` directory when you have JS files and CSS files in a different directory and the directory listing feature tells the attacker the list of files\n- Connecting `/esbuild` SSE endpoint: the SSE endpoint sends the URL path of the changed files when the file is changed (`new EventSource('/esbuild').addEventListener('change', e => console.log(e.type, e.data))`)\n- Fetching URLs in the known file: once the attacker knows one file, the attacker can know the URLs imported from that file\n\nThe scenario above fetches the compiled content, but if the victim has the source map option enabled, the attacker can also get the non-compiled content by fetching the source map file.\n\n### PoC\n\n1. Download [reproduction.zip](https://github.com/user-attachments/files/18561484/reproduction.zip)\n2. Extract it and move to that directory\n1. Run `npm i`\n1. Run `npm run watch`\n1. Run `fetch('http://127.0.0.1:8000/app.js').then(r => r.text()).then(content => console.log(content))` in a different website's dev tools.\n\n![image](https://github.com/user-attachments/assets/08fc2e4d-e1ec-44ca-b0ea-78a73c3c40e9)\n\n### Impact\n\nUsers using the serve feature may get the source code stolen by malicious websites.",
+      "reported_by": null,
+      "title": "esbuild enables any website to send any requests to the development server and read the response",
+      "metadata": null,
+      "cves": [],
+      "access": "public",
+      "severity": "moderate",
+      "module_name": "esbuild",
+      "vulnerable_versions": "<=0.24.2",
+      "github_advisory_id": "GHSA-67mh-4wv8-2f99",
+      "recommendation": "Upgrade to version 0.25.0 or later",
+      "patched_versions": ">=0.25.0",
+      "updated": "2025-02-10T17:48:08.000Z",
+      "cvss": {
+        "score": 5.3,
+        "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:N/A:N"
+      },
+      "cwe": ["CWE-346"],
+      "url": "https://github.com/advisories/GHSA-67mh-4wv8-2f99"
+    },
+    "1109131": {
+      "findings": [
+        {
+          "version": "5.4.20",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/vitejs/vite/security/advisories/GHSA-93m4-6634-74q7\n- https://github.com/vitejs/vite/commit/f479cc57c425ed41ceb434fecebd63931b1ed4ed\n- https://nvd.nist.gov/vuln/detail/CVE-2025-62522\n- https://github.com/advisories/GHSA-93m4-6634-74q7",
+      "created": "2025-10-20T19:54:28.000Z",
+      "id": 1109131,
+      "npm_advisory_id": null,
+      "overview": "### Summary\nFiles denied by [`server.fs.deny`](https://vitejs.dev/config/server-options.html#server-fs-deny) were sent if the URL ended with `\\` when the dev server is running on Windows.\n\n### Impact\nOnly apps that match the following conditions are affected:\n\n- explicitly exposes the Vite dev server to the network (using --host or [`server.host` config option](https://vitejs.dev/config/server-options.html#server-host))\n- running the dev server on Windows\n\n### Details\n`server.fs.deny` can contain patterns matching against files (by default it includes `.env`, `.env.*`, `*.{crt,pem}` as such patterns). These patterns were able to bypass by using a back slash(`\\`). The root cause is that `fs.readFile('/foo.png/')` loads `/foo.png`.\n\n### PoC\n```shell\nnpm create vite@latest\ncd vite-project/\ncat \"secret\" > .env\nnpm install\nnpm run dev\ncurl --request-target /.env\\ http://localhost:5173\n```\n<img width=\"1593\" height=\"616\" alt=\"image\" src=\"https://github.com/user-attachments/assets/36212f4e-1d3c-4686-b16f-16b35ca9e175\" />",
+      "reported_by": null,
+      "title": "vite allows server.fs.deny bypass via backslash on Windows",
+      "metadata": null,
+      "cves": ["CVE-2025-62522"],
+      "access": "public",
+      "severity": "moderate",
+      "module_name": "vite",
+      "vulnerable_versions": ">=5.2.6 <=5.4.20",
+      "github_advisory_id": "GHSA-93m4-6634-74q7",
+      "recommendation": "Upgrade to version 5.4.21 or later",
+      "patched_versions": ">=5.4.21",
+      "updated": "2025-10-21T14:51:26.000Z",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "cwe": ["CWE-22"],
+      "url": "https://github.com/advisories/GHSA-93m4-6634-74q7"
+    },
+    "1113515": {
+      "findings": [
+        {
+          "version": "4.52.4",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/rollup/rollup/security/advisories/GHSA-mw96-cpmx-2vgc\n- https://nvd.nist.gov/vuln/detail/CVE-2026-27606\n- https://github.com/rollup/rollup/commit/c60770d7aaf750e512c1b2774989ea4596e660b2\n- https://github.com/rollup/rollup/commit/c8cf1f9c48c516285758c1e11f08a54f304fd44e\n- https://github.com/rollup/rollup/commit/d6dee5e99bb82aac0bee1df4ab9efbde455452c3\n- https://github.com/rollup/rollup/releases/tag/v2.80.0\n- https://github.com/rollup/rollup/releases/tag/v3.30.0\n- https://github.com/rollup/rollup/releases/tag/v4.59.0\n- https://github.com/advisories/GHSA-mw96-cpmx-2vgc",
+      "created": "2026-02-25T22:37:26.000Z",
+      "id": 1113515,
+      "npm_advisory_id": null,
+      "overview": "### Summary\nThe Rollup module bundler (specifically v4.x and present in current source) is vulnerable to an Arbitrary File Write via Path Traversal. Insecure file name sanitization in the core engine allows an attacker to control output filenames (e.g., via CLI named inputs, manual chunk aliases, or malicious plugins) and use traversal sequences (`../`) to overwrite files anywhere on the host filesystem that the build process has permissions for. This can lead to persistent Remote Code Execution (RCE) by overwriting critical system or user configuration files.\n\n### Details\nThe vulnerability is caused by the combination of two flawed components in the Rollup core:\n\n1.  **Improper Sanitization**: In `src/utils/sanitizeFileName.ts`, the `INVALID_CHAR_REGEX` used to clean user-provided names for chunks and assets excludes the period (`.`) and forward/backward slashes (`/`, `\\`). \n    ```typescript\n    // src/utils/sanitizeFileName.ts (Line 3)\n    const INVALID_CHAR_REGEX = /[\\u0000-\\u001F\"#$%&*+,:;<=>?[\\]^`{|}\\u007F]/g;\n    ```\n    This allows path traversal sequences like `../../` to pass through the sanitizer unmodified.\n\n2.  **Unsafe Path Resolution**: In `src/rollup/rollup.ts`, the `writeOutputFile` function uses `path.resolve` to combine the output directory with the \"sanitized\" filename.\n    ```typescript\n    // src/rollup/rollup.ts (Line 317)\n    const fileName = resolve(outputOptions.dir || dirname(outputOptions.file!), outputFile.fileName);\n    ```\n    Because `path.resolve` follows the `../` sequences in `outputFile.fileName`, the resulting path points outside of the intended output directory. The subsequent call to `fs.writeFile` completes the arbitrary write.\n\n### PoC\nA demonstration of this vulnerability can be performed using the Rollup CLI or a configuration file.\n\n**Scenario: CLI Named Input Exploit**\n1.  Target a sensitive file location (for demonstration, we will use a file in the project root called `pwned.js`).\n2.  Execute Rollup with a specifically crafted named input where the key contains traversal characters:\n    ```bash\n    rollup --input \"a/../../pwned.js=main.js\" --dir dist\n    ```\n3.  **Result**: Rollup will resolve the output path for the entry chunk as `dist + a/../../pwned.js`, which resolves to the project root. The file `pwned.js` is created/overwritten outside the `dist` folder.\n\n**Reproduction Files provided :**\n*   `vuln_app.js`: Isolated logic exactly replicating the sanitization and resolution bug.\n*   `exploit.py`: Automated script to run the PoC and verify the file escape.\n\nvuln_app.js\n```js\nconst path = require('path');\nconst fs = require('fs');\n\n/**\n * REPLICATED ROLLUP VULNERABILITY\n * \n * 1. Improper Sanitization (from src/utils/sanitizeFileName.ts)\n * 2. Unsafe Path Resolution (from src/rollup/rollup.ts)\n */\n\nfunction sanitize(name) {\n    // The vulnerability: Rollup's regex fails to strip dots and slashes, \n    // allowing path traversal sequences like '../'\n    return name.replace(/[\\u0000-\\u001F\"#$%&*+,:;<=>?[\\]^`{|}\\u007F]/g, '_');\n}\n\nasync function build(userSuppliedName) {\n    const outputDir = path.join(__dirname, 'dist');\n    const fileName = sanitize(userSuppliedName);\n\n    // Vulnerability: path.resolve() follows traversal sequences in the filename\n    const outputPath = path.resolve(outputDir, fileName);\n\n    console.log(`[*] Target write path: ${outputPath}`);\n\n    if (!fs.existsSync(path.dirname(outputPath))) {\n        fs.mkdirSync(path.dirname(outputPath), { recursive: true });\n    }\n\n    fs.writeFileSync(outputPath, 'console.log(\"System Compromised!\");');\n    console.log(`[+] File written successfully.`);\n}\n\nbuild(process.argv[2] || 'bundle.js');\n\n```\n\nexploit.py\n```py\nimport subprocess\nfrom pathlib import Path\n\ndef run_poc():\n    # Target a file outside the 'dist' folder\n    poc_dir = Path(__file__).parent\n    malicious_filename = \"../pwned_by_rollup.js\"\n    target_path = poc_dir / \"pwned_by_rollup.js\"\n\n    print(f\"=== Rollup Path Traversal PoC ===\")\n    print(f\"[*] Malicious Filename: {malicious_filename}\")\n    \n    # Trigger the vulnerable app\n    subprocess.run([\"node\", \"poc/vuln_app.js\", malicious_filename])\n\n    if target_path.exists():\n        print(f\"[SUCCESS] File escaped 'dist' folder!\")\n        print(f\"[SUCCESS] Created: {target_path}\")\n        # target_path.unlink() # Cleanup\n    else:\n        print(\"[FAILED] Exploit did not work.\")\n\nif __name__ == \"__main__\":\n    run_poc()\n```\n\n## POC \n```rollup --input \"bypass/../../../../../../../Users/vaghe/OneDrive/Desktop/pwned_desktop.js=main.js\" --dir dist```\n\n<img width=\"1918\" height=\"1111\" alt=\"image\" src=\"https://github.com/user-attachments/assets/3474eb7c-9c4b-4acd-9103-c70596b490d4\" />\n\n\n\n### Impact\nThis is a **High** level of severity vulnerability.\n*   **Arbitrary File Write**: Attackers can overwrite sensitive files like `~/.ssh/authorized_keys`, `.bashrc`, or system binaries if the build process has sufficient privileges.\n*   **Supply Chain Risk**: Malicious third-party plugins or dependencies can use this to inject malicious code into other parts of a developer's machine during the build phase.\n*   **User Impact**: Developers running builds on untrusted repositories are at risk of system compromise.",
+      "reported_by": null,
+      "title": "Rollup 4 has Arbitrary File Write via Path Traversal",
+      "metadata": null,
+      "cves": ["CVE-2026-27606"],
+      "access": "public",
+      "severity": "high",
+      "module_name": "rollup",
+      "vulnerable_versions": ">=4.0.0 <4.59.0",
+      "github_advisory_id": "GHSA-mw96-cpmx-2vgc",
+      "recommendation": "Upgrade to version 4.59.0 or later",
+      "patched_versions": ">=4.59.0",
+      "updated": "2026-02-25T22:37:27.000Z",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "cwe": ["CWE-22"],
+      "url": "https://github.com/advisories/GHSA-mw96-cpmx-2vgc"
+    },
+    "1115551": {
+      "findings": [
+        {
+          "version": "4.0.3",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/micromatch/picomatch/security/advisories/GHSA-3v7f-55p6-f55p\n- https://github.com/micromatch/picomatch/commit/4516eb521f13a46b2fe1a1d2c9ef6b20ddc0e903\n- https://nvd.nist.gov/vuln/detail/CVE-2026-33672\n- https://github.com/advisories/GHSA-3v7f-55p6-f55p",
+      "created": "2026-03-25T21:13:39.000Z",
+      "id": 1115551,
+      "npm_advisory_id": null,
+      "overview": "### Impact\npicomatch is vulnerable to a **method injection vulnerability (CWE-1321)** affecting the `POSIX_REGEX_SOURCE` object. Because the object inherits from `Object.prototype`, specially crafted POSIX bracket expressions (e.g., `[[:constructor:]]`) can reference inherited method names. These methods are implicitly converted to strings and injected into the generated regular expression.\n\nThis leads to **incorrect glob matching behavior (integrity impact)**, where patterns may match unintended filenames. The issue does **not enable remote code execution**, but it can cause security-relevant logic errors in applications that rely on glob matching for filtering, validation, or access control.\n\nAll users of affected `picomatch` versions that process untrusted or user-controlled glob patterns are potentially impacted.\n\n### Patches\n\nThis issue is fixed in picomatch 4.0.4, 3.0.2 and 2.3.2.\n\nUsers should upgrade to one of these versions or later, depending on their supported release line.\n\n### Workarounds\n\nIf upgrading is not immediately possible, avoid passing untrusted glob patterns to picomatch.\n\nPossible mitigations include:\n- Sanitizing or rejecting untrusted glob patterns, especially those containing POSIX character classes like `[[:...:]]`.\n- Avoiding the use of POSIX bracket expressions if user input is involved.\n- Manually patching the library by modifying `POSIX_REGEX_SOURCE` to use a null prototype:\n\n  ```js\n  const POSIX_REGEX_SOURCE = {\n    __proto__: null,\n    alnum: 'a-zA-Z0-9',\n    alpha: 'a-zA-Z',\n    // ... rest unchanged\n  };\n  \n### Resources\n\n- fix for similar issue: https://github.com/micromatch/picomatch/pull/144\n- picomatch repository https://github.com/micromatch/picomatch",
+      "reported_by": null,
+      "title": "Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching",
+      "metadata": null,
+      "cves": ["CVE-2026-33672"],
+      "access": "public",
+      "severity": "moderate",
+      "module_name": "picomatch",
+      "vulnerable_versions": ">=4.0.0 <4.0.4",
+      "github_advisory_id": "GHSA-3v7f-55p6-f55p",
+      "recommendation": "Upgrade to version 4.0.4 or later",
+      "patched_versions": ">=4.0.4",
+      "updated": "2026-03-27T21:36:25.000Z",
+      "cvss": {
+        "score": 5.3,
+        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
+      },
+      "cwe": ["CWE-1321"],
+      "url": "https://github.com/advisories/GHSA-3v7f-55p6-f55p"
+    },
+    "1115554": {
+      "findings": [
+        {
+          "version": "4.0.3",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/micromatch/picomatch/security/advisories/GHSA-c2c7-rcm5-vvqj\n- https://github.com/micromatch/picomatch/commit/5eceecd27543b8e056b9307d69e105ea03618a7d\n- https://nvd.nist.gov/vuln/detail/CVE-2026-33671\n- https://github.com/advisories/GHSA-c2c7-rcm5-vvqj",
+      "created": "2026-03-25T21:12:07.000Z",
+      "id": 1115554,
+      "npm_advisory_id": null,
+      "overview": "### Impact\n`picomatch` is vulnerable to Regular Expression Denial of Service (ReDoS) when processing crafted extglob patterns. Certain patterns using extglob quantifiers such as `+()` and `*()`, especially when combined with overlapping alternatives or nested extglobs, are compiled into regular expressions that can exhibit catastrophic backtracking on non-matching input.\n\nExamples of problematic patterns include `+(a|aa)`, `+(*|?)`, `+(+(a))`, `*(+(a))`, and `+(+(+(a)))`. In local reproduction, these patterns caused multi-second event-loop blocking with relatively short inputs. For example, `+(a|aa)` compiled to `^(?:(?=.)(?:a|aa)+)$` and took about 2 seconds to reject a 41-character non-matching input, while nested patterns such as `+(+(a))` and `*(+(a))` took around 29 seconds to reject a 33-character input on a modern M1 MacBook.\n\nApplications are impacted when they allow untrusted users to supply glob patterns that are passed to `picomatch` for compilation or matching. In those cases, an attacker can cause excessive CPU consumption and block the Node.js event loop, resulting in a denial of service. Applications that only use trusted, developer-controlled glob patterns are much less likely to be exposed in a security-relevant way.\n\n### Patches\nThis issue is fixed in picomatch 4.0.4, 3.0.2 and 2.3.2.\n\nUsers should upgrade to one of these versions or later, depending on their supported release line.\n\n### Workarounds\nIf upgrading is not immediately possible, avoid passing untrusted glob patterns to `picomatch`.\n\nPossible mitigations include:\n- disable extglob support for untrusted patterns by using `noextglob: true`\n- reject or sanitize patterns containing nested extglobs or extglob quantifiers such as `+()` and `*()`\n- enforce strict allowlists for accepted pattern syntax\n- run matching in an isolated worker or separate process with time and resource limits\n- apply application-level request throttling and input validation for any endpoint that accepts glob patterns\n\n### Resources\n- Picomatch repository: https://github.com/micromatch/picomatch\n- `lib/parse.js` and `lib/constants.js` are involved in generating the vulnerable regex forms\n- Comparable ReDoS precedent: CVE-2024-4067 (`micromatch`)\n- Comparable generated-regex precedent: CVE-2024-45296 (`path-to-regexp`)",
+      "reported_by": null,
+      "title": "Picomatch has a ReDoS vulnerability via extglob quantifiers",
+      "metadata": null,
+      "cves": ["CVE-2026-33671"],
+      "access": "public",
+      "severity": "high",
+      "module_name": "picomatch",
+      "vulnerable_versions": ">=4.0.0 <4.0.4",
+      "github_advisory_id": "GHSA-c2c7-rcm5-vvqj",
+      "recommendation": "Upgrade to version 4.0.4 or later",
+      "patched_versions": ">=4.0.4",
+      "updated": "2026-03-27T21:36:14.000Z",
+      "cvss": {
+        "score": 7.5,
+        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+      },
+      "cwe": ["CWE-1333"],
+      "url": "https://github.com/advisories/GHSA-c2c7-rcm5-vvqj"
+    },
+    "1116229": {
+      "findings": [
+        {
+          "version": "5.4.20",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/vitejs/vite/security/advisories/GHSA-4w7w-66w2-5vf9\n- https://github.com/vitejs/vite/pull/22161\n- https://github.com/vitejs/vite/commit/79f002f2286c03c88c7b74c511c7f9fc6dc46694\n- https://github.com/vitejs/vite/releases/tag/v6.4.2\n- https://github.com/vitejs/vite/releases/tag/v7.3.2\n- https://github.com/vitejs/vite/releases/tag/v8.0.5\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39365\n- https://github.com/advisories/GHSA-4w7w-66w2-5vf9",
+      "created": "2026-04-06T18:03:46.000Z",
+      "id": 1116229,
+      "npm_advisory_id": null,
+      "overview": "### Summary\n\nAny files ending with `.map` even out side the project can be returned to the browser.\n\n### Impact\n\nOnly apps that match the following conditions are affected:\n\n- explicitly exposes the Vite dev server to the network (using `--host` or [`server.host` config option](https://vitejs.dev/config/server-options.html#server-host))\n- have a sensitive content in files ending with `.map` and the path is predictable\n\n### Details\n\nIn Vite v7.3.1, the dev server’s handling of `.map` requests for optimized dependencies resolves file paths and calls `readFile` without restricting `../` segments in the URL. As a result, it is possible to bypass the [`server.fs.strict`](https://vite.dev/config/server-options#server-fs-strict) allow list and retrieve `.map` files located outside the project root, provided they can be parsed as valid source map JSON.\n\n### PoC\n1. Create a minimal PoC sourcemap outside the project root\n    ```bash\n    cat > /tmp/poc.map <<'EOF'\n    {\"version\":3,\"file\":\"x.js\",\"sources\":[],\"names\":[],\"mappings\":\"\"}\n    EOF\n    ```\n2. Start the Vite dev server (example)\n    ```bash\n    pnpm -C playground/fs-serve dev --host 127.0.0.1 --port 18080\n    ```\n3. Confirm that direct `/@fs` access is blocked by `strict` (returns 403)\n    <img width=\"4004\" height=\"1038\" alt=\"image\" src=\"https://github.com/user-attachments/assets/15a859a8-1dc6-4105-8d58-80527c0dd9ab\" />\n4. Inject `../` segments under the optimized deps `.map` URL prefix to reach `/tmp/poc.map`\n    <img width=\"2790\" height=\"846\" alt=\"image\" src=\"https://github.com/user-attachments/assets/5d02957d-2e6a-4c45-9819-3f024e0e81f2\" />",
+      "reported_by": null,
+      "title": "Vite Vulnerable to Path Traversal in Optimized Deps `.map` Handling",
+      "metadata": null,
+      "cves": ["CVE-2026-39365"],
+      "access": "public",
+      "severity": "moderate",
+      "module_name": "vite",
+      "vulnerable_versions": "<=6.4.1",
+      "github_advisory_id": "GHSA-4w7w-66w2-5vf9",
+      "recommendation": "Upgrade to version 6.4.2 or later",
+      "patched_versions": ">=6.4.2",
+      "updated": "2026-04-07T22:16:29.000Z",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "cwe": ["CWE-22", "CWE-200"],
+      "url": "https://github.com/advisories/GHSA-4w7w-66w2-5vf9"
+    },
+    "1116230": {
+      "findings": [
+        {
+          "version": "7.3.1",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/vitejs/vite/security/advisories/GHSA-4w7w-66w2-5vf9\n- https://github.com/vitejs/vite/pull/22161\n- https://github.com/vitejs/vite/commit/79f002f2286c03c88c7b74c511c7f9fc6dc46694\n- https://github.com/vitejs/vite/releases/tag/v6.4.2\n- https://github.com/vitejs/vite/releases/tag/v7.3.2\n- https://github.com/vitejs/vite/releases/tag/v8.0.5\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39365\n- https://github.com/advisories/GHSA-4w7w-66w2-5vf9",
+      "created": "2026-04-06T18:03:46.000Z",
+      "id": 1116230,
+      "npm_advisory_id": null,
+      "overview": "### Summary\n\nAny files ending with `.map` even out side the project can be returned to the browser.\n\n### Impact\n\nOnly apps that match the following conditions are affected:\n\n- explicitly exposes the Vite dev server to the network (using `--host` or [`server.host` config option](https://vitejs.dev/config/server-options.html#server-host))\n- have a sensitive content in files ending with `.map` and the path is predictable\n\n### Details\n\nIn Vite v7.3.1, the dev server’s handling of `.map` requests for optimized dependencies resolves file paths and calls `readFile` without restricting `../` segments in the URL. As a result, it is possible to bypass the [`server.fs.strict`](https://vite.dev/config/server-options#server-fs-strict) allow list and retrieve `.map` files located outside the project root, provided they can be parsed as valid source map JSON.\n\n### PoC\n1. Create a minimal PoC sourcemap outside the project root\n    ```bash\n    cat > /tmp/poc.map <<'EOF'\n    {\"version\":3,\"file\":\"x.js\",\"sources\":[],\"names\":[],\"mappings\":\"\"}\n    EOF\n    ```\n2. Start the Vite dev server (example)\n    ```bash\n    pnpm -C playground/fs-serve dev --host 127.0.0.1 --port 18080\n    ```\n3. Confirm that direct `/@fs` access is blocked by `strict` (returns 403)\n    <img width=\"4004\" height=\"1038\" alt=\"image\" src=\"https://github.com/user-attachments/assets/15a859a8-1dc6-4105-8d58-80527c0dd9ab\" />\n4. Inject `../` segments under the optimized deps `.map` URL prefix to reach `/tmp/poc.map`\n    <img width=\"2790\" height=\"846\" alt=\"image\" src=\"https://github.com/user-attachments/assets/5d02957d-2e6a-4c45-9819-3f024e0e81f2\" />",
+      "reported_by": null,
+      "title": "Vite Vulnerable to Path Traversal in Optimized Deps `.map` Handling",
+      "metadata": null,
+      "cves": ["CVE-2026-39365"],
+      "access": "public",
+      "severity": "moderate",
+      "module_name": "vite",
+      "vulnerable_versions": ">=7.0.0 <=7.3.1",
+      "github_advisory_id": "GHSA-4w7w-66w2-5vf9",
+      "recommendation": "Upgrade to version 7.3.2 or later",
+      "patched_versions": ">=7.3.2",
+      "updated": "2026-04-07T22:16:29.000Z",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "cwe": ["CWE-22", "CWE-200"],
+      "url": "https://github.com/advisories/GHSA-4w7w-66w2-5vf9"
+    },
+    "1116232": {
+      "findings": [
+        {
+          "version": "7.3.1",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/vitejs/vite/security/advisories/GHSA-v2wj-q39q-566r\n- https://github.com/vitejs/vite/pull/22160\n- https://github.com/vitejs/vite/commit/a9a3df299378d9cbc5f069e3536a369f8188c8ff\n- https://github.com/vitejs/vite/releases/tag/v7.3.2\n- https://github.com/vitejs/vite/releases/tag/v8.0.5\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39364\n- https://github.com/advisories/GHSA-v2wj-q39q-566r",
+      "created": "2026-04-06T18:03:32.000Z",
+      "id": 1116232,
+      "npm_advisory_id": null,
+      "overview": "### Summary\n\nThe contents of files that are specified by [`server.fs.deny`](https://vite.dev/config/server-options#server-fs-deny) can be returned to the browser.\n\n### Impact\n\nOnly apps that match the following conditions are affected:\n\n- explicitly exposes the Vite dev server to the network (using `--host` or [`server.host` config option](https://vitejs.dev/config/server-options.html#server-host))\n- the sensitive file exists in the allowed directories specified by [`server.fs.allow`](https://vite.dev/config/server-options#server-fs-allow)\n- the sensitive file is denied with a pattern that matches a file by [`server.fs.deny`](https://vite.dev/config/server-options#server-fs-deny)\n\n### Details\n\nOn the Vite dev server, files that should be blocked by `server.fs.deny` (e.g., `.env`, `*.crt`) can be retrieved with HTTP 200 responses when query parameters such as `?raw`, `?import&raw`, or `?import&url&inline` are appended.\n\n### PoC\n\n1. Start the dev server: `pnpm exec vite root --host 127.0.0.1 --port 5175 --strictPort`\n2. Confirm that `server.fs.deny` is enforced (expect 403): `curl -i http://127.0.0.1:5175/src/.env | head -n 20`\n   <img width=\"3944\" height=\"1092\" alt=\"image\" src=\"https://github.com/user-attachments/assets/ecb9f2e0-e08f-4ac7-b194-e0f988c4cd4f\" />\n3. Confirm that the same files can be retrieved with query parameters (expect 200):\n   <img width=\"2014\" height=\"373\" alt=\"image\" src=\"https://github.com/user-attachments/assets/76bc2a6a-44f4-4161-ae47-eab5ae0c04a8\" />",
+      "reported_by": null,
+      "title": "Vite: `server.fs.deny` bypassed with queries",
+      "metadata": null,
+      "cves": ["CVE-2026-39364"],
+      "access": "public",
+      "severity": "high",
+      "module_name": "vite",
+      "vulnerable_versions": ">=7.1.0 <=7.3.1",
+      "github_advisory_id": "GHSA-v2wj-q39q-566r",
+      "recommendation": "Upgrade to version 7.3.2 or later",
+      "patched_versions": ">=7.3.2",
+      "updated": "2026-04-07T22:16:19.000Z",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "cwe": ["CWE-180", "CWE-284"],
+      "url": "https://github.com/advisories/GHSA-v2wj-q39q-566r"
+    },
+    "1116235": {
+      "findings": [
+        {
+          "version": "7.3.1",
+          "paths": []
+        }
+      ],
+      "found_by": null,
+      "deleted": null,
+      "references": "- https://github.com/vitejs/vite/security/advisories/GHSA-p9ff-h696-f583\n- https://github.com/vitejs/vite/pull/22159\n- https://github.com/vitejs/vite/commit/f02d9fde0b195afe3ea2944414186962fbbe41e0\n- https://github.com/vitejs/vite/releases/tag/v6.4.2\n- https://github.com/vitejs/vite/releases/tag/v7.3.2\n- https://github.com/vitejs/vite/releases/tag/v8.0.5\n- https://nvd.nist.gov/vuln/detail/CVE-2026-39363\n- https://github.com/advisories/GHSA-p9ff-h696-f583",
+      "created": "2026-04-06T18:03:24.000Z",
+      "id": 1116235,
+      "npm_advisory_id": null,
+      "overview": "### Summary\n\n[`server.fs`](https://vite.dev/config/server-options#server-fs-strict) check was not enforced to the `fetchModule` method that is exposed in Vite dev server's WebSocket. \n\n### Impact\n\nOnly apps that match the following conditions are affected:\n\n- explicitly exposes the Vite dev server to the network (using `--host` or [`server.host` config option](https://vitejs.dev/config/server-options.html#server-host))\n- WebSocket is not disabled by `server.ws: false`\n\nArbitrary files on the server (development machine, CI environment, container, etc.) can be exposed.\n\n### Details\n\nIf it is possible to connect to the Vite dev server’s WebSocket **without an `Origin` header**, an attacker can invoke `fetchModule` via the custom WebSocket event `vite:invoke` and combine `file://...` with `?raw` (or `?inline`) to retrieve the contents of arbitrary files on the server as a JavaScript string (e.g., `export default \"...\"`).\n\nThe access control enforced in the HTTP request path (such as `server.fs.allow`) is not applied to this WebSocket-based execution path.\n\n### PoC\n\n1. Start the dev server on the target \n   Example (used during validation with this repository):\n   ```bash\n   pnpm -C playground/alias exec vite --host 0.0.0.0 --port 5173\n   ```\n\n2. Confirm that access is blocked via the HTTP path (example: arbitrary file)\n   ```bash\n   curl -i 'http://localhost:5173/@fs/etc/passwd?raw'\n   ```\n   Result: `403 Restricted` (outside the allow list)\n   <img width=\"3898\" height=\"1014\" alt=\"image\" src=\"https://github.com/user-attachments/assets/f6593377-549c-45d7-b562-5c19833438af\" />\n\n3. Confirm that the same file can be retrieved via the WebSocket path\n   By connecting to the HMR WebSocket without an `Origin` header and sending a `vite:invoke` request that calls `fetchModule` with a `file://...` URL and `?raw`, the file contents are returned as a JavaScript module.\n  <img width=\"1049\" height=\"296\" alt=\"image\" src=\"https://github.com/user-attachments/assets/af969f7b-d34e-4af4-8adb-5e2b83b31972\" />\n  <img width=\"1382\" height=\"955\" alt=\"image\" src=\"https://github.com/user-attachments/assets/6a230d2e-197a-4c9c-b373-d0129756d5d7\" />",
+      "reported_by": null,
+      "title": "Vite Vulnerable to Arbitrary File Read via Vite Dev Server WebSocket",
+      "metadata": null,
+      "cves": ["CVE-2026-39363"],
+      "access": "public",
+      "severity": "high",
+      "module_name": "vite",
+      "vulnerable_versions": ">=7.0.0 <=7.3.1",
+      "github_advisory_id": "GHSA-p9ff-h696-f583",
+      "recommendation": "Upgrade to version 7.3.2 or later",
+      "patched_versions": ">=7.3.2",
+      "updated": "2026-04-07T22:16:11.000Z",
+      "cvss": {
+        "score": 0,
+        "vectorString": null
+      },
+      "cwe": ["CWE-200", "CWE-306"],
+      "url": "https://github.com/advisories/GHSA-p9ff-h696-f583"
+    }
+  },
+  "muted": [],
+  "metadata": {
+    "vulnerabilities": {
+      "info": 0,
+      "low": 0,
+      "moderate": 5,
+      "high": 4,
+      "critical": 0
+    },
+    "dependencies": 572,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 572
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -20,7 +20,7 @@ async function startServer() {
     res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
     res.setHeader(
       "Content-Security-Policy",
-      "default-src 'self'; script-src 'self' 'unsafe-inline' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
+      "default-src 'self'; script-src 'self' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
     );
     res.setHeader(
       "Strict-Transport-Security",


### PR DESCRIPTION
## Zusammenfassung
- hebt die fünf Security-Audit-Commits sauber auf aktuelles `main` und behält dabei die spätere Home-Prerender-/Startup-Fallback-Architektur
- entfernt das verbliebene Inline-JavaScript aus `client/index.html` durch kleine Public-Bootstrap-Skripte und macht damit `script-src 'unsafe-inline'` in der CSP entbehrlich
- übernimmt zusätzlich das Notfallkarten-Skript-Externalizing, das Hardening für externe Preview-Opens und den aktualisierten Security-Audit-Bericht

## Verifikation
- `npm run lint`
- `npm run build`
- `npm run check`
- Quellsuche auf verbliebene Inline-Skripte bzw. Inline-Handler in `client/index.html` und `client/public/**/*.html`

## Hinweise ausserhalb des Repos
- die Live-Site `https://borderline-angehoerige.netlify.app/` lieferte beim Audit weiterhin HTTP 503
- für `main` ist aktuell keine Branch-Protection hinterlegt
- GitHub-Rulesets waren beim Audit leer

## Kontext
Die konfliktträchtigste Stelle war `client/index.html`: Dort musste die ältere Security-Änderung mit der späteren Performance-Architektur kombiniert werden, statt einfach die Audit-Version zu übernehmen.
