### PR TITLE
[codex] Add communication handout text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -38,6 +38,10 @@ describe("handout text versions", () => {
     const radikaleAkzeptanzPdf = materials.find(
       item => item.id === "radikale-akzeptanz"
     )?.downloadUrl;
+    const wennWorteTreffenPdf = materials.find(
+      item => item.id === "wenn-worte-treffen"
+    )?.downloadUrl;
+    const dearPdf = materials.find(item => item.id === "dear")?.downloadUrl;
 
     expect(getHandoutTextVersion("leuchtturm")?.path).toBe(
       "/materialien/text/leuchtturm"
@@ -69,6 +73,10 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersion("radikale-akzeptanz")?.path).toBe(
       "/materialien/text/radikale-akzeptanz"
     );
+    expect(getHandoutTextVersion("wenn-worte-treffen")?.path).toBe(
+      "/materialien/text/wenn-worte-treffen"
+    );
+    expect(getHandoutTextVersion("dear")?.path).toBe("/materialien/text/dear");
     expect(getHandoutTextVersionHrefBySource(leuchtturmPdf)).toBe(
       "/materialien/text/leuchtturm"
     );
@@ -98,6 +106,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(radikaleAkzeptanzPdf)).toBe(
       "/materialien/text/radikale-akzeptanz"
+    );
+    expect(getHandoutTextVersionHrefBySource(wennWorteTreffenPdf)).toBe(
+      "/materialien/text/wenn-worte-treffen"
+    );
+    expect(getHandoutTextVersionHrefBySource(dearPdf)).toBe(
+      "/materialien/text/dear"
     );
     expect(getHandoutTextVersionBySource("/notfallplan-krise-v03.pdf")).toBe(
       null

--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -83,6 +83,16 @@ describe("MaterialienLibrarySection", () => {
         name: /Textversion lesen: Radikale Akzeptanz – Aufhören zu kämpfen, anfangen zu handeln/i,
       })
     ).toHaveAttribute("href", "/materialien/text/radikale-akzeptanz");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Wenn Worte treffen – 5 häufige Schuldzuweisungen/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/wenn-worte-treffen");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Die DEAR-Technik – Grenzen setzen ohne Vorwürfe/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/dear");
 
     fireEvent.click(screen.getByRole("button", { name: /Genesung\s*\(1\)/ }));
 

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -184,6 +184,42 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/selbstfuersorge");
   });
 
+  it("HandoutTextPage: rendert Wenn-Worte-treffen-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(
+      <HandoutTextPage params={{ handoutId: "wenn-worte-treffen" }} />
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /Wenn Worte treffen – 5 häufige Schuldzuweisungen/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Schuldzuweisungen sind keine Tatsachen/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Kommunizieren/i })
+    ).toHaveAttribute("href", "/kommunizieren");
+  });
+
+  it("HandoutTextPage: rendert DEAR-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "dear" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Die DEAR-Technik – Grenzen setzen ohne Vorwürfe/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/DEAR hilft Ihnen, Wünsche klar zu formulieren/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Grenzen/i })
+    ).toHaveAttribute("href", "/grenzen");
+  });
+
   it("HandoutTextPage: rendert Eisberg-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");
@@ -239,6 +275,21 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Spickzettel Grenzen/i,
       })
     ).toHaveAttribute("href", "/materialien/text/grenzen-spickzettel");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Die DEAR-Technik/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/dear");
