### PR TITLE
[codex] Fix search edge cases for empty query tokens

### DIFF
--- a/client/src/__tests__/search.test.tsx
+++ b/client/src/__tests__/search.test.tsx
@@ -1,0 +1,62 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { Router } from "wouter";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import Search, { getSearchTerms } from "@/components/Search";
+
+describe("Search helpers", () => {
+  it("ignores whitespace-only and one-letter search tokens", () => {
+    expect(getSearchTerms("  ")).toEqual([]);
+    expect(getSearchTerms(" a")).toEqual([]);
+    expect(getSearchTerms("a ")).toEqual([]);
+    expect(getSearchTerms(" a ")).toEqual([]);
+    expect(getSearchTerms("db t")).toEqual(["db"]);
+  });
+});
+
+describe("Search", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "scrollTo", {
+      value: vi.fn(),
+      writable: true,
+    });
+    Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+      value: vi.fn(),
+      writable: true,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("clears the active descendant when the query is no longer searchable", () => {
+    render(
+      <Router>
+        <Search isOpen onClose={() => {}} />
+      </Router>
+    );
+
+    const input = screen.getByRole("combobox", {
+      name: /website durchsuchen/i,
+    });
+
+    fireEvent.change(input, { target: { value: "Validierung" } });
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+
+    expect(input).toHaveAttribute("aria-activedescendant", "search-result-0");
+
+    fireEvent.change(input, { target: { value: " a" } });
+
+    expect(input).not.toHaveAttribute("aria-activedescendant");
+    expect(
+      screen.getByText(/mindestens einen suchbegriff mit 2 zeichen/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -13,6 +13,17 @@ interface SearchProps {
   onClose: () => void;
 }
 
+export function normalizeSearchQuery(query: string) {
+  return query.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+export function getSearchTerms(query: string) {
+  const normalizedQuery = normalizeSearchQuery(query);
+  return normalizedQuery
+    ? normalizedQuery.split(" ").filter(term => term.length > 1)
+    : [];
+}
+
 export default function Search({ isOpen, onClose }: SearchProps) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchEntry[]>([]);
@@ -38,6 +49,9 @@ export default function Search({ isOpen, onClose }: SearchProps) {
       })),
     []
   );
+  const normalizedQuery = useMemo(() => normalizeSearchQuery(query), [query]);
+  const searchTerms = useMemo(() => getSearchTerms(query), [query]);
+  const hasSearchTerms = searchTerms.length > 0;
 
   // Focus input when opened
   useEffect(() => {
@@ -78,15 +92,13 @@ export default function Search({ isOpen, onClose }: SearchProps) {
       debounceTimeoutRef.current = null;
     }
 
-    if (query.length < 2) {
+    if (!hasSearchTerms) {
       setResults([]);
+      setActiveIndex(-1);
       return;
     }
 
     debounceTimeoutRef.current = setTimeout(() => {
-      const queryLower = query.toLowerCase();
-      const searchTerms = queryLower.split(" ").filter(t => t.length > 1);
-
       const matches = normalizedSearchIndex
         .filter(({ searchText }) =>
           searchTerms.every(term => searchText.includes(term))
@@ -98,9 +110,15 @@ export default function Search({ isOpen, onClose }: SearchProps) {
         const aTitle = a.title.toLowerCase();
         const bTitle = b.title.toLowerCase();
 
-        if (aTitle.includes(queryLower) && !bTitle.includes(queryLower))
+        if (
+          aTitle.includes(normalizedQuery) &&
+          !bTitle.includes(normalizedQuery)
+        )
           return -1;
-        if (!aTitle.includes(queryLower) && bTitle.includes(queryLower))
+        if (
+          !aTitle.includes(normalizedQuery) &&
+          bTitle.includes(normalizedQuery)
+        )
           return 1;
         return 0;
       });
@@ -115,7 +133,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
         debounceTimeoutRef.current = null;
       }
     };
-  }, [normalizedSearchIndex, query]);
+  }, [hasSearchTerms, normalizedQuery, normalizedSearchIndex, searchTerms]);
 
   const handleResultClick = () => {
     setQuery("");
@@ -196,7 +214,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                   aria-expanded={results.length > 0}
                   aria-controls="search-results"
                   aria-activedescendant={
-                    activeIndex >= 0
+                    results.length > 0 && activeIndex >= 0
                       ? `search-result-${activeIndex}`
                       : undefined
                   }
@@ -223,10 +241,11 @@ export default function Search({ isOpen, onClose }: SearchProps) {
 
               {/* Results */}
               <div className="max-h-[60vh] overflow-y-auto" aria-live="polite">
-                {query.length < 2 ? (
+                {!hasSearchTerms ? (
                   <div className="px-4 py-8 text-center">
                     <p className="text-muted-foreground text-sm">
-                      Geben Sie mindestens 2 Zeichen ein, um zu suchen
+                      Geben Sie mindestens einen Suchbegriff mit 2 Zeichen ein,
+                      um zu suchen
                     </p>
                     <div className="mt-4 flex flex-wrap justify-center gap-2">
                       {[


### PR DESCRIPTION
## Was sich geändert hat

- die Suchlogik normalisiert Eingaben jetzt vor der Auswertung und ignoriert reine Whitespace- sowie Ein-Zeichen-Tokens sauber
- der Suchdialog leert `results` und `activeIndex` sofort, sobald keine gültigen Suchbegriffe mehr vorhanden sind
- `aria-activedescendant` wird nur noch gesetzt, wenn tatsächlich noch eine Ergebnisliste existiert
- neue Tests decken sowohl die Token-Normalisierung als auch das Zurücksetzen des ARIA-Zustands ab

## Warum das nötig war

Im Audit auf `main` gab es zwei konkrete Search-Befunde:

1. Eingaben wie Leerzeichen oder `" a"` konnten wegen der ungetrimmten Mindestlängen-Prüfung trotzdem in die Suche laufen und durch ein leeres `searchTerms`-Array faktisch beliebige Top-Treffer anzeigen.
2. Nach dem Zurücklöschen einer zuvor navigierten Suche blieb `aria-activedescendant` teilweise auf ein nicht mehr existentes Ergebnis gesetzt.

Beides führte zu unnötig verwirrendem Verhalten im Suchdialog, einmal funktional und einmal aus A11y-Sicht.

## Wirkung

- keine Schein-Treffer mehr bei praktisch leerer Eingabe
- konsistenter Keyboard- und Screenreader-State beim Zurücklöschen der Query
- kleine, klar abgegrenzte Absicherung eines realen Audit-Fundes auf `main`

## Validierung

- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`