### PR TITLE
[codex] Audit PDF handout text layer gaps

### DIFF
--- a/qa/audit-pdf-handouts.md
+++ b/qa/audit-pdf-handouts.md
@@ -1,0 +1,123 @@
+# Audit: PDF-Handouts
+
+## Meta
+
+- Repo: `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige`
+- Branch: `codex/audit-pdf-handouts`
+- Fokus: PDF-Handouts inhaltlich, layoutbezogen und funktional einordnen
+- Methode:
+  - technische Textlayer-Prüfung mit `pypdf`
+  - visuelle Stichprobe über die 6 priorisierten Core-Handouts
+  - Vergleich mit den 2 lokalen Notfall-PDFs
+- Reproduzierbar über: [`qa/scripts/scan-pdf-handouts.py`](./scripts/scan-pdf-handouts.py)
+  - für den Lauf ist eine Python-Umgebung mit `pypdf` nötig
+
+## Kurzfazit
+
+- Die beiden lokalen Notfall-PDFs sind technisch in deutlich besserem Zustand:
+  - `Notfallkarte-Zuerich-Psychische-Krise.pdf`: 1 Seite, `2633` extrahierbare Zeichen
+  - `notfallplan-krise-v03.pdf`: 2 Seiten, `4577` extrahierbare Zeichen
+- Die eigentliche Handout-Bibliothek hat dagegen ein systemisches A11y-Problem:
+  - `39` von `39` Remote-PDFs von `files.manuscdn.com` liefern `0` extrahierbare Zeichen
+  - damit sind sie für Screenreader, Copy/Paste, Browser-Suche und Suchindex praktisch blind
+- Der bereits gemergte Proxy-Fix löst die Zustellung sauber, aber nicht die Zugänglichkeit des Inhalts.
+
+## Inventar
+
+| Bereich                            | Anzahl | Textlayer-Status       | Bemerkung                        |
+| ---------------------------------- | -----: | ---------------------- | -------------------------------- |
+| Lokale PDFs im Repo                |      2 | vorhanden              | Notfall-PDFs bereits textbasiert |
+| Remote-PDFs (`files.manuscdn.com`) |     39 | `39/39` ohne Textlayer | systemisches Problem             |
+| Priorisierte Core-Remote-Handouts  |      6 | `6/6` ohne Textlayer   | höchste Umsetzungspriorität      |
+
+## Priorisierte Core-Handouts
+
+| ID                    | Titel                                                   | Kategorie      | Seiten | Grösse | Text extrahierbar | Einordnung                                      |
+| --------------------- | ------------------------------------------------------- | -------------- | -----: | -----: | ----------------: | ----------------------------------------------- |
+| `leuchtturm`          | Der Leuchtturm – Ihre Rolle als Angehörige/r            | verstehen      |      1 | 1.0 MB |                 0 | Core-Psychoedukation, zentrale Angehörigenrolle |
+| `eisberg`             | Der Eisberg – Wut ist oft die Spitze                    | verstehen      |      1 | 5.0 MB |                 0 | zentrale Emotions- und Konflikteinordnung       |
+| `rolle-klaeren`       | Ihre Rolle klären – Was Sie sein können (und was nicht) | unterstützen   |      1 | 6.0 MB |                 0 | wichtig für Grenz- und Rollenklärung            |
+| `krisenkommunikation` | Spickzettel Krisenkommunikation (A4)                    | kommunizieren  |      1 | 5.6 MB |                 0 | akute Formulierungshilfe, hoch praxisrelevant   |
+| `grenzen-spickzettel` | Spickzettel Grenzen – Die wichtigsten Sätze             | grenzen        |      1 | 5.2 MB |                 0 | konkrete Satzbausteine, hoher Copy/Paste-Bedarf |
+| `warnsignale`         | Warnsignale der Überlastung                             | selbstfürsorge |      1 | 5.2 MB |                 0 | stark alltagsbezogen, wichtig für Selbstschutz  |
+
+## Inhaltliche und visuelle Beobachtungen
+
+Die 6 Core-Handouts wirken gestalterisch konsistent und sorgfältig aufgebaut:
+
+- einheitliches A4-Hochformat mit klarer Titelzone, Farbcodierung und Footer
+- starke visuelle Metaphern wie Leuchtturm, Eisberg oder Warnsignale
+- strukturierte Infoboxen, Legenden und 3- bis 5-Schritte-Logik
+- hohe Praxisnähe: Formulierungshilfen, Einordnungshilfen, Krisen- und Rollenklärung
+
+Gerade diese Stärken verschärfen aber das A11y-Problem:
+
+- der fachliche Nutzen steckt sichtbar in Textblöcken, Kästen und Schrittlisten
+- Nutzerinnen und Nutzer können diese Inhalte weder zuverlässig vorlesen lassen noch markieren, durchsuchen oder übernehmen
+- besonders die beiden Spickzettel sind funktional darauf angelegt, einzelne Sätze nachzuschlagen oder zu kopieren, was im aktuellen PDF-Format technisch nicht gelingt
+
+## Funktionale Auswirkungen
+
+### Für Nutzerinnen und Nutzer
+
+- Screenreader erhalten bei den Remote-Handouts keinen verwertbaren Inhalt.
+- Browser-Suche innerhalb des PDFs funktioniert nicht.
+- Copy/Paste einzelner Formulierungen funktioniert nicht.
+- Mobile Nutzung bleibt mühsam, weil kleine Textflächen nur als Bild gezoomt werden können.
+
+### Für die Website
+
+- Die Suche kann den eigentlichen PDF-Inhalt nicht indexieren.
+- Der Inhalt der Handouts ist im aktuellen Webauftritt nur über Titel und Kurzbeschreibung auffindbar.
+- Der PDF-Proxy macht das Öffnen und Herunterladen konsistent, aber nicht barrierefrei.
+
+## Vergleich zu den lokalen Notfall-PDFs
+
+Die beiden lokalen Notfall-Dokumente sind der richtige technische Referenzpunkt:
+
+- sie enthalten extrahierbaren Text
+- sie sind damit deutlich besser für Screenreader, Suche und Weiterverarbeitung geeignet
+- das Hauptproblem liegt also nicht bei PDF als Format an sich, sondern bei der Art, wie die 39 Remote-Handouts erzeugt wurden
+
+## Priorisierung
+
+### P1 – zuerst umsetzen
+
+Für die 6 Core-Remote-Handouts sollte je ein zugängliches Text-Pendant entstehen.
+
+Empfohlene Form:
+
+1. eigene HTML-/Textversion pro Handout
+2. PDF bleibt zusätzlich als Druck- und Downloadformat bestehen
+3. von Materialkarten und Themen-Sections aus sowohl auf `PDF öffnen` als auch auf `Textversion` verlinken
+
+### P2 – danach
+
+- die restlichen `33` Remote-Handouts nach derselben Logik nachziehen
+- erst die fachlich wichtigsten Übersichts- und Spickzettel, dann sekundäre Vertiefungsblätter
+
+## Umsetzungsempfehlung
+
+Die sinnvollste Reihenfolge ist:
+
+1. die 6 Core-Handouts als HTML-/Textversionen nachbauen
+2. dafür nicht OCR-Rohtext ungeprüft ausliefern, sondern redaktionell saubere Pendants erzeugen
+3. PDFs weiterhin für Druck und Original-Layout behalten
+4. Suchindex und Materialkarten später um die Textversionen erweitern
+
+## Nächster konkreter Schritt
+
+Ein kleines, sauberes Folgepaket wäre:
+
+1. Inhaltsstruktur für die 6 Core-Handouts als textbasierte Datenmodelle erfassen
+2. erste 1 bis 2 Handouts als Referenz-HTML umsetzen
+3. CTA-Muster festlegen:
+   - `Textversion lesen`
+   - `PDF öffnen`
+   - `PDF herunterladen`
+
+## Grenze dieses Audits
+
+- Die visuelle Inhaltsprüfung basiert auf den Vorschauen der 6 Core-Handouts.
+- Es wurde bewusst keine automatisierte OCR als Quelltext-Ersatz in Produktcode übernommen.
+- Für die eigentliche Umsetzung braucht es deshalb eine redaktionell saubere Übertragung der Inhalte in HTML oder strukturierte Daten.

