### PR TITLE
[codex] Add prognosis and family handout text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -42,6 +42,10 @@ describe("handout text versions", () => {
       item => item.id === "wenn-worte-treffen"
     )?.downloadUrl;
     const dearPdf = materials.find(item => item.id === "dear")?.downloadUrl;
+    const genesungZahlenPdf = materials.find(
+      item => item.id === "genesung-zahlen"
+    )?.downloadUrl;
+    const kinderPdf = materials.find(item => item.id === "kinder")?.downloadUrl;
 
     expect(getHandoutTextVersion("leuchtturm")?.path).toBe(
       "/materialien/text/leuchtturm"
@@ -77,6 +81,12 @@ describe("handout text versions", () => {
       "/materialien/text/wenn-worte-treffen"
     );
     expect(getHandoutTextVersion("dear")?.path).toBe("/materialien/text/dear");
+    expect(getHandoutTextVersion("genesung-zahlen")?.path).toBe(
+      "/materialien/text/genesung-zahlen"
+    );
+    expect(getHandoutTextVersion("kinder")?.path).toBe(
+      "/materialien/text/kinder"
+    );
     expect(getHandoutTextVersionHrefBySource(leuchtturmPdf)).toBe(
       "/materialien/text/leuchtturm"
     );
@@ -112,6 +122,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(dearPdf)).toBe(
       "/materialien/text/dear"
+    );
+    expect(getHandoutTextVersionHrefBySource(genesungZahlenPdf)).toBe(
+      "/materialien/text/genesung-zahlen"
+    );
+    expect(getHandoutTextVersionHrefBySource(kinderPdf)).toBe(
+      "/materialien/text/kinder"
     );
     expect(getHandoutTextVersionBySource("/notfallplan-krise-v03.pdf")).toBe(
       null

--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -93,6 +93,16 @@ describe("MaterialienLibrarySection", () => {
         name: /Textversion lesen: Die DEAR-Technik – Grenzen setzen ohne Vorwürfe/i,
       })
     ).toHaveAttribute("href", "/materialien/text/dear");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Genesung in Zahlen – Was die Forschung zeigt/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/genesung-zahlen");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Wenn Mama oder Papa grosse Gefühle hat/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/kinder");
 
     fireEvent.click(screen.getByRole("button", { name: /Genesung\s*\(1\)/ }));
 

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -220,6 +220,40 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/grenzen");
   });
 
+  it("HandoutTextPage: rendert Genesung-in-Zahlen-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "genesung-zahlen" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Genesung in Zahlen – Was die Forschung zeigt/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Genesung ist möglich\. Sie braucht Zeit/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Genesung/i })
+    ).toHaveAttribute("href", "/genesung");
+  });
+
+  it("HandoutTextPage: rendert Kinder-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "kinder" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Wenn Mama oder Papa grosse Gefühle hat/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Kinder spüren, dass etwas anders ist/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Verstehen/i })
+    ).toHaveAttribute("href", "/verstehen");
+  });
+
   it("HandoutTextPage: rendert Eisberg-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");
@@ -290,6 +324,26 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Wenn Worte treffen/i,
       })
     ).toHaveAttribute("href", "/materialien/text/wenn-worte-treffen");
