### PR TITLE
[codex] Add more understanding handout text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -14,6 +14,12 @@ describe("handout text versions", () => {
     const eisbergPdf = materials.find(
       item => item.id === "eisberg"
     )?.downloadUrl;
+    const spaltungPdf = materials.find(
+      item => item.id === "spaltung"
+    )?.downloadUrl;
+    const alarmModusPdf = materials.find(
+      item => item.id === "alarm-modus"
+    )?.downloadUrl;
     const rolleKlaerenPdf = materials.find(
       item => item.id === "rolle-klaeren"
     )?.downloadUrl;
@@ -33,6 +39,12 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersion("eisberg")?.path).toBe(
       "/materialien/text/eisberg"
     );
+    expect(getHandoutTextVersion("spaltung")?.path).toBe(
+      "/materialien/text/spaltung"
+    );
+    expect(getHandoutTextVersion("alarm-modus")?.path).toBe(
+      "/materialien/text/alarm-modus"
+    );
     expect(getHandoutTextVersion("rolle-klaeren")?.path).toBe(
       "/materialien/text/rolle-klaeren"
     );
@@ -50,6 +62,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(eisbergPdf)).toBe(
       "/materialien/text/eisberg"
+    );
+    expect(getHandoutTextVersionHrefBySource(spaltungPdf)).toBe(
+      "/materialien/text/spaltung"
+    );
+    expect(getHandoutTextVersionHrefBySource(alarmModusPdf)).toBe(
+      "/materialien/text/alarm-modus"
     );
     expect(getHandoutTextVersionHrefBySource(rolleKlaerenPdf)).toBe(
       "/materialien/text/rolle-klaeren"

--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -55,6 +55,16 @@ describe("MaterialienLibrarySection", () => {
     ).toHaveAttribute("href", "/materialien/text/eisberg");
     expect(
       screen.getByRole("link", {
+        name: /Textversion lesen: Spaltung – das Pendel zwischen Extremen/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/spaltung");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Alarm-Modus vs\. Denk-Modus/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/alarm-modus");
+    expect(
+      screen.getByRole("link", {
         name: /Textversion lesen: Spickzettel Grenzen – Die wichtigsten Sätze/i,
       })
     ).toHaveAttribute("href", "/materialien/text/grenzen-spickzettel");

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -163,6 +163,36 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/verstehen");
   });
 
+  it("HandoutTextPage: rendert Spaltung-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "spaltung" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Spaltung – das Pendel zwischen Extremen/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Unter Stress kippt die Bewertung Ihres Angehörigen/i)
+    ).toBeInTheDocument();
+  });
+
+  it("HandoutTextPage: rendert Alarm-Modus-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "alarm-modus" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Alarm-Modus vs\. Denk-Modus/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Im Alarm-Modus ist Ihr Gegenüber vorübergehend nicht erreichbar/i
+      )
+    ).toBeInTheDocument();
+  });
+
   it("Grenzen: zeigt Textversion für Spickzettel Grenzen", async () => {
     const { default: Grenzen } = await import("@/pages/Grenzen");
     withRouter(<Grenzen />);

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -391,6 +391,83 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),
+  createHandoutTextVersion("spaltung", {
+    kicker: "Textversion",
+    summary:
+      "Unter Stress kippt die Bewertung oft in Extreme. Angehörige werden dann vorübergehend idealisiert oder entwertet, während die Grauzone schwer erreichbar wird.",
+    intro: [
+      "Diese Seite überträgt das Handout «Spaltung – das Pendel zwischen Extremen» in eine lesbare Web-Version. Die zentrale Bildidee bleibt erhalten: Unter Belastung pendelt die Wahrnehmung zwischen Idealisierung und Entwertung, statt den ganzen Menschen zu sehen.",
+      "Für Angehörige ist die Grafik als Orientierung gedacht. Sie erklärt, warum das Kippen so schmerzhaft und verwirrend wirkt, und zeigt, wie stabilisierende Reaktionen helfen können, die Grauzone wieder erreichbar zu machen.",
+    ],
+    sections: [
+      {
+        title: "Die drei Zustände",
+        intro:
+          "Das Handout stellt zwei verzerrte Bewertungszustände und die schwer erreichbare Grauzone dazwischen gegenüber.",
+        cards: [
+          {
+            title: "Idealisierung",
+            text: "«Du bist der beste Mensch der Welt!» So erleben Sie es: Ihr Angehöriger überhäuft Sie mit Lob und Zuneigung. Sie fühlen sich gebraucht und wichtig – aber auch unter Druck, diesem Bild gerecht zu werden.",
+          },
+          {
+            title: "Grauzone",
+            text: "«Du bist ein Mensch – mit Stärken und Schwächen.» Das Ziel: Ihr Angehöriger kann Sie als ganzen Menschen sehen – nicht nur als Retter oder Feind. Dieses Sowohl-als-auch ist das, was Therapie langfristig fördert.",
+          },
+          {
+            title: "Entwertung",
+            text: "«Du bist das Schlimmste. Du bist gegen mich!» So erleben Sie es: Plötzlich sind Sie der Feind – obwohl sich nichts geändert hat. Alles Gute scheint vergessen. Das tut weh und ist verwirrend.",
+          },
+        ],
+      },
+      {
+        title: "Was das Pendel kippen kann",
+        intro:
+          "Die Grafik markiert kleine Auslöser, die von aussen oft banal wirken, unter Stress aber stark ins Gewicht fallen.",
+        bullets: ["Stress", "Kritik", "Abstand", "Missverständnis"],
+      },
+      {
+        title: "Wichtiger Hinweis",
+        calloutTitle: "Warum das Kippen so irritierend ist",
+        calloutText:
+          "Diese Trigger sind oft winzig – für Aussenstehende kaum erkennbar. Das Kippen ist kein böser Wille Ihres Angehörigen, sondern ein erlerntes Muster der Emotionsregulation.",
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es bei der Spaltung geht",
+        calloutText:
+          "Unter Stress kippt die Bewertung Ihres Angehörigen leicht ins Extreme – die Grauzone wird schwer erreichbar. Weder die Idealisierung noch die Entwertung sind ein realistisches Bild von Ihnen. Beides sind Verzerrungen. Sie sind derselbe Mensch – vor und nach dem Kippen.",
+      },
+      {
+        title: "Legende der Grafik",
+        bullets: [
+          "Zwei Bewertungszustände = beide verzerrt, beide vorübergehend",
+          "Trigger = kleine Enttäuschungen, die das Pendel kippen können",
+          "Grauzone = der realistische Bereich – hier können Sie stabilisierend wirken",
+        ],
+      },
+      {
+        title: "3 Schritte zur Stabilisierung",
+        cards: [
+          {
+            title: "1. Wahrnehmen",
+            text: "Erkennen Sie das Muster – bei Ihrem Angehörigen und bei sich selbst. «Werde ich gerade idealisiert oder entwertet? Bin ich wirklich so gut oder so schlecht – oder ist das Pendel gekippt?» Allein dieses Erkennen schafft inneren Abstand.",
+          },
+          {
+            title: "2. Pause",
+            text: "Nicht sofort reagieren. Zeit gewinnen und Distanz schaffen. «Ich brauche einen Moment, bevor ich antworte.» Lassen Sie die erste Welle vorbeiziehen. Weder Gegenangriff noch Unterwerfung helfen.",
+          },
+          {
+            title: "3. Integration",
+            text: "Bleiben Sie konsistent – auch wenn die Bewertung schwankt. «Ich bin derselbe Mensch wie gestern. Ich habe dich lieb, auch wenn du gerade wütend auf mich bist.» Ihre Beständigkeit ist der Anker, der die Grauzone erreichbar macht. Sowohl-als-auch statt Entweder-oder.",
+          },
+        ],
+      },
+    ],
+    sourceLine:
+      "Quelle: Nach Linehan (2015), DBT Skills Training, Handouts 10, 15, 16. Gunderson et al. (2011), Family Psychoeducation for BPD.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 09.02.2026.",
+  }),
   createHandoutTextVersion("krisenkommunikation", {
     kicker: "Textversion",
     summary:
@@ -458,6 +535,75 @@ export const handoutTextVersions: HandoutTextVersion[] = [
       },
     ],
     sourceLine: "Quelle: Mason/Kreger (2014); Linehan (1993).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("alarm-modus", {
+    kicker: "Textversion",
+    summary:
+      "Wenn der Alarm-Modus aktiv ist, ist Ihr Gegenüber vorübergehend schwer erreichbar. Erst beruhigen, dann klären: Die Brücke vom Alarm zum Denken braucht Sicherheit und weniger Druck.",
+    intro: [
+      "Diese Seite überträgt das Handout «Alarm-Modus vs. Denk-Modus» in eine lesbare Web-Version. Die Grundidee des Originals bleibt erhalten: Unter hoher Anspannung steht nicht dieselbe Denkfähigkeit zur Verfügung wie in ruhigeren Momenten.",
+      "Für Angehörige ist das eine Entlastung und eine Handlungsorientierung zugleich. Nicht jede Eskalation ist böser Wille oder bewusste Verweigerung – oft ist sie Ausdruck eines neurobiologisch eingeengten Zustands.",
+    ],
+    sections: [
+      {
+        title: "Trigger",
+        calloutTitle: "Was den Alarm auslösen kann",
+        calloutText: "Kritik, Zurückweisung, Überforderung.",
+      },
+      {
+        title: "Die zwei Modi",
+        intro:
+          "Das Handout stellt einen hoch aktivierten Alarm-Zustand einem wieder zugänglichen Denk-Zustand gegenüber.",
+        cards: [
+          {
+            title: "Alarm-Modus",
+            text: "Körper auf Kampf oder Flucht. Amygdala überaktiv. Denken eingeschränkt. Impulsivität hoch. Schuldgefühle kommen später.",
+          },
+          {
+            title: "Denk-Modus",
+            text: "Präfrontaler Kortex aktiv. Fähigkeiten verfügbar: Zuhören, Abwägen, Planen. Gespräch möglich. Lösungen finden.",
+          },
+          {
+            title: "Übergang",
+            text: "Erst beruhigen, dann klären. Die Brücke vom Alarm zum Denken entsteht nicht durch Druck, sondern durch Entlastung und Sicherheit.",
+          },
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es beim Alarm-Modus geht",
+        calloutText:
+          "Im Alarm-Modus ist Ihr Gegenüber vorübergehend nicht erreichbar. Das ist keine Lüge, kein böser Wille – es ist Neurobiologie.",
+      },
+      {
+        title: "Legende der Grafik",
+        bullets: [
+          "Terracotta = Alarm-Modus",
+          "Sage = Denk-Modus",
+          "Sand = Übergang",
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Erkennen und Stopp",
+            text: "Fragen Sie sich: Ist mein Gegenüber gerade im Alarm-Modus?",
+          },
+          {
+            title: "2. Aktiv beruhigen",
+            text: "Stimme senken, Tempo verlangsamen, Raum geben.",
+          },
+          {
+            title: "3. Klärendes Gespräch",
+            text: "Erst wenn der Denk-Modus zurück ist.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Porges (2011), Polyvagal-Theorie; Linehan (1993).",
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -475,6 +475,23 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Spaltung",
+    description:
+      "Lesbare Web-Version zum Pendel zwischen Idealisierung, Entwertung und der schwer erreichbaren Grauzone",
+    keywords: [
+      "textversion",
+      "spaltung",
+      "idealisierung",
+      "entwertung",
+      "grauzone",
+      "pendel",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/spaltung",
+    section: "Materialien",
+  },
+  {
     title: "Die Spaltung verstehen",
     description:
       "Infografik: Wie starke Idealisierung und Entwertung in Krisen entstehen können",
@@ -587,6 +604,23 @@ export const searchableContent: SearchEntry[] = [
       "pdf",
     ],
     href: "/materialien/text/krisenkommunikation",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Alarm-Modus vs. Denk-Modus",
+    description:
+      "Lesbare Web-Version zur Unterscheidung zwischen Alarm-Zustand, Denk-Zustand und den passenden nächsten Schritten",
+    keywords: [
+      "textversion",
+      "alarm-modus",
+      "denk-modus",
+      "neurobiologie",
+      "trigger",
+      "beruhigen",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/alarm-modus",
     section: "Materialien",
   },
   {


### PR DESCRIPTION
## What changed
- add two more accessible handout text versions: `spaltung` and `alarm-modus`
- extend search coverage for both new text versions
- expand tests for helper mapping, material-library links, and page rendering

## Why
After the six core handouts were covered, the next most coherent small package was the remaining `Verstehen` pair. Both handouts live in the same topic area, reuse the existing CTA surface, and add more readable access to key explanatory content for relatives.

## User impact
- visitors can now read two more `Verstehen` handouts directly as structured web content
- the existing `Verstehen` materials area now exposes additional text versions without any extra PDF-only friction
- search can lead directly to the new text versions

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
