### PR TITLE
[codex] Add first handout text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  getHandoutTextVersion,
+  getHandoutTextVersionBySource,
+  getHandoutTextVersionHrefBySource,
+} from "@/content/handoutTextVersions";
+import { materials } from "@/content/materialien";
+
+describe("handout text versions", () => {
+  it("maps known remote handouts to text version routes", () => {
+    const leuchtturmPdf = materials.find(
+      item => item.id === "leuchtturm"
+    )?.downloadUrl;
+    const krisenPdf = materials.find(
+      item => item.id === "krisenkommunikation"
+    )?.downloadUrl;
+
+    expect(getHandoutTextVersion("leuchtturm")?.path).toBe(
+      "/materialien/text/leuchtturm"
+    );
+    expect(getHandoutTextVersion("krisenkommunikation")?.path).toBe(
+      "/materialien/text/krisenkommunikation"
+    );
+    expect(getHandoutTextVersionHrefBySource(leuchtturmPdf)).toBe(
+      "/materialien/text/leuchtturm"
+    );
+    expect(getHandoutTextVersionHrefBySource(krisenPdf)).toBe(
+      "/materialien/text/krisenkommunikation"
+    );
+    expect(getHandoutTextVersionBySource("/notfallplan-krise-v03.pdf")).toBe(
+      null
+    );
+  });
+});