--- a/qa/scripts/scan-pdf-handouts.py
+++ b/qa/scripts/scan-pdf-handouts.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+import urllib.request
+from pathlib import Path
+
+try:
+    from pypdf import PdfReader
+except ModuleNotFoundError as exc:  # pragma: no cover - user-facing guard
+    raise SystemExit(
+        "Missing dependency 'pypdf'. Run this script with the bundled Codex "
+        "workspace Python or install pypdf in your current environment."
+    ) from exc
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTENT_DIR = REPO_ROOT / "client" / "src" / "content"
+MATERIALS_FILE = CONTENT_DIR / "materialien.ts"
+LOCAL_PDFS = [
+    REPO_ROOT / "client" / "public" / "Notfallkarte-Zuerich-Psychische-Krise.pdf",
+    REPO_ROOT / "client" / "public" / "notfallplan-krise-v03.pdf",
+]
+REMOTE_PDF_RE = re.compile(r'https://files\.manuscdn\.com[^"\']+\.pdf')
+
+
+def decode_ts_string(value: str) -> str:
+    if "\\" in value:
+        return bytes(value, "utf-8").decode("unicode_escape")
+    return value
+
+
+def analyze_pdf(path: Path) -> dict[str, object]:
+    reader = PdfReader(str(path))
+    page_text_lengths: list[int] = []
+    sample_parts: list[str] = []
+
+    for page in reader.pages:
+        try:
+            text = (page.extract_text() or "").strip()
+        except Exception:
+            text = ""
+
+        page_text_lengths.append(len(text))
+        if text and len(sample_parts) < 2:
+            sample_parts.append(" ".join(text.split())[:240])
+
+    return {
+        "path": str(path),
+        "pages": len(reader.pages),
+        "bytes": path.stat().st_size,
+        "text_chars_total": sum(page_text_lengths),
+        "text_chars_by_page": page_text_lengths,
+        "sample": sample_parts,
+    }
+
+
+def parse_material_entries() -> list[dict[str, object]]:
+    text = MATERIALS_FILE.read_text()
+    entries = re.findall(r"\{\n(.*?)\n  \},", text, re.S)
+    parsed: list[dict[str, object]] = []
+
+    for body in entries:
+        fields: dict[str, object] = {}
+        for key, value in re.findall(
+            r'\s*(\w+):\s*("(?:[^"\\]|\\.)*"|true|false),?', body
+        ):
+            if value in {"true", "false"}:
+                fields[key] = value == "true"
+            else:
+                fields[key] = decode_ts_string(value[1:-1])
+        parsed.append(fields)
+
+    return parsed
+
+
+def collect_remote_pdfs() -> list[str]:
+    seen: list[str] = []
+    for path in sorted(CONTENT_DIR.glob("*.ts")):
+        text = path.read_text()
+        for url in REMOTE_PDF_RE.findall(text):
+            if url not in seen:
+                seen.append(url)
+    return seen
+
+
+def build_title_map() -> dict[str, str]:
+    title_map: dict[str, str] = {}
+    for path in sorted(CONTENT_DIR.glob("*.ts")):
+        text = path.read_text()
+
+        for pattern in (
+            r'title:\s*"([^"]+)"[\s\S]*?downloadUrl:\s*"(https://files\.manuscdn\.com[^"]+\.pdf)"',
+            r'title:\s*"([^"]+)"[\s\S]*?pdfUrl:\s*"(https://files\.manuscdn\.com[^"]+\.pdf)"',
+            r'title:\s*"([^"]+)"[\s\S]*?pdf:\s*"(https://files\.manuscdn\.com[^"]+\.pdf)"',
+        ):
+            for title, url in re.findall(pattern, text):
+                title_map.setdefault(url, decode_ts_string(title))
+
+    return title_map
+
+
+def main() -> None:
+    materials = parse_material_entries()
+    remote_urls = collect_remote_pdfs()
+    title_map = build_title_map()
+
+    core_remote = [
+        item
+        for item in materials
+        if item.get("priority") == "core"
+        and isinstance(item.get("title"), str)
+        and isinstance(item.get("id"), str)
+        and (
+            str(item.get("pdfUrl", "")).startswith("https://")
+            or str(item.get("downloadUrl", "")).startswith("https://")
+        )
+    ]
+
+    report: dict[str, object] = {
+        "repo_root": str(REPO_ROOT),
+        "local_pdfs": [],
+        "remote_summary": {},
+        "core_remote_handouts": [],
+    }
+
+    for path in LOCAL_PDFS:
+        analysis = analyze_pdf(path)
+        analysis["label"] = path.name
+        cast_list = report["local_pdfs"]
+        assert isinstance(cast_list, list)
+        cast_list.append(analysis)
+
+    with tempfile.TemporaryDirectory(prefix="pdf-handout-scan.") as tmpdir:
+        tmp = Path(tmpdir)
+        remote_results: list[dict[str, object]] = []
+
+        for url in remote_urls:
+            local_path = tmp / url.rsplit("/", 1)[-1]
+            urllib.request.urlretrieve(url, local_path)
+            analysis = analyze_pdf(local_path)
+            analysis["url"] = url
+            analysis["title"] = title_map.get(url)
+            remote_results.append(analysis)
+
+        zero_text = sum(1 for item in remote_results if item["text_chars_total"] == 0)
+        report["remote_summary"] = {
+            "total_remote_pdfs": len(remote_results),
+            "zero_text_remote_pdfs": zero_text,
+            "remote_pdfs_with_text": len(remote_results) - zero_text,
+        }
+
+        by_url = {item["url"]: item for item in remote_results}
+        core_results: list[dict[str, object]] = []
+        for item in core_remote:
+            url = str(item.get("pdfUrl") or item.get("downloadUrl"))
+            result = dict(by_url[url])
+            result["id"] = item["id"]
+            result["title"] = item["title"]
+            result["kind"] = item.get("kind")
+            result["category"] = item.get("category")
+            core_results.append(result)
+
+        report["core_remote_handouts"] = core_results
+
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Was sich ändert

Dieser PR ergänzt einen fokussierten Audit für die PDF-Handouts:

- Bericht unter `qa/audit-pdf-handouts.md`
- reproduzierbares Scan-Skript unter `qa/scripts/scan-pdf-handouts.py`

## Wichtigste Befunde

- Die 2 lokalen Notfall-PDFs enthalten extrahierbaren Text.
- Die 39 Remote-Handouts von `files.manuscdn.com` enthalten dagegen keinen extrahierbaren Textlayer.
- Die 6 priorisierten Core-Handouts sind damit zwar visuell nutzbar, aber für Screenreader, Suche und Copy/Paste technisch praktisch blind.

## Warum das wichtig ist

Der gemergte Proxy-Fix hat die Zustellung der PDFs sauber gemacht. Dieses Paket dokumentiert den nächsten getrennten Hauptpunkt: die eigentliche Inhalts- und A11y-Lücke der bildbasierten Handouts.

## Validierung

- `qa/scripts/scan-pdf-handouts.py` mit der gebündelten Workspace-Python-Runtime ausgeführt
- Bericht gegen den tatsächlichen Scanstand abgeglichen
