### PR TITLE
[codex] Add more accessible handout text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -11,11 +11,17 @@ describe("handout text versions", () => {
     const leuchtturmPdf = materials.find(
       item => item.id === "leuchtturm"
     )?.downloadUrl;
+    const eisbergPdf = materials.find(
+      item => item.id === "eisberg"
+    )?.downloadUrl;
     const rolleKlaerenPdf = materials.find(
       item => item.id === "rolle-klaeren"
     )?.downloadUrl;
     const krisenPdf = materials.find(
       item => item.id === "krisenkommunikation"
+    )?.downloadUrl;
+    const grenzenSpickzettelPdf = materials.find(
+      item => item.id === "grenzen-spickzettel"
     )?.downloadUrl;
     const warnsignalePdf = materials.find(
       item => item.id === "warnsignale"
@@ -24,11 +30,17 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersion("leuchtturm")?.path).toBe(
       "/materialien/text/leuchtturm"
     );
+    expect(getHandoutTextVersion("eisberg")?.path).toBe(
+      "/materialien/text/eisberg"
+    );
     expect(getHandoutTextVersion("rolle-klaeren")?.path).toBe(
       "/materialien/text/rolle-klaeren"
     );
     expect(getHandoutTextVersion("krisenkommunikation")?.path).toBe(
       "/materialien/text/krisenkommunikation"
+    );
+    expect(getHandoutTextVersion("grenzen-spickzettel")?.path).toBe(
+      "/materialien/text/grenzen-spickzettel"
     );
     expect(getHandoutTextVersion("warnsignale")?.path).toBe(
       "/materialien/text/warnsignale"
@@ -36,11 +48,17 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersionHrefBySource(leuchtturmPdf)).toBe(
       "/materialien/text/leuchtturm"
     );
+    expect(getHandoutTextVersionHrefBySource(eisbergPdf)).toBe(
+      "/materialien/text/eisberg"
+    );
     expect(getHandoutTextVersionHrefBySource(rolleKlaerenPdf)).toBe(
       "/materialien/text/rolle-klaeren"
     );
     expect(getHandoutTextVersionHrefBySource(krisenPdf)).toBe(
       "/materialien/text/krisenkommunikation"
+    );
+    expect(getHandoutTextVersionHrefBySource(grenzenSpickzettelPdf)).toBe(
+      "/materialien/text/grenzen-spickzettel"
     );
     expect(getHandoutTextVersionHrefBySource(warnsignalePdf)).toBe(
       "/materialien/text/warnsignale"

--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -50,6 +50,16 @@ describe("MaterialienLibrarySection", () => {
     ).toHaveAttribute("href", "/materialien/text/rolle-klaeren");
     expect(
       screen.getByRole("link", {
+        name: /Textversion lesen: Der Eisberg – Wut ist oft die Spitze/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/eisberg");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Spickzettel Grenzen – Die wichtigsten Sätze/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/grenzen-spickzettel");
+    expect(
+      screen.getByRole("link", {
         name: /Textversion lesen: Warnsignale der Überlastung/i,
       })
     ).toHaveAttribute("href", "/materialien/text/warnsignale");

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -146,6 +146,33 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/selbstfuersorge");
   });
 
+  it("HandoutTextPage: rendert Eisberg-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "eisberg" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Der Eisberg – Wut ist oft die Spitze/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Was Sie sehen \(Wut\) ist oft nur die Spitze/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Verstehen/i })
+    ).toHaveAttribute("href", "/verstehen");
+  });
+
+  it("Grenzen: zeigt Textversion für Spickzettel Grenzen", async () => {
+    const { default: Grenzen } = await import("@/pages/Grenzen");
+    withRouter(<Grenzen />);
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Spickzettel Grenzen/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/grenzen-spickzettel");
+  });
+
   it("NotFound: rendert 404-Seite", async () => {
     const { default: NotFound } = await import("@/pages/NotFound");
     withRouter(<NotFound />);

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -280,6 +280,117 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),
+  createHandoutTextVersion("eisberg", {
+    kicker: "Textversion",
+    summary:
+      "Was sichtbar wie Wut, Vorwürfe oder Lautwerden wirkt, hat oft eine verdeckte Unterseite aus Angst, Scham, Trauer, Einsamkeit und Stress.",
+    intro: [
+      "Diese Seite überträgt das Handout «Der Eisberg» in eine lesbare Web-Version. Die zentrale Bildidee bleibt erhalten: sichtbares Verhalten ist nur die Spitze, darunter liegen oft andere Gefühle und Bedürfnisse.",
+      "Für Angehörige ist die Grafik als Einordnungshilfe gedacht. Sie soll Wut nicht verharmlosen, aber helfen, Verhalten differenzierter zu lesen und die eigene Reaktion bewusster zu wählen.",
+    ],
+    sections: [
+      {
+        title: "Sichtbar",
+        intro:
+          "Die obere Spitze des Eisbergs steht für das, was im Alltag direkt auffällt und oft schnell eskaliert.",
+        cards: [
+          {
+            title: "Wut",
+            text: "Starke Gereiztheit oder explosive Reaktionen, die sofort als Problem sichtbar werden.",
+          },
+          {
+            title: "Vorwürfe",
+            text: "Anklagen, Schuldzuweisungen oder harte Botschaften, die bei Angehörigen schnell Abwehr auslösen.",
+          },
+          {
+            title: "Laut werden",
+            text: "Erhöhte Lautstärke oder scharfer Ton als sichtbares Verhalten an der Oberfläche.",
+          },
+        ],
+      },
+      {
+        title: "Darunter",
+        intro:
+          "Unter der Wasserlinie zeigt die Grafik die verborgenen Gefühle und Bedürfnisse, die an der Oberfläche nicht sofort erkennbar sind.",
+        cards: [
+          {
+            title: "Angst",
+            text: "Unsicherheit, Bedrohungsgefühl oder Verlassensangst können sich hinter Wut verbergen.",
+          },
+          {
+            title: "Scham",
+            text: "Starke innere Beschämung wird oft nicht direkt gezeigt, sondern über Abwehr oder Angriff nach aussen geleitet.",
+          },
+          {
+            title: "Trauer",
+            text: "Verlust, Schmerz oder Enttäuschung können verdeckt bleiben und trotzdem das Verhalten prägen.",
+          },
+          {
+            title: "Einsamkeit",
+            text: "Das Gefühl, nicht erreicht oder verstanden zu werden, kann unterm sichtbaren Konflikt liegen.",
+          },
+          {
+            title: "Stress",
+            text: "Überforderung und Anspannung verstärken sichtbare Reaktionen und engen den Handlungsspielraum ein.",
+          },
+        ],
+      },
+      {
+        title: "Anspannung und Ventile",
+        intro:
+          "Die Grafik ergänzt den Eisberg um zwei Regler: mehr Trigger und Überforderung erhöhen den Druck, mehr Sicherheit, Skills und Erholung entlasten.",
+        cards: [
+          {
+            title: "Anspannung",
+            text: "Die Anzeige visualisiert, wie hoch die innere Aktivierung gerade ist.",
+          },
+          {
+            title: "Mehr Trigger",
+            text: "Stress, Überforderung und belastende Reize erhöhen den inneren Druck.",
+          },
+          {
+            title: "Mehr Ventile",
+            text: "Sicherheit, Skills und Erholung senken die Anspannung und schaffen wieder Spielraum.",
+          },
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es beim Eisberg geht",
+        calloutText:
+          "Was Sie sehen (Wut) ist oft nur die Spitze – darunter liegen Schmerz, Angst, Scham und Überforderung.",
+      },
+      {
+        title: "3 Schritte",
+        cards: [
+          {
+            title: "1. Erkennen",
+            text: "Was sehe ich? Was könnte darunter liegen?",
+          },
+          {
+            title: "2. Verstehen",
+            text: "Welches Gefühl oder Bedürfnis steckt dahinter?",
+          },
+          {
+            title: "3. Handeln",
+            text: "Wie kann ich darauf eingehen, ohne mich selbst zu verlieren?",
+          },
+        ],
+      },
+      {
+        title: "Legende der Grafik",
+        bullets: [
+          "Spitze = sichtbares Verhalten",
+          "Unter Wasser = verborgene Gefühle",
+          "Ventile = Stresszufuhr oder Entlastung",
+        ],
+      },
+    ],
+    sourceLine:
+      "Quelle: Psychoedukation, Emotionsmodell nach DBT (Linehan, 1993).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
   createHandoutTextVersion("krisenkommunikation", {
     kicker: "Textversion",
     summary:
@@ -445,6 +556,80 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     ],
     sourceLine:
       "Quelle: Maslach/Leiter (2016), Burnout-Prävention; Mason/Kreger (2014).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("grenzen-spickzettel", {
+    kicker: "Textversion",
+    summary:
+      "Der Spickzettel bündelt konkrete Satzbausteine für klare Grenzen, Spiegeln ohne Aufsaugen und eine Exit-Strategie mit Liebe, Grenze und Konsequenz.",
+    intro: [
+      "Diese Seite überträgt den «Spickzettel Grenzen» in eine lesbare und kopierbare Web-Version. Er ist dafür gedacht, vor schwierigen Gesprächen kurz die wichtigsten Satzmuster durchzugehen.",
+      "Die Struktur folgt den vier Bereichen des Originals: DEAR-Technik, Beispielsätze bei Grenzüberschreitungen, Spiegeln statt Aufsaugen und die L.M.K.-Exit-Strategie.",
+    ],
+    sections: [
+      {
+        title: "Wann anwenden?",
+        calloutTitle: "Einsatz des Spickzettels",
+        calloutText:
+          "Wenn Sie eine Grenze setzen möchten, ohne die Beziehung zu gefährden. Ideal zum Üben vor schwierigen Gesprächen.",
+      },
+      {
+        title: "Bereich 1: DEAR-Technik",
+        cards: [
+          {
+            title: "D – Beschreiben",
+            text: "Was ist passiert? Fakten. Ich beschreibe, was passiert ist...",
+          },
+          {
+            title: "E – Äussern",
+            text: "Was fühle ich? Ich-Aussage. Ich fühle mich dabei...",
+          },
+          {
+            title: "A – Behaupten",
+            text: "Was brauche ich? Klar sagen. Ich wünsche mir...",
+          },
+          {
+            title: "R – Verstärken",
+            text: "Was ist der Gewinn? Positiv. Das würde mir helfen, weil...",
+          },
+        ],
+      },
+      {
+        title: "Bereich 2: Bei Grenzüberschreitungen",
+        bullets: [
+          "Ich verstehe, dass du aufgebracht bist. Ich bin trotzdem nicht bereit, mich anschreien zu lassen.",
+          "Wenn das so weitergeht, werde ich den Raum verlassen.",
+          "Ich liebe dich UND ich brauche jetzt eine Pause.",
+        ],
+      },
+      {
+        title: "Bereich 3: Spiegeln statt Aufsaugen",
+        bullets: [
+          "Ich sehe, dass du leidest.",
+          "Das klingt wirklich schwer für dich.",
+          "Ich bin für dich da – aber ich kann das Problem nicht für dich lösen.",
+        ],
+      },
+      {
+        title: "Bereich 4: L.M.K. (Lebe Mit Konsequenzen) – Exit-Strategie",
+        cards: [
+          {
+            title: "L = Liebe zeigen",
+            text: "Du bist mir wichtig...",
+          },
+          {
+            title: "M = Meine Grenze",
+            text: "Ich brauche...",
+          },
+          {
+            title: "K = Konsequenz",
+            text: "Wenn nicht, dann...",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Mason/Kreger (2014); Linehan (1993), DBT.",
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -458,6 +458,23 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Der Eisberg",
+    description:
+      "Lesbare Web-Version des Eisberg-Handouts zu sichtbarer Wut, verborgenen Gefühlen und 3 Schritten zur Einordnung",
+    keywords: [
+      "textversion",
+      "eisberg",
+      "wut",
+      "angst",
+      "scham",
+      "gefühle",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/eisberg",
+    section: "Materialien",
+  },
+  {
     title: "Die Spaltung verstehen",
     description:
       "Infografik: Wie starke Idealisierung und Entwertung in Krisen entstehen können",
@@ -587,6 +604,23 @@ export const searchableContent: SearchEntry[] = [
       "pdf",
     ],
     href: "/materialien/text/warnsignale",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Spickzettel Grenzen",
+    description:
+      "Lesbare Web-Version mit DEAR-Technik, Beispielsätzen für Grenzen und L.M.K.-Exit-Strategie",
+    keywords: [
+      "textversion",
+      "spickzettel grenzen",
+      "dear",
+      "grenzen",
+      "satzbausteine",
+      "lmk",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/grenzen-spickzettel",
     section: "Materialien",
   },
 

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -12,6 +12,7 @@ import {
   Download,
   ExternalLink,
   Eye,
+  FileText,
   Heart,
   MessageSquare,
   Phone,
@@ -23,6 +24,7 @@ import ContentSection from "@/components/ContentSection";
 
 import { grenzenItems } from "@/content/grenzen";
 import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 export default function Grenzen() {
   return (
@@ -521,48 +523,69 @@ export default function Grenzen() {
                   <strong className="text-foreground">
                     Vorschau = Web-Bild.
                   </strong>{" "}
+                  Wenn verfügbar, führt «Textversion» zur lesbaren Web-Version.
                   «PDF öffnen» öffnet die A4-Druckversion im neuen Tab.
                 </span>
               </p>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {grenzenItems.map((item, index) => (
-                  <Card
-                    key={item.title}
-                    className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
-                      grenzenItems.length > 1 && index === 0
-                        ? "sm:col-span-2"
-                        : ""
-                    }`}
-                  >
-                    <div className="relative aspect-[3/4] bg-muted overflow-hidden">
-                      <img
-                        src={item.url}
-                        alt={item.title}
-                        className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-500"
-                        loading="lazy"
-                        width={400}
-                        height={223}
-                        decoding="async"
-                      />
-                    </div>
-                    <CardContent className="p-3">
-                      <h3 className="font-medium text-sm text-foreground mb-2">
-                        {item.title}
-                      </h3>
-                      <a
-                        href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                        className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-                      >
-                        <ExternalLink className="w-4 h-4" />
-                        PDF öffnen
-                      </a>
-                    </CardContent>
-                  </Card>
-                ))}
+                {grenzenItems.map((item, index) => {
+                  const textVersionHref = getHandoutTextVersionHrefBySource(
+                    item.pdfUrl
+                  );
+
+                  return (
+                    <Card
+                      key={item.title}
+                      className={`overflow-hidden hover:shadow-lg transition-all duration-500 group ${
+                        grenzenItems.length > 1 && index === 0
+                          ? "sm:col-span-2"
+                          : ""
+                      }`}
+                    >
+                      <div className="relative aspect-[3/4] bg-muted overflow-hidden">
+                        <img
+                          src={item.url}
+                          alt={item.title}
+                          className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-500"
+                          loading="lazy"
+                          width={400}
+                          height={223}
+                          decoding="async"
+                        />
+                      </div>
+                      <CardContent className="p-3">
+                        <h3 className="font-medium text-sm text-foreground mb-2">
+                          {item.title}
+                        </h3>
+                        <div className="grid gap-2">
+                          {textVersionHref ? (
+                            <Link
+                              href={textVersionHref}
+                              aria-label={`Textversion lesen: ${item.title}`}
+                              className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-sage-dark hover:bg-sage-mid text-white transition-colors"
+                            >
+                              <FileText className="w-4 h-4" />
+                              Textversion
+                            </Link>
+                          ) : null}
+                          <a
+                            href={
+                              getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl
+                            }
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                            className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                            PDF öffnen
+                          </a>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  );
+                })}
               </div>
 
               <div className="mt-6 text-center">


### PR DESCRIPTION
## What changed
- add two more accessible handout text versions: `eisberg` and `grenzen-spickzettel`
- surface a `Textversion` CTA in the `Grenzen` topic page when a readable web version exists
- extend search coverage for the new text versions
- expand tests for handout mapping, material-library links, the new `Grenzen` CTA, and route rendering

## Why
Important core handouts still existed only as image-based PDFs, especially in `Verstehen` and `Grenzen`.

This PR continues the small-batch remediation track by adding two more high-value HTML alternatives, including one handout with clear copy/paste value for everyday sentence prompts.

## User impact
- visitors can now read two additional core handouts directly as structured web content
- the `Grenzen` topic page now exposes the readable web version instead of only the PDF flow when available
- search can lead directly to the new text versions

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
