### PR TITLE
[codex] Add more handout text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -11,21 +11,39 @@ describe("handout text versions", () => {
     const leuchtturmPdf = materials.find(
       item => item.id === "leuchtturm"
     )?.downloadUrl;
+    const rolleKlaerenPdf = materials.find(
+      item => item.id === "rolle-klaeren"
+    )?.downloadUrl;
     const krisenPdf = materials.find(
       item => item.id === "krisenkommunikation"
+    )?.downloadUrl;
+    const warnsignalePdf = materials.find(
+      item => item.id === "warnsignale"
     )?.downloadUrl;
 
     expect(getHandoutTextVersion("leuchtturm")?.path).toBe(
       "/materialien/text/leuchtturm"
     );
+    expect(getHandoutTextVersion("rolle-klaeren")?.path).toBe(
+      "/materialien/text/rolle-klaeren"
+    );
     expect(getHandoutTextVersion("krisenkommunikation")?.path).toBe(
       "/materialien/text/krisenkommunikation"
+    );
+    expect(getHandoutTextVersion("warnsignale")?.path).toBe(
+      "/materialien/text/warnsignale"
     );
     expect(getHandoutTextVersionHrefBySource(leuchtturmPdf)).toBe(
       "/materialien/text/leuchtturm"
     );
+    expect(getHandoutTextVersionHrefBySource(rolleKlaerenPdf)).toBe(
+      "/materialien/text/rolle-klaeren"
+    );
     expect(getHandoutTextVersionHrefBySource(krisenPdf)).toBe(
       "/materialien/text/krisenkommunikation"
+    );
+    expect(getHandoutTextVersionHrefBySource(warnsignalePdf)).toBe(
+      "/materialien/text/warnsignale"
     );
     expect(getHandoutTextVersionBySource("/notfallplan-krise-v03.pdf")).toBe(
       null

--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -43,6 +43,16 @@ describe("MaterialienLibrarySection", () => {
       "href",
       "/materialien/text/leuchtturm"
     );
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Ihre Rolle klären – Was Sie sein können/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/rolle-klaeren");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Warnsignale der Überlastung/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/warnsignale");
 
     fireEvent.click(screen.getByRole("button", { name: /Genesung\s*\(1\)/ }));
 

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -129,6 +129,23 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/materialien");
   });
 
+  it("HandoutTextPage: rendert Warnsignale-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "warnsignale" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Warnsignale der Überlastung/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Überlastung kommt nicht plötzlich/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Selbstfürsorge/i })
+    ).toHaveAttribute("href", "/selbstfuersorge");
+  });
+
   it("NotFound: rendert 404-Seite", async () => {
     const { default: NotFound } = await import("@/pages/NotFound");
     withRouter(<NotFound />);

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -175,6 +175,111 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),
+  createHandoutTextVersion("rolle-klaeren", {
+    kicker: "Textversion",
+    summary:
+      "Sie können Orientierung, Hoffnung und klare Grenzen geben. Therapie ersetzen, Verhalten kontrollieren oder die Genesung tragen müssen Sie nicht.",
+    intro: [
+      "Diese Seite überträgt die Infografik «Ihre Rolle klären» in eine lesbare Web-Version. Die Grundstruktur des Originals bleibt erhalten: Ihr Beitrag, nicht Ihre Aufgabe und die Rolle professioneller Hilfe.",
+      "Das Handout hilft Angehörigen dabei, Unterstützung realistisch zu verstehen: zugewandt und stabil bleiben, ohne in Therapie, Kontrolle oder Selbstaufgabe abzurutschen.",
+    ],
+    sections: [
+      {
+        title: "Ihr Beitrag",
+        intro:
+          "Die linke Spalte des Handouts beschreibt, was Angehörige tatsächlich leisten können, ohne ihre Rolle zu überschreiten.",
+        cards: [
+          {
+            title: "Verlässlicher Anker",
+            text: "Berechenbar und stabil bleiben.",
+          },
+          {
+            title: "Geduldige/r Zuhörer/in",
+            text: "Zuhören, ohne zu urteilen.",
+          },
+          {
+            title: "Übungspartner/in",
+            text: "Neue Verhaltensweisen gemeinsam üben.",
+          },
+          {
+            title: "Hoffnung geben",
+            text: "Vermitteln, dass Besserung möglich ist.",
+          },
+          {
+            title: "Grenzen halten",
+            text: "Klar und konsequent bleiben.",
+          },
+        ],
+      },
+      {
+        title: "Nicht Ihre Aufgabe",
+        intro:
+          "Die rechte Spalte grenzt bewusst ab, welche Rollen zwar verständlich erscheinen, aber Angehörige überfordern oder in problematische Dynamiken bringen.",
+        cards: [
+          {
+            title: "Therapeut/in",
+            text: "Die Therapie ersetzen oder kontrollieren.",
+          },
+          {
+            title: "Retter/in",
+            text: "Alle Probleme lösen wollen.",
+          },
+          {
+            title: "Kontrolleur/in",
+            text: "Verhalten überwachen oder erzwingen.",
+          },
+          {
+            title: "Sündenbock",
+            text: "Schuld für alles übernehmen.",
+          },
+          {
+            title: "Verantwortlich für Genesung",
+            text: "Die Genesung liegt nicht in Ihrer Hand.",
+          },
+        ],
+      },
+      {
+        title: "Professionelle Hilfe",
+        calloutTitle: "Was Fachpersonen übernehmen",
+        calloutText:
+          "Therapie, Psychiatrie und Beratung – das ist Aufgabe der Fachpersonen.",
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es im Handout geht",
+        calloutText:
+          "Sie können unterstützen und Grenzen halten. Sie müssen nicht therapieren.",
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "Regelmässig prüfen",
+            text: "Fragen Sie sich: Bin ich noch in meiner Rolle oder rutsche ich ab?",
+          },
+          {
+            title: "Mit Fachpersonen sprechen",
+            text: "Holen Sie sich Rücksprache, wenn Sie unsicher sind oder die Rollen verschwimmen.",
+          },
+          {
+            title: "Sich erinnern",
+            text: "Ihre Stabilität ist Ihr wichtigster Beitrag.",
+          },
+        ],
+      },
+      {
+        title: "Legende der Grafik",
+        bullets: [
+          "Sage = Ihr Beitrag",
+          "Terracotta = Nicht Ihre Aufgabe",
+          "Slate = Professionelle Hilfe",
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Gunderson et al., Family Guidelines; Kreger (2014).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
   createHandoutTextVersion("krisenkommunikation", {
     kicker: "Textversion",
     summary:
@@ -242,6 +347,104 @@ export const handoutTextVersions: HandoutTextVersion[] = [
       },
     ],
     sourceLine: "Quelle: Mason/Kreger (2014); Linehan (1993).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("warnsignale", {
+    kicker: "Textversion",
+    summary:
+      "Überlastung baut sich oft schrittweise auf. Wer erste Warnzeichen ernst nimmt, kann früher gegensteuern und rechtzeitig Hilfe holen.",
+    intro: [
+      "Diese Seite überträgt das Handout «Warnsignale der Überlastung» in eine lesbare Web-Version. Die Ampellogik des Originals bleibt inhaltlich erhalten: grün, gelb und rot markieren unterschiedliche Belastungsstufen.",
+      "Die Grafik ist als frühzeitige Orientierung gedacht, nicht als Selbstvorwurf. Entscheidend ist, Belastung ernst zu nehmen, bevor Erschöpfung oder Krisen eskalieren.",
+    ],
+    sections: [
+      {
+        title: "Kernaussage",
+        calloutTitle: "Zentraler Satz des Handouts",
+        calloutText: "Überlastung kommt nicht plötzlich – sie kündigt sich an.",
+      },
+      {
+        title: "Noch im Rahmen",
+        intro:
+          "Die grüne Stufe beschreibt erste, noch gut beeinflussbare Belastungszeichen. Sie sind ernst zu nehmen, aber noch ein günstiger Moment zum Gegensteuern.",
+        cards: [
+          {
+            title: "Gelegentliche Gereiztheit",
+            text: "Die innere Spannung steigt schneller als sonst, beruhigt sich aber noch wieder.",
+          },
+          {
+            title: "Leichte Schlafprobleme",
+            text: "Ein- oder Durchschlafen fällt schwerer, ohne dass der ganze Alltag schon kippt.",
+          },
+          {
+            title: "Weniger Lust auf Hobbys",
+            text: "Freude, Interesse oder Erholung kommen zu kurz.",
+          },
+        ],
+      },
+      {
+        title: "Achtung, handeln",
+        intro:
+          "Die gelbe Stufe zeigt, dass Belastung bereits deutlicher in Stimmung, Körper und Beziehungen eingreift. Jetzt reicht blosses Durchhalten meist nicht mehr.",
+        cards: [
+          {
+            title: "Emotionale Taubheit oder Dauerfrust",
+            text: "Sie fühlen sich abgestumpft, leer oder dauerhaft gereizt.",
+          },
+          {
+            title: "Körperliche Beschwerden",
+            text: "Stress zeigt sich bereits spürbar körperlich.",
+          },
+          {
+            title: "Sozialer Rückzug beginnt",
+            text: "Kontakte werden weniger, Austausch wird anstrengender oder vermieden.",
+          },
+        ],
+      },
+      {
+        title: "Hilfe suchen",
+        intro:
+          "Die rote Stufe steht für deutliche Warnsignale. Hier braucht es Unterstützung von aussen und nicht nur mehr Disziplin im Alltag.",
+        cards: [
+          {
+            title: "Hoffnungslosigkeit",
+            text: "Die Belastung wirkt festgefahren und ohne Ausweg.",
+          },
+          {
+            title: "Kontrollverlust-Angst",
+            text: "Sie haben das Gefühl, sich selbst oder die Situation nicht mehr im Griff zu haben.",
+          },
+          {
+            title: "Eigene Identität verloren",
+            text: "Sie erleben sich fast nur noch in der Angehörigenrolle.",
+          },
+          {
+            title: "Körperliche Dauerbeschwerden",
+            text: "Stresssymptome halten an und werden zu einem dauerhaften Problem.",
+          },
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Grün",
+            text: "Selbstfürsorge aktivieren.",
+          },
+          {
+            title: "2. Gelb",
+            text: "Professionelle Beratung suchen.",
+          },
+          {
+            title: "3. Rot",
+            text: "Sofort Hilfe holen.",
+          },
+        ],
+      },
+    ],
+    sourceLine:
+      "Quelle: Maslach/Leiter (2016), Burnout-Prävention; Mason/Kreger (2014).",
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -426,6 +426,23 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Ihre Rolle klären",
+    description:
+      "Lesbare Web-Version zur Angehörigenrolle mit Abgrenzung zwischen eigenem Beitrag, professioneller Hilfe und klaren Grenzen",
+    keywords: [
+      "textversion",
+      "rolle klären",
+      "unterstützen",
+      "angehörigenrolle",
+      "grenzen",
+      "professionelle hilfe",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/rolle-klaeren",
+    section: "Materialien",
+  },
+  {
     title: "Der Eisberg: Was hinter Wut liegen kann",
     description:
       "Infografik: Hinter sichtbarer Wut liegen oft Schmerz, Angst oder Scham",
@@ -553,6 +570,23 @@ export const searchableContent: SearchEntry[] = [
       "pdf",
     ],
     href: "/materialien/text/krisenkommunikation",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Warnsignale der Überlastung",
+    description:
+      "Lesbare Web-Version des Ampel-Handouts zu Überlastung, Frühwarnzeichen und nächsten Schritten",
+    keywords: [
+      "textversion",
+      "warnsignale",
+      "überlastung",
+      "selbstfürsorge",
+      "ampel",
+      "burnout",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/warnsignale",
     section: "Materialien",
   },
 

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -12,6 +12,7 @@ import {
   Download,
   ExternalLink,
   Eye,
+  FileText,
   Heart,
   Lightbulb,
   Users,
@@ -26,6 +27,7 @@ import {
   unterstuetzenSubcategories,
 } from "@/content/unterstuetzen";
 import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 export default function UnterstuetzenUebersicht() {
   const [activeFilter, setActiveFilter] = useState("alle");
@@ -361,6 +363,7 @@ export default function UnterstuetzenUebersicht() {
                   <strong className="text-foreground">
                     Vorschau = Web-Bild.
                   </strong>{" "}
+                  Wenn verfügbar, führt «Textversion» zur lesbaren Web-Version.
                   «PDF öffnen» öffnet die A4-Druckversion im neuen Tab.
                 </span>
               </p>
@@ -407,43 +410,63 @@ export default function UnterstuetzenUebersicht() {
                 ref={gridRef}
                 className="grid grid-cols-1 sm:grid-cols-2 gap-4"
               >
-                {filteredItems.map((item, index) => (
-                  <Card
-                    key={item.title}
-                    className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
-                      filteredItems.length > 1 && index === 0
-                        ? "sm:col-span-2"
-                        : ""
-                    }`}
-                  >
-                    <div className="aspect-[4/3] bg-muted overflow-hidden">
-                      <img
-                        src={item.url}
-                        alt={item.title}
-                        className="w-full h-full object-cover object-top"
-                        loading="lazy"
-                        width={400}
-                        height={223}
-                        decoding="async"
-                      />
-                    </div>
-                    <CardContent className="p-4">
-                      <h3 className="font-medium text-sm text-foreground mb-2">
-                        {item.title}
-                      </h3>
-                      <a
-                        href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                        className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                      >
-                        <ExternalLink className="w-4 h-4" />
-                        PDF öffnen
-                      </a>
-                    </CardContent>
-                  </Card>
-                ))}
+                {filteredItems.map((item, index) => {
+                  const textVersionHref = getHandoutTextVersionHrefBySource(
+                    item.pdfUrl
+                  );
+
+                  return (
+                    <Card
+                      key={item.title}
+                      className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
+                        filteredItems.length > 1 && index === 0
+                          ? "sm:col-span-2"
+                          : ""
+                      }`}
+                    >
+                      <div className="aspect-[4/3] bg-muted overflow-hidden">
+                        <img
+                          src={item.url}
+                          alt={item.title}
+                          className="w-full h-full object-cover object-top"
+                          loading="lazy"
+                          width={400}
+                          height={223}
+                          decoding="async"
+                        />
+                      </div>
+                      <CardContent className="p-4">
+                        <h3 className="font-medium text-sm text-foreground mb-2">
+                          {item.title}
+                        </h3>
+                        <div className="grid gap-2">
+                          {textVersionHref ? (
+                            <Link
+                              href={textVersionHref}
+                              aria-label={`Textversion lesen: ${item.title}`}
+                              className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-sage-dark hover:bg-sage-mid text-white transition-colors"
+                            >
+                              <FileText className="w-4 h-4" />
+                              Textversion
+                            </Link>
+                          ) : null}
+                          <a
+                            href={
+                              getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl
+                            }
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                            className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                            PDF öffnen
+                          </a>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
               </div>
 
               <div className="mt-4 text-center">

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -6,6 +6,7 @@ import {
   Filter,
   Activity,
   Zap,
+  FileText,
   Heart,
 } from "lucide-react";
 import ContentSection from "@/components/ContentSection";
@@ -16,6 +17,7 @@ import {
   type SelbstfuersorgeKategorie,
 } from "@/content/selbstfuersorge";
 import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 const selbstfuersorgeCategories = [
   {
@@ -67,9 +69,10 @@ export default function SelbstfuersorgeInfografikenSection() {
       preview="Infografiken als hochauflösende PDFs zum Herunterladen und Ausdrucken."
     >
       <p className="text-sm text-muted-foreground mb-4">
-        <strong className="text-foreground">Vorschau = Web-Bild.</strong> «PDF
-        öffnen» öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer
-        oben rechts.
+        <strong className="text-foreground">Vorschau = Web-Bild.</strong> Wenn
+        verfügbar, führt «Textversion» zur lesbaren Web-Version. «PDF öffnen»
+        öffnet die A4-Druckversion im neuen Tab – Download im PDF-Viewer oben
+        rechts.
       </p>
 
       <div className="flex flex-wrap gap-2 mb-6">
@@ -96,39 +99,57 @@ export default function SelbstfuersorgeInfografikenSection() {
       </div>
 
       <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {filteredItems.map(item => (
-          <Card
-            key={item.id}
-            className={`overflow-hidden border-border/50 hover:shadow-md transition-shadow ${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""}`}
-          >
-            <div className="aspect-[3/4] overflow-hidden bg-muted">
-              <img
-                src={item.webp}
-                alt={item.title}
-                className="w-full h-full object-cover object-top"
-                loading="lazy"
-                width={400}
-                height={223}
-                decoding="async"
-              />
-            </div>
-            <CardContent className="p-4">
-              <h3 className="font-medium text-foreground mb-1 text-sm">
-                {item.title}
-              </h3>
-              <p className="text-xs text-muted-foreground mb-3">{item.desc}</p>
-              <a
-                href={getHandoutOpenHref(item.pdf) ?? item.pdf}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-              >
-                <ExternalLink className="w-4 h-4" /> PDF öffnen
-              </a>
-            </CardContent>
-          </Card>
-        ))}
+        {filteredItems.map(item => {
+          const textVersionHref = getHandoutTextVersionHrefBySource(item.pdf);
+
+          return (
+            <Card
+              key={item.id}
+              className={`overflow-hidden border-border/50 hover:shadow-md transition-shadow ${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""}`}
+            >
+              <div className="aspect-[3/4] overflow-hidden bg-muted">
+                <img
+                  src={item.webp}
+                  alt={item.title}
+                  className="w-full h-full object-cover object-top"
+                  loading="lazy"
+                  width={400}
+                  height={223}
+                  decoding="async"
+                />
+              </div>
+              <CardContent className="p-4">
+                <h3 className="font-medium text-foreground mb-1 text-sm">
+                  {item.title}
+                </h3>
+                <p className="text-xs text-muted-foreground mb-3">
+                  {item.desc}
+                </p>
+                <div className="grid gap-2">
+                  {textVersionHref ? (
+                    <Link
+                      href={textVersionHref}
+                      aria-label={`Textversion lesen: ${item.title}`}
+                      className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-sage-dark hover:bg-sage-mid text-white transition-colors"
+                    >
+                      <FileText className="w-4 h-4" />
+                      Textversion
+                    </Link>
+                  ) : null}
+                  <a
+                    href={getHandoutOpenHref(item.pdf) ?? item.pdf}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                    className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                  >
+                    <ExternalLink className="w-4 h-4" /> PDF öffnen
+                  </a>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
       <div className="mt-4 text-center">


### PR DESCRIPTION
## What changed
- add two more accessible handout text versions: `rolle-klaeren` and `warnsignale`
- surface `Textversion` CTAs in the `Unterstützen` overview materials block and the `Selbstfürsorge` infographic section when a readable web version exists
- extend search coverage for the new text versions
- expand tests for helper mapping, library links, and route rendering

## Why
The first handout text-version package established the pattern, but important core handouts in `Unterstützen` and `Selbstfürsorge` were still only available as image-based PDFs.

This PR continues the small-batch remediation approach by adding two more high-value, readable HTML alternatives without mixing in unrelated PDF work.

## User impact
- visitors can now read two additional core handouts directly as structured web content
- the most relevant topic entry points now expose the readable version instead of only the PDF flow
- search can route directly to the new text versions

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