+  });
+
+  it("Kommunizieren: zeigt Textversion für Wenn Worte treffen", async () => {
+    const { default: Kommunizieren } = await import("@/pages/Kommunizieren");
+    withRouter(<Kommunizieren />);
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Wenn Worte treffen/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/wenn-worte-treffen");
   });
 
   it("NotFound: rendert 404-Seite", async () => {

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -903,6 +903,130 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),
+  createHandoutTextVersion("wenn-worte-treffen", {
+    kicker: "Textversion",
+    summary:
+      "Schuldzuweisungen treffen oft hart, sagen aber meist mehr über Schmerz, Angst oder Hilflosigkeit als über Ihren Wert. Die Web-Version zeigt fünf häufige Sätze und ruhigere Antworten darauf.",
+    intro: [
+      "Diese Seite überträgt das Handout «Wenn Worte treffen – 5 häufige Schuldzuweisungen» in eine lesbare Web-Version. Es richtet sich an Angehörige, die in belasteten Gesprächen mit harten Vorwürfen oder entwertenden Sätzen konfrontiert werden.",
+      "Die Struktur des Originals bleibt erhalten: eine entlastende Grundhaltung, fünf typische Schuldzuweisungen mit möglicher Einordnung und Antwort sowie ein abschliessender Merksatz, der Mitgefühl und Selbstschutz zusammenhält.",
+    ],
+    sections: [
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es im Handout geht",
+        calloutText:
+          "Schuldzuweisungen sind keine Tatsachen. Sie sind Ausdruck von Schmerz, der keinen anderen Weg findet. Das zu wissen schützt Sie – ohne den Schmerz des anderen zu entwerten.",
+      },
+      {
+        title: "5 häufige Schuldzuweisungen – und was dahintersteckt",
+        cards: [
+          {
+            title: "«Du bist schuld, dass es mir so schlecht geht.»",
+            text: "Dahinter stehen oft Überforderung und Hilflosigkeit. Mögliche Antwort: «Ich sehe, dass es dir schlecht geht. Ich bin nicht die Ursache – aber ich bin da.»",
+          },
+          {
+            title: "«Wenn du gehst, bringe ich mich um.»",
+            text: "Dahinter stehen oft Verlustangst und Verzweiflung. Mögliche Antwort: «Ich höre, wie verzweifelt du bist. Ich gehe nicht weg – und ich rufe jetzt Hilfe.» Das Handout markiert hier zusätzlich: Fachperson informieren.",
+          },
+          {
+            title: "«Du verstehst mich sowieso nicht.»",
+            text: "Dahinter stehen oft Einsamkeit und Enttäuschung. Mögliche Antwort: «Vielleicht verstehe ich nicht alles. Aber ich versuche es. Erzähl mir mehr.»",
+          },
+          {
+            title: "«Du bist genau wie alle anderen.»",
+            text: "Dahinter stehen oft Angst vor Ablehnung und Spaltung. Mögliche Antwort: «Das tut mir weh. Ich bin hier, weil du mir wichtig bist – auch wenn es gerade schwierig ist.»",
+          },
+          {
+            title: "«Ohne dich wäre alles besser.»",
+            text: "Dahinter stehen oft Scham und nach aussen gerichteter Selbsthass. Mögliche Antwort: «Das ist ein harter Satz. Ich bleibe trotzdem. Aber ich brauche auch Respekt.»",
+          },
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Mitfühlen und sich gleichzeitig schützen",
+        calloutText:
+          "Der Satz sagt etwas über den Schmerz – nicht über Sie. Sie dürfen mitfühlen und sich gleichzeitig schützen.",
+      },
+    ],
+    sourceLine:
+      "Quellen: [1] Gunderson & Berkowitz, BPD Family Guidelines (NEABPD). [2] APA, DSM-5. [3] Linehan (1993).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 09.02.2026.",
+  }),
+  createHandoutTextVersion("dear", {
+    kicker: "Textversion",
+    summary:
+      "DEAR hilft, Wünsche klar und ohne Vorwürfe zu formulieren. Die vier Schritte geben Gesprächen Struktur und senken das Eskalationsrisiko.",
+    intro: [
+      "Diese Seite überträgt das Handout «Die DEAR-Technik – Grenzen setzen ohne Vorwürfe» in eine lesbare Web-Version. Es richtet sich an Angehörige, die eigene Wünsche und Grenzen klarer ansprechen möchten.",
+      "Das Original verbindet die vier Schritte von DEAR mit kurzen Beispielen, einer Farblegende und drei alltagsnahen Übungshinweisen. Diese Struktur bleibt in der Web-Version erhalten.",
+    ],
+    sections: [
+      {
+        title: "Kernaussage",
+        calloutTitle: "Zentraler Satz des Handouts",
+        calloutText:
+          "DEAR hilft Ihnen, Wünsche klar zu formulieren – ohne Vorwürfe, ohne Eskalation.",
+      },
+      {
+        title: "Die 4 Schritte",
+        intro:
+          "Für die Web-Version ist die Abfolge bewusst nach dem Akronym DEAR sortiert. Jeder Schritt kombiniert eine Funktion mit einem kurzen Beispielsatz.",
+        cards: [
+          {
+            title: "D = Describe (Beschreiben)",
+            text: "Beschreiben Sie die Situation objektiv, ohne Bewertung. Beispiel: «Mir ist aufgefallen, dass du in den letzten Tagen oft spät nach Hause kommst.»",
+          },
+          {
+            title: "E = Express (Äussern)",
+            text: "Drücken Sie Ihre Gefühle aus. Ich-Botschaft. Beispiel: «Das macht mir Sorgen, weil ich mich dann allein fühle.»",
+          },
+          {
+            title: "A = Assert (Behaupten)",
+            text: "Sagen Sie klar, was Sie sich wünschen. Beispiel: «Ich wünsche mir, dass wir abends öfter zusammen essen.»",
+          },
+          {
+            title: "R = Reinforce (Verstärken)",
+            text: "Zeigen Sie den positiven Effekt auf. Beispiel: «Das würde mir helfen, mich verbundener zu fühlen.»",
+          },
+        ],
+      },
+      {
+        title: "Legende",
+        cards: [
+          {
+            title: "Sand",
+            text: "Beschreiben",
+          },
+          {
+            title: "Sage",
+            text: "Äussern",
+          },
+          {
+            title: "Terracotta",
+            text: "Behaupten",
+          },
+          {
+            title: "Slate",
+            text: "Verstärken",
+          },
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        bullets: [
+          "Schreiben Sie einen DEAR-Satz für eine aktuelle Situation auf.",
+          "Üben Sie den Satz laut, bevor Sie ihn im Gespräch einsetzen.",
+          "Beginnen Sie mit kleinen Themen, bevor Sie grosse ansprechen.",
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Linehan (1993), DBT Skills Training, DEAR MAN.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
   createHandoutTextVersion("grenzen-spickzettel", {
     kicker: "Textversion",
     summary:

--- a/client/src/content/kommunizieren.ts
+++ b/client/src/content/kommunizieren.ts
@@ -46,6 +46,13 @@ export const kommItems: KommunikationsMaterial[] = [
     category: "konflikte",
   },
   {
+    title: "Wenn Worte treffen",
+    url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/azZbLPyPkSupQskI.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/hEXKCmWYeiyUnwXr.pdf",
+    category: "konflikte",
+  },
+  {
     title: "Zuhören ohne Zustimmen",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/eeZIHGmfprWnoPPf.webp",
     pdfUrl:

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -675,6 +675,40 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Wenn Worte treffen",
+    description:
+      "Lesbare Web-Version zu Schuldzuweisungen, typischen harten Sätzen und ruhigeren Antworten für Angehörige",
+    keywords: [
+      "textversion",
+      "wenn worte treffen",
+      "schuldzuweisungen",
+      "vorwürfe",
+      "anklage",
+      "kommunikation",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/wenn-worte-treffen",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Die DEAR-Technik",
+    description:
+      "Lesbare Web-Version zu DEAR mit Beschreiben, Äussern, Behaupten und Verstärken als klare Gesprächsstruktur",
+    keywords: [
+      "textversion",
+      "dear",
+      "dear man",
+      "grenzen",
+      "ich-botschaft",
+      "wünsche formulieren",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/dear",
+    section: "Materialien",
+  },
+  {
     title: "Textversion: Spickzettel Grenzen",
     description:
       "Lesbare Web-Version mit DEAR-Technik, Beispielsätzen für Grenzen und L.M.K.-Exit-Strategie",


### PR DESCRIPTION
## Was sich ändert
- ergänzt neue Web-Textversionen für `wenn-worte-treffen` und `dear`
- erweitert den Suchindex um beide neuen Handout-Seiten
- bindet `Wenn Worte treffen` zusätzlich in die thematische Kommunikations-Section ein
- sichert Registry, Materialsammlung, thematische Seiten und Handout-Routen per Tests ab

## Warum
Die bildbasierten Handouts sollen schrittweise als lesbare, suchbare und besser zugängliche Web-Versionen verfügbar werden. Dieses Paket ergänzt zwei weitere alltagsnahe Kommunikations-/Grenzen-Handouts und zieht zugleich den naheliegenden Sichtbarkeits-Pfad auf der Kommunikations-Seite nach.

## Wirkung
- Angehörige können beide Inhalte direkt im Browser lesen statt nur als bildbasiertes PDF zu öffnen
- `Wenn Worte treffen` ist jetzt nicht nur in der Materialsammlung, sondern auch auf der Kommunikations-Seite mit Textversion sichtbar
- Suche und Regressionstests kennen die neuen Inhalte explizit

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