+  });
+
+  it("Genesung: zeigt Textversion für Genesung in Zahlen", async () => {
+    const { default: Genesung } = await import("@/pages/Genesung");
+    withRouter(<Genesung />);
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Genesung in Zahlen/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/genesung-zahlen");
+  });
+
+  it("Verstehen: zeigt Textversion für Kinder-Handout", async () => {
+    const { default: Verstehen } = await import("@/pages/Verstehen");
+    withRouter(<Verstehen />);
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Wenn Mama oder Papa grosse Gefühle hat/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/kinder");
   });
 
   it("NotFound: rendert 404-Seite", async () => {

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -1027,6 +1027,164 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),
+  createHandoutTextVersion("genesung-zahlen", {
+    kicker: "Textversion",
+    summary:
+      "Langzeitdaten machen Hoffnung: Genesung ist möglich, aber sie braucht Zeit, Rückschläge, Geduld und professionelle Unterstützung.",
+    intro: [
+      "Diese Seite überträgt das Handout «Genesung in Zahlen – Was die Forschung zeigt» in eine lesbare Web-Version. Es richtet sich an Angehörige, die Hoffnung auf belastbare Daten stützen möchten, ohne den Weg zu romantisieren.",
+      "Die Struktur des Originals bleibt erhalten: drei zentrale Kennzahlen, eine grobe zeitliche Einordnung, die Kernaussage des Handouts und drei konkrete Hinweise für den Alltag von Angehörigen.",
+    ],
+    sections: [
+      {
+        title: "Was die Forschung zeigt",
+        cards: [
+          {
+            title: "85–93%",
+            text: "erreichen innerhalb von 10 Jahren eine symptomatische Remission.",
+          },
+          {
+            title: "50%",
+            text: "erreichen eine vollständige Genesung im Sinn von Recovery.",
+          },
+          {
+            title: "77%",
+            text: "zeigen über 16 Jahre eine anhaltende Remission.",
+          },
+        ],
+      },
+      {
+        title: "Zeitliche Orientierung",
+        intro:
+          "Die Zeitachse des Handouts ist keine feste Prognose, sondern eine grobe Orientierung dafür, wie Entwicklung über Jahre statt über Wochen gedacht werden sollte.",
+        cards: [
+          {
+            title: "Jahr 0",
+            text: "Diagnose",
+          },
+          {
+            title: "2–4 Jahre",
+            text: "Erste Remission möglich",
+          },
+          {
+            title: "4–6 Jahre",
+            text: "Stabilere Phasen",
+          },
+          {
+            title: "6–10 Jahre",
+            text: "Hohe Remissionsrate",
+          },
+          {
+            title: "10+ Jahre",
+            text: "Anhaltende Remission",
+          },
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Zentraler Satz des Handouts",
+        calloutText:
+          "Genesung ist möglich. Sie braucht Zeit, Geduld und professionelle Hilfe.",
+      },
+      {
+        title: "Legende",
+        cards: [
+          {
+            title: "Remission",
+            text: "Die Grafik verwendet diesen Begriff für die symptomatische Remission.",
+          },
+          {
+            title: "Recovery",
+            text: "Die Grafik verwendet diesen Begriff für vollständige Genesung.",
+          },
+          {
+            title: "Anhaltende Remission",
+            text: "Die Grafik verwendet diesen Begriff für länger anhaltende Remission.",
+          },
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        bullets: [
+          "Teilen Sie diese Zahlen mit Ihrem Angehörigen, wenn der Moment passt.",
+          "Erinnern Sie sich: Rückfälle gehören zum Prozess.",
+          "Bleiben Sie geduldig – Genesung ist ein Marathon, kein Sprint.",
+        ],
+      },
+    ],
+    sourceLine:
+      "Quelle: Zanarini et al. (2012), McLean Study; Gunderson et al. (2011).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("kinder", {
+    kicker: "Textversion",
+    summary:
+      "Kinder merken meist, dass etwas anders ist. Eine altersgerechte Erklärung schafft Sicherheit, nimmt Schuld und stärkt das Vertrauen.",
+    intro: [
+      "Diese Seite überträgt das Handout «Wenn Mama oder Papa grosse Gefühle hat» in eine lesbare Web-Version. Es richtet sich an Angehörige, die Borderline kindgerecht erklären und Kinder im Familiensystem besser schützen möchten.",
+      "Die Struktur des Originals bleibt erhalten: zuerst die entlastende Grundhaltung, dann altersbezogene Erklärungen, Hinweise für Geschwisterkinder, Schutzfaktoren und ein Merksatz, der Kinder konsequent von Verantwortung entlastet.",
+    ],
+    sections: [
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es im Handout geht",
+        calloutText:
+          "Kinder spüren, dass etwas anders ist – auch wenn niemand darüber spricht. Schweigen schützt sie nicht. Eine altersgerechte Erklärung gibt ihnen Sicherheit, nimmt ihnen die Schuld und stärkt das Vertrauen.",
+      },
+      {
+        title: "So können Sie es erklären – nach Alter",
+        cards: [
+          {
+            title: "4–7 Jahre: Bildsprache",
+            text: "«Mama/Papa hat manchmal ganz grosse Gefühle – wie ein Sturm im Kopf. Das ist nicht deine Schuld. Wir sind für dich da.» Vermeiden Sie das Wort krank und sprechen Sie von grossen Gefühlen.",
+          },
+          {
+            title: "8–12 Jahre: Einfache Erklärung",
+            text: "«Das Gehirn verarbeitet Gefühle anders. Es gibt Fachleute, die helfen. Es ist nicht deine Aufgabe, Mama/Papa besser zu machen.» Benennen Sie klar: Das Kind trägt keine Verantwortung.",
+          },
+          {
+            title: "13+ Jahre: Ehrliches Gespräch",
+            text: "«Mama/Papa hat eine Diagnose, die Borderline heisst. Gefühle werden extrem stark erlebt. Es ist behandelbar. Du darfst Fragen stellen – jederzeit.» Bieten Sie an, gemeinsam verlässliche Infos zu lesen.",
+          },
+        ],
+      },
+      {
+        title: "Wenn ein Geschwisterkind betroffen ist",
+        bullets: [
+          "Unter 12: Dein Bruder/deine Schwester braucht mehr Hilfe. Du bist genauso wichtig.",
+          "12+: Du musst nicht die Rolle der Erwachsenen übernehmen. Deine Gefühle sind erlaubt.",
+        ],
+      },
+      {
+        title: "3 Schutzfaktoren für Kinder",
+        cards: [
+          {
+            title: "Stabilität",
+            text: "Verlässliche Bezugsperson. Routinen beibehalten.",
+          },
+          {
+            title: "Offenheit",
+            text: "Erklären statt schweigen. Gefühle aktiv erfragen.",
+          },
+          {
+            title: "Entlastung",
+            text: "Du bist nicht schuld. Eigene Freiräume geben.",
+          },
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Ein Satz, der immer wieder gesagt werden darf",
+        calloutText:
+          "«Du bist nicht schuld. Und du musst das nicht allein verstehen.» Dieser Satz darf in jeder Altersgruppe fallen – so oft wie nötig.",
+      },
+    ],
+    sourceLine:
+      "Quellen: [1] Lenz, A. (2014): Kinder psychisch kranker Eltern. Hogrefe. [2] Mattejat, F. & Lisofsky, B. (2008): Nicht von schlechten Eltern. Balance Verlag. [3] BApK: Geschwister psychisch erkrankter Menschen.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 09.02.2026.",
+  }),
   createHandoutTextVersion("grenzen-spickzettel", {
     kicker: "Textversion",
     summary:

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -709,6 +709,40 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Genesung in Zahlen",
+    description:
+      "Lesbare Web-Version zu Remission, Recovery, Langzeitdaten und realistisch hoffnungsvollen Prognosezahlen",
+    keywords: [
+      "textversion",
+      "genesung in zahlen",
+      "remission",
+      "recovery",
+      "prognose",
+      "langzeitdaten",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/genesung-zahlen",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Wenn Mama oder Papa grosse Gefühle hat",
+    description:
+      "Lesbare Web-Version zu altersgerechter Erklärung von Borderline, Entlastung von Kindern und Schutzfaktoren im Familiensystem",
+    keywords: [
+      "textversion",
+      "kinder",
+      "mama oder papa",
+      "borderline erklären",
+      "geschwister",
+      "schutzfaktoren",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/kinder",
+    section: "Materialien",
+  },
+  {
     title: "Textversion: Spickzettel Grenzen",
     description:
       "Lesbare Web-Version mit DEAR-Technik, Beispielsätzen für Grenzen und L.M.K.-Exit-Strategie",

--- a/client/src/content/verstehen.ts
+++ b/client/src/content/verstehen.ts
@@ -65,6 +65,18 @@ export const verstehenInfografiken: VerstehenInfografik[] = [
     alt: "Alarm-Modus vs. Denk-Modus",
   },
   {
+    id: "kinder",
+    title: "Wenn Mama oder Papa grosse Gefühle hat",
+    description:
+      "Borderline altersgerecht erklären und Kinder mit Klarheit, Entlastung und Schutz begleiten.",
+    category: "grundlagen",
+    webpUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/PrnKdbomSunLKPVv.webp",
+    pdfUrl:
+      "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/birikKPATMlHGPWf.pdf",
+    alt: "Wenn Mama oder Papa grosse Gefühle hat",
+  },
+  {
     id: "4-phasen",
     title: "Der 4-Phasen-Zyklus",
     description:

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -9,6 +9,7 @@ import {
   ArrowRight,
   BookOpen,
   ExternalLink,
+  FileText,
   Heart,
   Image as ImageIcon,
   RefreshCw,
@@ -22,6 +23,7 @@ import ContentSection from "@/components/ContentSection";
 import { TableOfContents } from "@/components/UXEnhancements";
 import { genesungItems as genesungMaterialItems } from "@/content/genesung";
 import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 function GenesungInfografiken() {
   return (
@@ -29,52 +31,71 @@ function GenesungInfografiken() {
       title="Materialien & Infografiken"
       icon={<ImageIcon className="w-6 h-6 text-sage-dark" />}
       id="infografiken"
+      defaultOpen={true}
       preview="Vertiefende Materialien zu Verlauf, Hoffnung, Rückschritten und der Rolle von Angehörigen."
     >
       <p className="text-muted-foreground mb-6">
-        Vorschau = Web-Bild. «PDF öffnen» öffnet die A4-Druckversion im neuen
-        Tab.
+        Vorschau = Web-Bild. Wenn verfügbar, führt «Textversion» zur lesbaren
+        Web-Version. «PDF öffnen» öffnet die A4-Druckversion im neuen Tab.
       </p>
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        {genesungMaterialItems.map((item, index) => (
-          <Card
-            key={item.title}
-            className={`overflow-hidden border-border/50 hover:shadow-lg transition-all duration-500 group ${
-              genesungMaterialItems.length > 1 && index === 0
-                ? "sm:col-span-2"
-                : ""
-            }`}
-          >
-            <div className="aspect-[3/4] overflow-hidden bg-muted">
-              <img
-                src={item.img}
-                alt={item.title}
-                className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-700"
-                loading="lazy"
-                width={400}
-                height={223}
-                decoding="async"
-              />
-            </div>
-            <CardContent className="p-4">
-              <h3 className="font-semibold text-foreground mb-1">
-                {item.title}
-              </h3>
-              <p className="text-muted-foreground text-sm mb-3">{item.desc}</p>
-              <a
-                href={getHandoutOpenHref(item.pdf) ?? item.pdf}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
-              >
-                <ExternalLink className="w-4 h-4" />
-                PDF öffnen
-              </a>
-            </CardContent>
-          </Card>
-        ))}
+        {genesungMaterialItems.map((item, index) => {
+          const textVersionHref = getHandoutTextVersionHrefBySource(item.pdf);
+
+          return (
+            <Card
+              key={item.title}
+              className={`overflow-hidden border-border/50 hover:shadow-lg transition-all duration-500 group ${
+                genesungMaterialItems.length > 1 && index === 0
+                  ? "sm:col-span-2"
+                  : ""
+              }`}
+            >
+              <div className="aspect-[3/4] overflow-hidden bg-muted">
+                <img
+                  src={item.img}
+                  alt={item.title}
+                  className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-700"
+                  loading="lazy"
+                  width={400}
+                  height={223}
+                  decoding="async"
+                />
+              </div>
+              <CardContent className="p-4">
+                <h3 className="font-semibold text-foreground mb-1">
+                  {item.title}
+                </h3>
+                <p className="text-muted-foreground text-sm mb-3">
+                  {item.desc}
+                </p>
+                <div className="grid gap-2">
+                  {textVersionHref ? (
+                    <Link
+                      href={textVersionHref}
+                      aria-label={`Textversion lesen: ${item.title}`}
+                      className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-sage-dark hover:bg-sage-mid text-white transition-colors"
+                    >
+                      <FileText className="w-4 h-4" />
+                      Textversion
+                    </Link>
+                  ) : null}
+                  <a
+                    href={getHandoutOpenHref(item.pdf) ?? item.pdf}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                    className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                    PDF öffnen
+                  </a>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
       <div className="flex flex-wrap gap-3 justify-center mt-8">
         <Button variant="outline" asChild>

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -1,5 +1,12 @@
 import { useRef, useState, type CSSProperties } from "react";
-import { BookOpen, Brain, Download, ExternalLink, Filter } from "lucide-react";
+import {
+  BookOpen,
+  Brain,
+  Download,
+  ExternalLink,
+  FileText,
+  Filter,
+} from "lucide-react";
 import { motion } from "framer-motion";
 import { Link } from "wouter";
 import { Button } from "@/components/ui/button";
@@ -9,6 +16,7 @@ import {
   type VerstehenMaterialCategory,
 } from "@/content/verstehen";
 import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 
 const verstehenCategories = [
   {
@@ -58,8 +66,9 @@ export default function VerstehenMaterialsSection() {
       </h2>
 
       <p className="text-muted-foreground mb-6">
-        Diese Materialien ergänzen die Seite, ersetzen sie aber nicht. Beginnen
-        Sie mit den Grundlagen, wenn Sie gerade Orientierung brauchen.
+        Diese Materialien ergänzen die Seite, ersetzen sie aber nicht. Wenn
+        verfügbar, führt «Textversion» zur lesbaren Web-Version. Beginnen Sie
+        mit den Grundlagen, wenn Sie gerade Orientierung brauchen.
       </p>
 
       <div className="flex flex-wrap gap-2 mb-6">
@@ -90,47 +99,67 @@ export default function VerstehenMaterialsSection() {
       </div>
 
       <div ref={gridRef} className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        {filteredItems.map(item => (
-          <Card
-            key={item.id}
-            className={`${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""} overflow-hidden hover:shadow-lg transition-shadow`}
-          >
-            <button
-              type="button"
-              className="aspect-[3/4] bg-muted cursor-pointer w-full"
-              onClick={() =>
-                window.open(item.webpUrl, "_blank", "noopener,noreferrer")
-              }
-              aria-label={`${item.alt} – Vorschau öffnen`}
+        {filteredItems.map(item => {
+          const textVersionHref = getHandoutTextVersionHrefBySource(
+            item.pdfUrl
+          );
+
+          return (
+            <Card
+              key={item.id}
+              className={`${item.featured && activeFilter === "alle" ? "md:col-span-2" : ""} overflow-hidden hover:shadow-lg transition-shadow`}
             >
-              <img
-                src={item.webpUrl}
-                alt={item.alt}
-                className="w-full h-full object-cover object-top"
-                loading="lazy"
-                width={400}
-                height={223}
-                decoding="async"
-              />
-            </button>
-            <CardContent className="p-4">
-              <h3 className="font-medium text-foreground mb-1">{item.title}</h3>
-              <p className="text-sm text-muted-foreground mb-3">
-                {item.description}
-              </p>
-              <a
-                href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+              <button
+                type="button"
+                className="aspect-[3/4] bg-muted cursor-pointer w-full"
+                onClick={() =>
+                  window.open(item.webpUrl, "_blank", "noopener,noreferrer")
+                }
+                aria-label={`${item.alt} – Vorschau öffnen`}
               >
-                <ExternalLink className="w-4 h-4" />
-                PDF öffnen
-              </a>
-            </CardContent>
-          </Card>
-        ))}
+                <img
+                  src={item.webpUrl}
+                  alt={item.alt}
+                  className="w-full h-full object-cover object-top"
+                  loading="lazy"
+                  width={400}
+                  height={223}
+                  decoding="async"
+                />
+              </button>
+              <CardContent className="p-4">
+                <h3 className="font-medium text-foreground mb-1">
+                  {item.title}
+                </h3>
+                <p className="text-sm text-muted-foreground mb-3">
+                  {item.description}
+                </p>
+                <div className="grid gap-2">
+                  {textVersionHref ? (
+                    <Link
+                      href={textVersionHref}
+                      aria-label={`Textversion lesen: ${item.title}`}
+                      className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full bg-sage-dark hover:bg-sage-mid text-white transition-colors"
+                    >
+                      <FileText className="w-4 h-4" />
+                      Textversion
+                    </Link>
+                  ) : null}
+                  <a
+                    href={getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+                    className="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium h-9 px-3 w-full border border-input bg-background hover:bg-accent hover:text-accent-foreground transition-colors"
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                    PDF öffnen
+                  </a>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
       </div>
 
       <div className="mt-6 text-center">


### PR DESCRIPTION
## Was sich ändert
- ergänzt neue Web-Textversionen für `genesung-zahlen` und `kinder`
- erweitert den Suchindex um beide neuen Handout-Seiten
- bindet `Genesung in Zahlen` direkt auf der Genesungs-Seite als Textversion an
- bindet `Wenn Mama oder Papa grosse Gefühle hat` zusätzlich in die Verstehen-Materialien ein
- sichert die neuen Routen und UI-Pfade über Registry-, Materialsammlungs- und Smoke-Tests ab

## Warum
Die letzten nicht-akuten bildbasierten Kern-Handouts sollen als lesbare, suchbare und besser zugängliche Web-Versionen verfügbar werden. Dieses Paket deckt den Prognose-/Hoffnungs-Block sowie das Familien-/Kinder-Handout ab und zieht die thematischen Zugänge gleich mit.

## Wirkung
- Angehörige können Prognose- und Kinderinhalte direkt im Browser lesen statt nur als bildbasiertes PDF zu öffnen
- `/genesung` zeigt für `Genesung in Zahlen` nun direkt eine Textversion
- `/verstehen` zeigt das Kinder-Handout nun thematisch mit Textversion statt nur indirekt über die Materialsammlung

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
