### PR TITLE
[codex] Proxy remote handout PDF open links

### DIFF
--- a/client/src/__tests__/handouts.test.ts
+++ b/client/src/__tests__/handouts.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  getHandoutDownloadHref,
+  getHandoutOpenHref,
+  resolveHandoutAsset,
+} from "@/content/handouts";
+import { kommItems } from "@/content/kommunizieren";
+import { verstehenInfografiken } from "@/content/verstehen";
+
+describe("handout delivery helpers", () => {
+  it("maps known remote materials to proxied open and download URLs", () => {
+    const sourceUrl = verstehenInfografiken[0].pdfUrl;
+
+    expect(getHandoutOpenHref(sourceUrl)).toBe(
+      "/api/material-download/leuchtturm?disposition=inline"
+    );
+    expect(getHandoutDownloadHref(sourceUrl)).toBe(
+      "/api/material-download/leuchtturm"
+    );
+    expect(resolveHandoutAsset("leuchtturm")?.sourceUrl).toBe(sourceUrl);
+  });
+
+  it("allowlists non-library handouts through generated ids", () => {
+    const sourceUrl = kommItems[0].pdfUrl;
+
+    expect(getHandoutOpenHref(sourceUrl)).toBe(
+      "/api/material-download/kommunizieren-wenn-gespraeche-kippen-3-schritte?disposition=inline"
+    );
+    expect(
+      resolveHandoutAsset("kommunizieren-wenn-gespraeche-kippen-3-schritte")
+        ?.sourceUrl
+    ).toBe(sourceUrl);
+  });
+
+  it("keeps local pdf paths untouched", () => {
+    expect(getHandoutOpenHref("/notfallplan-krise-v03.pdf")).toBe(
+      "/notfallplan-krise-v03.pdf"
+    );
+    expect(
+      getHandoutDownloadHref("/Notfallkarte-Zuerich-Psychische-Krise.pdf")
+    ).toBe("/Notfallkarte-Zuerich-Psychische-Krise.pdf");
+  });
+});