--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -36,6 +36,14 @@ describe("MaterialienLibrarySection", () => {
     );
     expect(localDownloadLink).toHaveAttribute("download", "");
 
+    const textVersionLink = screen.getByRole("link", {
+      name: /Textversion lesen: Der Leuchtturm – Ihre Rolle als Angehörige\/r/i,
+    });
+    expect(textVersionLink).toHaveAttribute(
+      "href",
+      "/materialien/text/leuchtturm"
+    );
+
     fireEvent.click(screen.getByRole("button", { name: /Genesung\s*\(1\)/ }));
 
     expect(

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -112,6 +112,23 @@ describe("Smoke Tests – Kritische Seiten", () => {
     expect(screen.getAllByText(/Notfallkarte/i)[0]).toBeInTheDocument();
   });
 
+  it("HandoutTextPage: rendert Leuchtturm-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "leuchtturm" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Der Leuchtturm – Ihre Rolle als Angehörige\/r/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Sie können das Schiff nicht steuern/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zur Materialsammlung/i })
+    ).toHaveAttribute("href", "/materialien");
+  });
+
   it("NotFound: rendert 404-Seite", async () => {
     const { default: NotFound } = await import("@/pages/NotFound");
     withRouter(<NotFound />);

--- a/client/src/app/routes.ts
+++ b/client/src/app/routes.ts
@@ -24,6 +24,7 @@ const Grenzen = lazy(() => import("@/pages/Grenzen"));
 const Selbstfuersorge = lazy(() => import("@/pages/Selbstfuersorge"));
 const Soforthilfe = lazy(() => import("@/pages/Soforthilfe"));
 const Materialien = lazy(() => import("@/pages/Materialien"));
+const HandoutTextPage = lazy(() => import("@/pages/HandoutTextPage"));
 const SelbsttestPage = lazy(() => import("@/pages/SelbsttestPage"));
 const Impressum = lazy(() => import("@/pages/Impressum"));
 const Datenschutz = lazy(() => import("@/pages/Datenschutz"));
@@ -74,6 +75,7 @@ export const routes: AppRoute[] = [
   },
   { path: "/soforthilfe", component: Soforthilfe, requiresMotion: true },
   { path: "/notfall", redirectTo: "/soforthilfe" },
+  { path: "/materialien/text/:handoutId", component: HandoutTextPage },
   { path: "/materialien", component: Materialien, requiresMotion: true },
   { path: "/selbsttest", component: SelbsttestPage, requiresMotion: true },
   { path: "/impressum", component: Impressum, requiresMotion: true },

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -1,0 +1,277 @@
+import {
+  materials,
+  type MaterialCategory,
+  type MaterialItem,
+} from "./materialien";
+
+export interface HandoutTextCard {
+  title: string;
+  text: string;
+}
+
+export interface HandoutTextSection {
+  title: string;
+  intro?: string;
+  cards?: HandoutTextCard[];
+  bullets?: string[];
+  calloutTitle?: string;
+  calloutText?: string;
+}
+
+export interface HandoutTextVersion {
+  id: string;
+  path: string;
+  title: string;
+  description: string;
+  summary: string;
+  kicker: string;
+  topicLabel: string;
+  topicHref: string;
+  category: Exclude<MaterialCategory, "alle">;
+  kind: MaterialItem["kind"];
+  previewImageUrl: string;
+  pdfSourceUrl: string;
+  intro: string[];
+  sections: HandoutTextSection[];
+  sourceLine: string;
+  standLine: string;
+}
+
+const TOPIC_META: Record<
+  Exclude<MaterialCategory, "alle">,
+  { label: string; href: string }
+> = {
+  verstehen: { label: "Verstehen", href: "/verstehen" },
+  unterstuetzen: { label: "Unterstützen", href: "/unterstuetzen/uebersicht" },
+  kommunizieren: { label: "Kommunizieren", href: "/kommunizieren" },
+  grenzen: { label: "Grenzen", href: "/grenzen" },
+  selbstfuersorge: { label: "Selbstfürsorge", href: "/selbstfuersorge" },
+  genesung: { label: "Genesung", href: "/genesung" },
+  soforthilfe: { label: "Soforthilfe", href: "/soforthilfe" },
+};
+
+function requireMaterial(id: string) {
+  const material = materials.find(item => item.id === id);
+  if (!material) {
+    throw new Error(`Unknown material item: ${id}`);
+  }
+
+  const pdfSourceUrl = material.pdfUrl ?? material.downloadUrl;
+  if (!pdfSourceUrl) {
+    throw new Error(`Material item is missing a PDF source: ${id}`);
+  }
+
+  return {
+    material,
+    topic: TOPIC_META[material.category],
+    pdfSourceUrl,
+  };
+}
+
+function createHandoutTextVersion(
+  id: string,
+  config: Omit<
+    HandoutTextVersion,
+    | "id"
+    | "path"
+    | "title"
+    | "description"
+    | "topicLabel"
+    | "topicHref"
+    | "category"
+    | "kind"
+    | "previewImageUrl"
+    | "pdfSourceUrl"
+  >
+): HandoutTextVersion {
+  const { material, topic, pdfSourceUrl } = requireMaterial(id);
+
+  return {
+    id,
+    path: `/materialien/text/${id}`,
+    title: material.title,
+    description: material.description,
+    topicLabel: topic.label,
+    topicHref: topic.href,
+    category: material.category,
+    kind: material.kind,
+    previewImageUrl: material.url,
+    pdfSourceUrl,
+    ...config,
+  };
+}
+
+export const handoutTextVersions: HandoutTextVersion[] = [
+  createHandoutTextVersion("leuchtturm", {
+    kicker: "Textversion",
+    summary:
+      "Sie können die Krise nicht steuern, aber Sie können als Angehörige oder Angehöriger Orientierung geben: ruhig, klar und verlässlich.",
+    intro: [
+      "Diese Seite überträgt die Inhalte des Handouts «Der Leuchtturm» in eine lesbare Web-Version. Sie ist als barriereärmere Ergänzung zur gestalteten PDF-Fassung gedacht.",
+      "Die Grafik stellt nicht die Gefühle der betroffenen Person in den Mittelpunkt, sondern Ihre Haltung als Angehörige oder Angehöriger: Zustände wechseln, Ihre Orientierung darf stabil bleiben.",
+    ],
+    sections: [
+      {
+        title: "Die Bildidee",
+        intro:
+          "Das Handout arbeitet mit einer einfachen Metapher: Krise und Alltag wechseln sich ab, der Leuchtturm bleibt trotzdem stehen.",
+        cards: [
+          {
+            title: "Sturm",
+            text: "Krise oder Überflutung: intensive Gefühle, hohe Anspannung, wenig Übersicht.",
+          },
+          {
+            title: "Ruhe",
+            text: "Stabilität oder Alltag: mehr Kontaktfähigkeit, mehr Orientierung, mehr Spielraum.",
+          },
+          {
+            title: "Übergang",
+            text: "Krisen kommen und Krisen gehen. Der Pfeil steht für diesen Wechsel zwischen Zuständen.",
+          },
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Was der Leuchtturm meint",
+        calloutText:
+          "Sie können das Schiff nicht steuern – aber Sie können Orientierung geben: ruhig, klar, verlässlich.",
+      },
+      {
+        title: "3 Schritte",
+        cards: [
+          {
+            title: "1. Stabilität wahren",
+            text: "Bewahren Sie innere Ruhe. Lassen Sie sich nicht mitreissen.",
+          },
+          {
+            title: "2. Orientierung geben",
+            text: "Seien Sie ein verlässlicher Ankerpunkt.",
+          },
+          {
+            title: "3. Verlässlich bleiben",
+            text: "Seien Sie beständig da, unabhängig vom Zustand.",
+          },
+        ],
+      },
+      {
+        title: "Legende der Grafik",
+        cards: [
+          {
+            title: "Leuchtturm",
+            text: "Der Leuchtturm steht für Ihre Haltung: stabil, ruhig und klar.",
+          },
+          {
+            title: "Sturm und Ruhe",
+            text: "Die Zustände wechseln. Sie sind wichtig, aber sie definieren nicht alles.",
+          },
+          {
+            title: "Pfeile",
+            text: "Die Pfeile markieren den Übergang: Krisen sind nicht statisch, und auch Ruhe ist nicht für immer gesichert.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Nach Kreger (2014), Angehörigen-Psychoedukation.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("krisenkommunikation", {
+    kicker: "Textversion",
+    summary:
+      "Wenn Gespräche kippen, helfen Verbindung, kurze Orientierung und eine klare Grenze oft mehr als langes Argumentieren.",
+    intro: [
+      "Diese Seite überträgt den «Spickzettel Krisenkommunikation» in eine such- und kopierbare Textfassung. Die Struktur bleibt nah am A4-Original, ist aber für das Lesen am Bildschirm aufbereitet.",
+      "Die Grundidee ist bewusst knapp gehalten: zuerst Verbindung herstellen, dann Kontakt halten, dann Grenze und nächsten Schritt benennen.",
+    ],
+    sections: [
+      {
+        title: "1. Die 3 Schritte",
+        cards: [
+          {
+            title: "Verbinden",
+            text: "«Ich sehe, dass du gerade sehr aufgebracht bist.»",
+          },
+          {
+            title: "Kontakt",
+            text: "«Das klingt belastend. Ich bin hier.»",
+          },
+          {
+            title: "Grenze + Plan",
+            text: "«So kann ich nicht weiterreden. Pause 10 Min, dann weiter.»",
+          },
+        ],
+      },
+      {
+        title: "2. Der Standardsatz",
+        calloutTitle: "Standardsatz",
+        calloutText:
+          "Ich sehe, dass du gerade sehr angespannt bist. Und gleichzeitig gilt: So reden wir nicht. Pause 10 Minuten, dann weiter.",
+      },
+      {
+        title: "3. Grenzen setzen",
+        intro:
+          "Die Grafik verdichtet Grenzsetzung auf drei Bausteine: erst benennen, was gerade passiert, dann Ihre Grenze, dann den nächsten Schritt.",
+        cards: [
+          {
+            title: "Fakt",
+            text: "Beschreiben Sie kurz und sachlich, was gerade geschieht, statt in Motive oder Gegenangriffe einzusteigen.",
+          },
+          {
+            title: "Ich-Grenze",
+            text: "Sagen Sie klar, was so für Sie nicht geht oder wo Sie das Gespräch unterbrechen müssen.",
+          },
+          {
+            title: "Nächster Schritt",
+            text: "Formulieren Sie, wie es konkret weitergeht: Pause, Uhrzeit oder nächster Kontaktpunkt.",
+          },
+        ],
+      },
+      {
+        title: "4. Exit-Sätze",
+        calloutTitle: "Exit-Sätze",
+        calloutText:
+          "Ich gehe nicht weg, ich mache nur eine Pause. Wir sprechen um [Uhrzeit] weiter. Ich bin wieder da.",
+      },
+      {
+        title: "5. Notfallnummern",
+        bullets: [
+          "Dargebotene Hand 143",
+          "Pro Mente Sana 0848 800 858",
+          "Notfall PUK Zürich 044 384 21 11",
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Mason/Kreger (2014); Linehan (1993).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+];
+
+const handoutTextVersionsById = new Map(
+  handoutTextVersions.map(version => [version.id, version])
+);
+const handoutTextVersionsBySource = new Map(
+  handoutTextVersions.map(version => [version.pdfSourceUrl, version])
+);
+
+export function getHandoutTextVersion(id: string | undefined) {
+  if (!id) {
+    return null;
+  }
+
+  return handoutTextVersionsById.get(id) ?? null;
+}
+
+export function getHandoutTextVersionBySource(sourceUrl: string | undefined) {
+  if (!sourceUrl) {
+    return null;
+  }
+
+  return handoutTextVersionsBySource.get(sourceUrl) ?? null;
+}
+
+export function getHandoutTextVersionHrefBySource(
+  sourceUrl: string | undefined
+) {
+  return getHandoutTextVersionBySource(sourceUrl)?.path ?? null;
+}

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -409,6 +409,23 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Der Leuchtturm",
+    description:
+      "Lesbare Web-Version des Handouts zur Angehörigenrolle mit Kernaussage, Bildidee und 3 Schritten",
+    keywords: [
+      "textversion",
+      "leuchtturm",
+      "rolle",
+      "angehörige",
+      "stabilität",
+      "orientierung",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/leuchtturm",
+    section: "Materialien",
+  },
+  {
     title: "Der Eisberg: Was hinter Wut liegen kann",
     description:
       "Infografik: Hinter sichtbarer Wut liegen oft Schmerz, Angst oder Scham",
@@ -519,6 +536,23 @@ export const searchableContent: SearchEntry[] = [
       "infografik",
     ],
     href: "/materialien",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Spickzettel Krisenkommunikation",
+    description:
+      "Lesbare Web-Version mit 3 Schritten, Standardsatz, Exit-Sätzen und Notfallnummern",
+    keywords: [
+      "textversion",
+      "krisenkommunikation",
+      "spickzettel",
+      "standardsatz",
+      "exit-sätze",
+      "grenze",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/krisenkommunikation",
     section: "Materialien",
   },
 

--- a/client/src/pages/Barrierefreiheit.tsx
+++ b/client/src/pages/Barrierefreiheit.tsx
@@ -23,7 +23,7 @@ const conformanceItems = [
 ];
 
 const knownLimitations = [
-  "PDF-Downloads sind derzeit nicht vollständig barrierefrei aufbereitet",
+  "Viele ältere PDF-Handouts sind noch nicht vollständig barrierefrei aufbereitet; für erste Kernmaterialien stehen bereits lesbare Textversionen zur Verfügung",
   "Einzelne interaktive Übungen (Übungsszenarien) können mit Screenreadern eingeschränkt nutzbar sein",
 ];
 

--- a/client/src/pages/HandoutTextPage.tsx
+++ b/client/src/pages/HandoutTextPage.tsx
@@ -1,0 +1,228 @@
+import Layout from "@/components/Layout";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
+import { getHandoutDownloadHref, getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersion } from "@/content/handoutTextVersions";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import NotFound from "@/pages/NotFound";
+import type { RouteComponentProps } from "wouter";
+import { Link } from "wouter";
+import {
+  ArrowLeft,
+  BookOpen,
+  Download,
+  ExternalLink,
+  FileText,
+  Library,
+} from "lucide-react";
+
+type HandoutTextPageParams = {
+  handoutId?: string;
+};
+
+export default function HandoutTextPage({
+  params,
+}: RouteComponentProps<HandoutTextPageParams>) {
+  const handout = getHandoutTextVersion(params?.handoutId);
+
+  if (!handout) {
+    return <NotFound />;
+  }
+
+  const openHref =
+    getHandoutOpenHref(handout.pdfSourceUrl) ?? handout.pdfSourceUrl;
+  const downloadHref =
+    getHandoutDownloadHref(handout.pdfSourceUrl) ?? handout.pdfSourceUrl;
+
+  return (
+    <Layout>
+      <SEO
+        title={`${handout.title} – Textversion`}
+        description={`${handout.description} Diese Seite bietet eine lesbare Textversion des Handouts.`}
+        path={handout.path}
+      />
+      <MedicalPageSchema
+        title={`${handout.title} – Textversion`}
+        description={handout.summary}
+        path={handout.path}
+      />
+
+      <section className="py-12 md:py-16 bg-gradient-to-b from-sage-wash/50 via-background to-background">
+        <div className="container">
+          <div className="max-w-6xl mx-auto grid gap-8 lg:grid-cols-[1.25fr_0.95fr] items-start">
+            <div>
+              <div className="flex flex-wrap items-center gap-3 mb-4">
+                <span className="inline-flex items-center rounded-full bg-sage-dark px-4 py-1.5 text-sm font-medium text-white">
+                  {handout.kicker}
+                </span>
+                <span className="inline-flex items-center gap-2 rounded-full border border-border bg-white/90 px-4 py-1.5 text-sm text-muted-foreground">
+                  <Library className="w-4 h-4 text-sage-dark" />
+                  {handout.topicLabel}
+                </span>
+                <span className="inline-flex items-center gap-2 rounded-full border border-border bg-white/90 px-4 py-1.5 text-sm text-muted-foreground">
+                  <FileText className="w-4 h-4 text-sage-dark" />
+                  {handout.kind}
+                </span>
+              </div>
+
+              <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground leading-tight mb-5">
+                {handout.title}
+              </h1>
+
+              <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-6 max-w-3xl">
+                {handout.summary}
+              </p>
+
+              <div className="flex flex-wrap gap-3 mb-5">
+                <Button
+                  asChild
+                  className="bg-sage-dark hover:bg-sage-mid text-white"
+                >
+                  <a href={openHref} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="w-4 h-4" />
+                    PDF öffnen
+                  </a>
+                </Button>
+                <Button asChild variant="outline">
+                  <a href={downloadHref} download="">
+                    <Download className="w-4 h-4" />
+                    PDF herunterladen
+                  </a>
+                </Button>
+                <Button asChild variant="outline">
+                  <Link href="/materialien">
+                    <ArrowLeft className="w-4 h-4" />
+                    Zur Materialsammlung
+                  </Link>
+                </Button>
+              </div>
+
+              <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
+                <Link
+                  href={handout.topicHref}
+                  className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
+                >
+                  <BookOpen className="w-4 h-4 text-sage-dark" />
+                  Zum Themenbereich {handout.topicLabel}
+                </Link>
+                <Link
+                  href="/barrierefreiheit"
+                  className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
+                >
+                  <FileText className="w-4 h-4 text-sage-dark" />
+                  Warum diese Textversion hilfreich ist
+                </Link>
+              </div>
+            </div>
+
+            <Card className="overflow-hidden border-border/60 bg-white/90 shadow-sm">
+              <img
+                src={handout.previewImageUrl}
+                alt={`Vorschau des Handouts ${handout.title}`}
+                className="w-full h-auto object-cover object-top"
+                loading="eager"
+                width={720}
+                height={900}
+                decoding="async"
+              />
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-8">
+        <div className="container">
+          <div className="max-w-6xl mx-auto">
+            <Card className="border-sage-light bg-sage-wash/70">
+              <CardContent className="p-6">
+                <h2 className="text-lg font-semibold text-foreground mb-3">
+                  Lesbare Web-Version statt bildbasiertem PDF
+                </h2>
+                <div className="space-y-3 text-muted-foreground leading-relaxed">
+                  {handout.intro.map(text => (
+                    <p key={text}>{text}</p>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="pb-14 md:pb-16">
+        <div className="container">
+          <div className="max-w-6xl mx-auto grid gap-6">
+            {handout.sections.map(section => (
+              <Card key={section.title} className="border-border/60 shadow-sm">
+                <CardContent className="p-6 md:p-7">
+                  <h2 className="text-2xl font-semibold text-foreground mb-3">
+                    {section.title}
+                  </h2>
+
+                  {section.intro ? (
+                    <p className="text-muted-foreground leading-relaxed mb-5">
+                      {section.intro}
+                    </p>
+                  ) : null}
+
+                  {section.calloutTitle && section.calloutText ? (
+                    <div className="rounded-xl border border-sage-light/80 bg-sage-wash/50 p-5 mb-5">
+                      <h3 className="font-semibold text-foreground mb-2">
+                        {section.calloutTitle}
+                      </h3>
+                      <p className="text-base leading-relaxed text-foreground">
+                        {section.calloutText}
+                      </p>
+                    </div>
+                  ) : null}
+
+                  {section.cards?.length ? (
+                    <div className="grid gap-4 md:grid-cols-3">
+                      {section.cards.map(card => (
+                        <div
+                          key={`${section.title}-${card.title}`}
+                          className="rounded-xl border border-border/60 bg-background p-5"
+                        >
+                          <h3 className="font-semibold text-foreground mb-2">
+                            {card.title}
+                          </h3>
+                          <p className="text-sm leading-relaxed text-muted-foreground">
+                            {card.text}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  ) : null}
+
+                  {section.bullets?.length ? (
+                    <ul className="grid gap-3">
+                      {section.bullets.map(item => (
+                        <li
+                          key={item}
+                          className="rounded-xl border border-border/60 bg-background px-4 py-3 text-sm text-muted-foreground"
+                        >
+                          {item}
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </CardContent>
+              </Card>
+            ))}
+
+            <Card className="border-border/60 bg-muted/20">
+              <CardContent className="p-6">
+                <p className="text-sm text-muted-foreground mb-2">
+                  {handout.sourceLine}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {handout.standLine}
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+    </Layout>
+  );
+}

--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -3,6 +3,7 @@ import {
   Download,
   ExternalLink,
   Eye,
+  FileText,
   Filter,
   Heart,
   MessageCircle,
@@ -18,6 +19,7 @@ import {
   type KommunikationsKategorie,
 } from "@/content/kommunizieren";
 import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 function CategoryIcon({
   icon,
@@ -57,8 +59,9 @@ export default function KommunizierenMaterialsSection() {
       <p className="text-sm text-muted-foreground mb-4 flex items-center gap-2">
         <Eye className="w-4 h-4 flex-shrink-0" />
         <span>
-          <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF
-          öffnen» öffnet die A4-Druckversion im neuen Tab.
+          <strong className="text-foreground">Vorschau = Web-Bild.</strong> Wenn
+          verfügbar, führt «Textversion» zur lesbaren Web-Version. «PDF öffnen»
+          öffnet die A4-Druckversion im neuen Tab.
         </span>
       </p>
 
@@ -98,41 +101,61 @@ export default function KommunizierenMaterialsSection() {
       </div>
 
       <div ref={gridRef} className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-        {filteredItems.map((item, index) => (
-          <Card
-            key={item.title}
-            className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
-              filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""
-            }`}
-          >
-            <div className="aspect-[4/3] bg-muted">
-              <img
-                src={item.url}
-                alt={item.title}
-                className="w-full h-full object-cover object-top"
-                loading="lazy"
-                width={400}
-                height={223}
-                decoding="async"
-              />
-            </div>
-            <CardContent className="p-4">
-              <h3 className="font-medium text-foreground text-sm mb-2">
-                {item.title}
-              </h3>
-              <a
-                href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+        {filteredItems.map((item, index) =>
+          (() => {
+            const textVersionHref = getHandoutTextVersionHrefBySource(
+              item.pdfUrl
+            );
+
+            return (
+              <Card
+                key={item.title}
+                className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
+                  filteredItems.length > 1 && index === 0 ? "sm:col-span-2" : ""
+                }`}
               >
-                <ExternalLink className="w-4 h-4" />
-                PDF öffnen
-              </a>
-            </CardContent>
-          </Card>
-        ))}
+                <div className="aspect-[4/3] bg-muted">
+                  <img
+                    src={item.url}
+                    alt={item.title}
+                    className="w-full h-full object-cover object-top"
+                    loading="lazy"
+                    width={400}
+                    height={223}
+                    decoding="async"
+                  />
+                </div>
+                <CardContent className="p-4">
+                  <h3 className="font-medium text-foreground text-sm mb-2">
+                    {item.title}
+                  </h3>
+                  <div className="grid gap-2">
+                    {textVersionHref ? (
+                      <Link
+                        href={textVersionHref}
+                        aria-label={`Textversion lesen: ${item.title}`}
+                        className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-terracotta-mid hover:bg-terracotta-dark text-white transition-colors"
+                      >
+                        <FileText className="w-4 h-4" />
+                        Textversion
+                      </Link>
+                    ) : null}
+                    <a
+                      href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                      className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                      PDF öffnen
+                    </a>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })()
+        )}
       </div>
 
       <div className="text-center">

--- a/client/src/sections/MaterialienLibrarySection.tsx
+++ b/client/src/sections/MaterialienLibrarySection.tsx
@@ -5,6 +5,7 @@ import {
   Download,
   ExternalLink,
   Eye,
+  FileText,
   Filter,
   Heart,
   Image as ImageIcon,
@@ -25,6 +26,7 @@ import {
   type MaterialItem,
 } from "@/content/materialien";
 import { getHandoutDownloadHref, getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 function CategoryIcon({
   icon,
@@ -64,6 +66,10 @@ function MaterialCard({
     ? (item.downloadUrl ?? item.url)
     : (getHandoutOpenHref(pdfSource) ?? item.url);
   const downloadHref = getHandoutDownloadHref(pdfSource);
+  const textVersionHref = item.isHtml
+    ? null
+    : getHandoutTextVersionHrefBySource(pdfSource);
+  const openLabel = item.isHtml ? "Öffnen" : "PDF öffnen";
 
   return (
     <Card className="h-full hover:shadow-lg transition-all hover:border-sage-mid/30 overflow-hidden">
@@ -98,15 +104,29 @@ function MaterialCard({
         </h3>
         <p className="text-sm text-muted-foreground mb-4">{item.description}</p>
         <div className="flex gap-2 flex-wrap">
+          {textVersionHref ? (
+            <Link
+              href={textVersionHref}
+              aria-label={`Textversion lesen: ${item.title}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-sage-dark hover:bg-sage-dark/90 text-white transition-colors"
+            >
+              <FileText className="w-4 h-4" />
+              Textversion lesen
+            </Link>
+          ) : null}
           <a
             href={openHref}
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${item.title} öffnen`}
-            className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 bg-sage-dark hover:bg-sage-dark/90 text-white transition-colors"
+            className={`inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 transition-colors ${
+              textVersionHref
+                ? "border border-sage-dark text-sage-dark hover:bg-sage-light/40"
+                : "bg-sage-dark hover:bg-sage-dark/90 text-white"
+            }`}
           >
             <ExternalLink className="w-4 h-4" />
-            Öffnen
+            {openLabel}
           </a>
           {downloadHref ? (
             <a
@@ -235,8 +255,9 @@ export default function MaterialienLibrarySection() {
                 <strong className="text-foreground">
                   Vorschau = Web-Bild.
                 </strong>{" "}
-                «Öffnen» öffnet die Druckversion im neuen Tab. Die Notfallkarte
-                öffnet als HTML-Seite.
+                Wenn verfügbar, führt «Textversion lesen» zur lesbaren
+                Web-Version. «PDF öffnen» öffnet die Druckversion im neuen Tab.
+                Die Notfallkarte öffnet als HTML-Seite.
               </p>
             </div>
 

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -1,7 +1,14 @@
 import { type CSSProperties, useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { Link } from "wouter";
-import { BookOpen, Brain, Download, ExternalLink, Filter } from "lucide-react";
+import {
+  BookOpen,
+  Brain,
+  Download,
+  ExternalLink,
+  FileText,
+  Filter,
+} from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
@@ -9,6 +16,7 @@ import {
   type VerstehenMaterialCategory,
 } from "@/content/verstehen";
 import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 const verstehenCategories = [
   {
@@ -58,8 +66,9 @@ export default function VerstehenInfografikenSection() {
       </h2>
 
       <p className="text-muted-foreground mb-6">
-        Vorschau = Web-Bild. «PDF öffnen» öffnet die A4-Druckversion im neuen
-        Tab – Download im PDF-Viewer oben rechts.
+        Vorschau = Web-Bild. Wenn verfügbar, führt «Textversion» zur lesbaren
+        Web-Version. «PDF öffnen» öffnet die A4-Druckversion im neuen Tab –
+        Download im PDF-Viewer oben rechts.
       </p>
 
       <div className="flex flex-wrap gap-2 mb-6">
@@ -86,47 +95,69 @@ export default function VerstehenInfografikenSection() {
       </div>
 
       <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {filteredItems.map(item => (
-          <Card
-            key={item.id}
-            className={`${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""} overflow-hidden hover:shadow-lg transition-shadow`}
-          >
-            <button
-              type="button"
-              className="aspect-[3/4] bg-muted cursor-pointer w-full"
-              onClick={() =>
-                window.open(item.webpUrl, "_blank", "noopener,noreferrer")
-              }
-              aria-label={`${item.alt} – Vorschau öffnen`}
-            >
-              <img
-                src={item.webpUrl}
-                alt={item.alt}
-                className="w-full h-full object-cover object-top"
-                loading="lazy"
-                width={400}
-                height={223}
-                decoding="async"
-              />
-            </button>
-            <CardContent className="p-4">
-              <h3 className="font-medium text-foreground mb-1">{item.title}</h3>
-              <p className="text-sm text-muted-foreground mb-3">
-                {item.description}
-              </p>
-              <a
-                href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+        {filteredItems.map(item =>
+          (() => {
+            const textVersionHref = getHandoutTextVersionHrefBySource(
+              item.pdfUrl
+            );
+
+            return (
+              <Card
+                key={item.id}
+                className={`${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""} overflow-hidden hover:shadow-lg transition-shadow`}
               >
-                <ExternalLink className="w-4 h-4" />
-                PDF öffnen
-              </a>
-            </CardContent>
-          </Card>
-        ))}
+                <button
+                  type="button"
+                  className="aspect-[3/4] bg-muted cursor-pointer w-full"
+                  onClick={() =>
+                    window.open(item.webpUrl, "_blank", "noopener,noreferrer")
+                  }
+                  aria-label={`${item.alt} – Vorschau öffnen`}
+                >
+                  <img
+                    src={item.webpUrl}
+                    alt={item.alt}
+                    className="w-full h-full object-cover object-top"
+                    loading="lazy"
+                    width={400}
+                    height={223}
+                    decoding="async"
+                  />
+                </button>
+                <CardContent className="p-4">
+                  <h3 className="font-medium text-foreground mb-1">
+                    {item.title}
+                  </h3>
+                  <p className="text-sm text-muted-foreground mb-3">
+                    {item.description}
+                  </p>
+                  <div className="grid gap-2">
+                    {textVersionHref ? (
+                      <Link
+                        href={textVersionHref}
+                        aria-label={`Textversion lesen: ${item.title}`}
+                        className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-sage-dark hover:bg-sage-mid text-white transition-colors"
+                      >
+                        <FileText className="w-4 h-4" />
+                        Textversion
+                      </Link>
+                    ) : null}
+                    <a
+                      href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                      className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                    >
+                      <ExternalLink className="w-4 h-4" />
+                      PDF öffnen
+                    </a>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })()
+        )}
       </div>
 
       <div className="mt-6 text-center">


### PR DESCRIPTION
## What changed
- add first accessible text versions for the handouts `leuchtturm` and `krisenkommunikation`
- introduce a dedicated `HandoutTextPage` route at `/materialien/text/:handoutId`
- surface `Textversion lesen` CTAs in the material library and relevant topic sections when a text version exists
- extend search coverage and update the accessibility page to reflect the first available text alternatives
- add tests for text-version lookup, library links, and page rendering

## Why
Most remote handout PDFs currently have no usable text layer. That makes search, screen reader access, copy/paste, and low-friction reading much harder than it should be for core materials.

This PR creates the first small product package that offers readable same-app HTML alternatives without mixing in broader PDF remediation work.

## User impact
- visitors can now read two key handouts directly as structured web content
- the material library makes the difference between `Textversion lesen`, `PDF öffnen`, and `PDF herunterladen` explicit
- search can lead directly to the readable versions

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