--- a/client/src/content/handouts.ts
+++ b/client/src/content/handouts.ts
@@ -1,0 +1,171 @@
+import { genesungItems } from "./genesung";
+import { grenzenItems } from "./grenzen";
+import { kommItems } from "./kommunizieren";
+import { materials } from "./materialien";
+import { selbstfuersorgeInfografiken } from "./selbstfuersorge";
+import { unterstuetzenItems } from "./unterstuetzen";
+import { verstehenInfografiken } from "./verstehen";
+
+export type HandoutDisposition = "attachment" | "inline";
+
+export interface HandoutAsset {
+  id: string;
+  title: string;
+  sourceUrl: string;
+  fileName: string;
+}
+
+const HANDOUT_ASSET_PATH_PREFIX = "/api/material-download";
+const REMOTE_ASSET_RE = /^https?:\/\//i;
+
+function slugifySegment(value: string) {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/ä/g, "ae")
+    .replace(/ö/g, "oe")
+    .replace(/ü/g, "ue")
+    .replace(/ß/g, "ss")
+    .normalize("NFKD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function buildFileName(id: string) {
+  return `${id}.pdf`;
+}
+
+function registerAsset(
+  registry: Map<string, HandoutAsset>,
+  sourceUrl: string | undefined,
+  id: string,
+  title: string
+) {
+  if (
+    !sourceUrl ||
+    !REMOTE_ASSET_RE.test(sourceUrl) ||
+    registry.has(sourceUrl)
+  ) {
+    return;
+  }
+
+  registry.set(sourceUrl, {
+    id,
+    title,
+    sourceUrl,
+    fileName: buildFileName(id),
+  });
+}
+
+function buildRegistry() {
+  const registry = new Map<string, HandoutAsset>();
+
+  for (const item of materials) {
+    registerAsset(
+      registry,
+      item.pdfUrl ?? item.downloadUrl,
+      item.id,
+      item.title
+    );
+  }
+
+  for (const item of verstehenInfografiken) {
+    registerAsset(registry, item.pdfUrl, `verstehen-${item.id}`, item.title);
+  }
+
+  for (const item of unterstuetzenItems) {
+    registerAsset(
+      registry,
+      item.pdfUrl,
+      `unterstuetzen-${slugifySegment(item.title)}`,
+      item.title
+    );
+  }
+
+  for (const item of kommItems) {
+    registerAsset(
+      registry,
+      item.pdfUrl,
+      `kommunizieren-${slugifySegment(item.title)}`,
+      item.title
+    );
+  }
+
+  for (const item of grenzenItems) {
+    registerAsset(
+      registry,
+      item.pdfUrl,
+      `grenzen-${slugifySegment(item.title)}`,
+      item.title
+    );
+  }
+
+  for (const item of selbstfuersorgeInfografiken) {
+    registerAsset(registry, item.pdf, `selbstfuersorge-${item.id}`, item.title);
+  }
+
+  for (const item of genesungItems) {
+    registerAsset(
+      registry,
+      item.pdf,
+      `genesung-${slugifySegment(item.title)}`,
+      item.title
+    );
+  }
+
+  return registry;
+}
+
+const handoutAssetsBySource = buildRegistry();
+const handoutAssetsById = new Map(
+  Array.from(handoutAssetsBySource.values()).map(asset => [asset.id, asset])
+);
+
+export function buildHandoutAssetPath(
+  id: string,
+  disposition: HandoutDisposition = "attachment"
+) {
+  const path = `${HANDOUT_ASSET_PATH_PREFIX}/${encodeURIComponent(id)}`;
+  return disposition === "inline" ? `${path}?disposition=inline` : path;
+}
+
+export function resolveHandoutAsset(id: string): HandoutAsset | null {
+  return handoutAssetsById.get(id) ?? null;
+}
+
+export function getHandoutAssetBySource(
+  sourceUrl: string | undefined
+): HandoutAsset | null {
+  if (!sourceUrl) {
+    return null;
+  }
+
+  return handoutAssetsBySource.get(sourceUrl) ?? null;
+}
+
+export function getHandoutOpenHref(sourceUrl: string | undefined) {
+  if (!sourceUrl) {
+    return null;
+  }
+
+  if (!REMOTE_ASSET_RE.test(sourceUrl)) {
+    return sourceUrl;
+  }
+
+  const asset = getHandoutAssetBySource(sourceUrl);
+  return asset ? buildHandoutAssetPath(asset.id, "inline") : sourceUrl;
+}
+
+export function getHandoutDownloadHref(sourceUrl: string | undefined) {
+  if (!sourceUrl) {
+    return null;
+  }
+
+  if (!REMOTE_ASSET_RE.test(sourceUrl)) {
+    return sourceUrl;
+  }
+
+  const asset = getHandoutAssetBySource(sourceUrl);
+  return asset ? buildHandoutAssetPath(asset.id, "attachment") : sourceUrl;
+}

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -21,6 +21,7 @@ import { Link } from "wouter";
 import ContentSection from "@/components/ContentSection";
 import { TableOfContents } from "@/components/UXEnhancements";
 import { genesungItems as genesungMaterialItems } from "@/content/genesung";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 function GenesungInfografiken() {
   return (
@@ -62,7 +63,7 @@ function GenesungInfografiken() {
               </h3>
               <p className="text-muted-foreground text-sm mb-3">{item.desc}</p>
               <a
-                href={item.pdf}
+                href={getHandoutOpenHref(item.pdf) ?? item.pdf}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -22,6 +22,7 @@ import { Link } from "wouter";
 import ContentSection from "@/components/ContentSection";
 
 import { grenzenItems } from "@/content/grenzen";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 export default function Grenzen() {
   return (
@@ -550,7 +551,7 @@ export default function Grenzen() {
                         {item.title}
                       </h3>
                       <a
-                        href={item.pdfUrl}
+                        href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -25,6 +25,7 @@ import {
   unterstuetzenItems,
   unterstuetzenSubcategories,
 } from "@/content/unterstuetzen";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 export default function UnterstuetzenUebersicht() {
   const [activeFilter, setActiveFilter] = useState("alle");
@@ -431,7 +432,7 @@ export default function UnterstuetzenUebersicht() {
                         {item.title}
                       </h3>
                       <a
-                        href={item.pdfUrl}
+                        href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
                         target="_blank"
                         rel="noopener noreferrer"
                         aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/client/src/sections/GenesungInfografikenSection.tsx
+++ b/client/src/sections/GenesungInfografikenSection.tsx
@@ -16,6 +16,7 @@ import {
   genesungItems,
   type GenesungKategorie,
 } from "@/content/genesung";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 const genesungIcons = {
   alle: Filter,
@@ -100,7 +101,7 @@ export default function GenesungInfografikenSection() {
               </h3>
               <p className="text-muted-foreground text-sm mb-3">{item.desc}</p>
               <a
-                href={item.pdf}
+                href={getHandoutOpenHref(item.pdf) ?? item.pdf}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -17,6 +17,7 @@ import {
   kommSubcategories,
   type KommunikationsKategorie,
 } from "@/content/kommunizieren";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 function CategoryIcon({
   icon,
@@ -120,7 +121,7 @@ export default function KommunizierenMaterialsSection() {
                 {item.title}
               </h3>
               <a
-                href={item.pdfUrl}
+                href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/client/src/sections/MaterialienLibrarySection.tsx
+++ b/client/src/sections/MaterialienLibrarySection.tsx
@@ -18,13 +18,13 @@ import { Link } from "wouter";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
-  getMaterialDownloadHref,
   categoryMeta,
   materials,
   quickStarts,
   type MaterialCategory,
   type MaterialItem,
 } from "@/content/materialien";
+import { getHandoutDownloadHref, getHandoutOpenHref } from "@/content/handouts";
 
 function CategoryIcon({
   icon,
@@ -59,8 +59,11 @@ function MaterialCard({
   onPreview: (image: string, title: string) => void;
 }) {
   const previewSrc = item.isHtml ? (item.previewUrl ?? item.url) : item.url;
-  const openHref = item.downloadUrl ?? item.url;
-  const downloadHref = getMaterialDownloadHref(item);
+  const pdfSource = item.pdfUrl ?? item.downloadUrl;
+  const openHref = item.isHtml
+    ? (item.downloadUrl ?? item.url)
+    : (getHandoutOpenHref(pdfSource) ?? item.url);
+  const downloadHref = getHandoutDownloadHref(pdfSource);
 
   return (
     <Card className="h-full hover:shadow-lg transition-all hover:border-sage-mid/30 overflow-hidden">

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -15,6 +15,7 @@ import {
   selbstfuersorgeInfografiken,
   type SelbstfuersorgeKategorie,
 } from "@/content/selbstfuersorge";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 const selbstfuersorgeCategories = [
   {
@@ -117,7 +118,7 @@ export default function SelbstfuersorgeInfografikenSection() {
               </h3>
               <p className="text-xs text-muted-foreground mb-3">{item.desc}</p>
               <a
-                href={item.pdf}
+                href={getHandoutOpenHref(item.pdf) ?? item.pdf}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -8,6 +8,7 @@ import {
   verstehenInfografiken,
   type VerstehenMaterialCategory,
 } from "@/content/verstehen";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 const verstehenCategories = [
   {
@@ -114,7 +115,7 @@ export default function VerstehenInfografikenSection() {
                 {item.description}
               </p>
               <a
-                href={item.pdfUrl}
+                href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -8,6 +8,7 @@ import {
   verstehenInfografiken,
   type VerstehenMaterialCategory,
 } from "@/content/verstehen";
+import { getHandoutOpenHref } from "@/content/handouts";
 
 const verstehenCategories = [
   {
@@ -118,7 +119,7 @@ export default function VerstehenMaterialsSection() {
                 {item.description}
               </p>
               <a
-                href={item.pdfUrl}
+                href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}

--- a/netlify/functions/material-download.ts
+++ b/netlify/functions/material-download.ts
@@ -12,7 +12,11 @@ export default async (_req: Request, context: MaterialDownloadContext) => {
     return new Response("Material nicht gefunden.", { status: 404 });
   }
 
-  return createMaterialDownloadResponse(id);
+  const url = new URL(_req.url);
+  const disposition =
+    url.searchParams.get("disposition") === "inline" ? "inline" : "attachment";
+
+  return createMaterialDownloadResponse(id, disposition);
 };
 
 export const config = {

--- a/server/index.ts
+++ b/server/index.ts
@@ -34,7 +34,12 @@ async function startServer() {
   });
 
   app.get("/api/material-download/:id", async (req, res) => {
-    const response = await createMaterialDownloadResponse(req.params.id);
+    const disposition =
+      req.query.disposition === "inline" ? "inline" : "attachment";
+    const response = await createMaterialDownloadResponse(
+      req.params.id,
+      disposition
+    );
     await sendResponse(res, response);
   });
 

--- a/server/material-download.ts
+++ b/server/material-download.ts
@@ -1,7 +1,13 @@
-import { resolveMaterialDownload } from "../client/src/content/materialien";
+import {
+  resolveHandoutAsset,
+  type HandoutDisposition,
+} from "../client/src/content/handouts";
 
-export async function createMaterialDownloadResponse(id: string) {
-  const download = resolveMaterialDownload(id);
+export async function createMaterialDownloadResponse(
+  id: string,
+  disposition: HandoutDisposition = "attachment"
+) {
+  const download = resolveHandoutAsset(id);
   if (!download) {
     return new Response("Material nicht gefunden.", { status: 404 });
   }
@@ -28,7 +34,7 @@ export async function createMaterialDownloadResponse(id: string) {
     );
     headers.set(
       "Content-Disposition",
-      attachmentDisposition(download.fileName)
+      contentDisposition(download.fileName, disposition)
     );
     headers.set("X-Content-Type-Options", "nosniff");
 
@@ -46,7 +52,7 @@ export async function createMaterialDownloadResponse(id: string) {
   }
 }
 
-function attachmentDisposition(fileName: string) {
+function contentDisposition(fileName: string, disposition: HandoutDisposition) {
   const encodedName = encodeURIComponent(fileName);
-  return `attachment; filename="${fileName}"; filename*=UTF-8''${encodedName}`;
+  return `${disposition}; filename="${fileName}"; filename*=UTF-8''${encodedName}`;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -114,7 +114,14 @@ function vitePluginManusDebugCollector(): Plugin {
             return next();
           }
 
-          const response = await createMaterialDownloadResponse(id);
+          const disposition =
+            requestUrl.searchParams.get("disposition") === "inline"
+              ? "inline"
+              : "attachment";
+          const response = await createMaterialDownloadResponse(
+            id,
+            disposition
+          );
           const headers = Object.fromEntries(response.headers.entries());
           const body = Buffer.from(await response.arrayBuffer());
 


### PR DESCRIPTION
## Was sich geändert hat

- neue zentrale Handout-Registry in `client/src/content/handouts.ts`, die alle bekannten Remote-PDFs allowlist-basiert auflöst
- der bestehende `/api/material-download/:id`-Pfad unterstützt jetzt zwei Modi:
  - `attachment` für echte Downloads
  - `inline` für `PDF öffnen` im neuen Tab
- die Materialien-Bibliothek verwendet denselben Helfer jetzt konsistent für Öffnen und Herunterladen
- die Fachseiten und Sections mit bisherigen Direktlinks auf `files.manuscdn.com` öffnen Remote-PDFs jetzt ebenfalls same-origin über den Proxy
- neue Tests decken die Registry- und URL-Auflösung ab

## Warum das nötig war

Im PDF-/Handout-Audit zeigte sich ein klarer funktionaler Bruch:

- in der Materialien-Bibliothek war der Download-Flow bereits auf den Proxy umgestellt
- mehrere Fachseiten verlinkten dieselben Remote-PDFs aber weiterhin direkt cross-origin
- Manus liefert diese PDFs ohne `Content-Disposition: attachment`, daher öffneten sie im Browser direkt auf dem CDN statt über einen konsistenten Website-Flow

Damit hing das Verhalten stark davon ab, wo Nutzerinnen und Nutzer das gleiche Handout anklicken.

## Wirkung

- `PDF öffnen` tut nun überall zuverlässig das, was das Label verspricht
- `Herunterladen` bleibt ein echter Attachment-Flow
- Remote-Handouts laufen nicht mehr gemischt über direkte CDN-Links und Website-Links
- die Handout-Auslieferung ist zentraler, überprüfbarer und für spätere Erweiterungen besser wartbar

## Nicht Teil dieses PRs

- die inhaltliche/A11y-Schwäche mehrerer bildbasierter PDF-Handouts ohne Textlayer
- mögliche inhaltliche oder gestalterische Überarbeitungen einzelner Handouts

## Validierung

- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`