### PR TITLE
[codex] add notfallplan text version

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -46,7 +46,13 @@ describe("handout text versions", () => {
       item => item.id === "genesung-zahlen"
     )?.downloadUrl;
     const kinderPdf = materials.find(item => item.id === "kinder")?.downloadUrl;
+    const notfallplanPdf = materials.find(
+      item => item.id === "notfallplan-krise"
+    )?.downloadUrl;
 
+    expect(getHandoutTextVersion("notfallplan-krise")?.path).toBe(
+      "/materialien/text/notfallplan-krise"
+    );
     expect(getHandoutTextVersion("leuchtturm")?.path).toBe(
       "/materialien/text/leuchtturm"
     );
@@ -129,8 +135,11 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersionHrefBySource(kinderPdf)).toBe(
       "/materialien/text/kinder"
     );
-    expect(getHandoutTextVersionBySource("/notfallplan-krise-v03.pdf")).toBe(
-      null
+    expect(getHandoutTextVersionHrefBySource(notfallplanPdf)).toBe(
+      "/materialien/text/notfallplan-krise"
     );
+    expect(
+      getHandoutTextVersionBySource("/notfallplan-krise-v03.pdf")?.path
+    ).toBe("/materialien/text/notfallplan-krise");
   });
 });

--- a/client/src/__tests__/materialien-library.test.tsx
+++ b/client/src/__tests__/materialien-library.test.tsx
@@ -35,6 +35,11 @@ describe("MaterialienLibrarySection", () => {
       "/Notfallkarte-Zuerich-Psychische-Krise.pdf"
     );
     expect(localDownloadLink).toHaveAttribute("download", "");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Notfallplan Krise – Suizidgedanken & Selbstverletzung/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/notfallplan-krise");
 
     const textVersionLink = screen.getByRole("link", {
       name: /Textversion lesen: Der Leuchtturm – Ihre Rolle als Angehörige\/r/i,

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -129,6 +129,23 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/materialien");
   });
 
+  it("HandoutTextPage: rendert Notfallplan-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "notfallplan-krise" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Notfallplan Krise – Suizidgedanken & Selbstverletzung/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Gefahr einschätzen, ruhig bleiben, direkt ansprechen/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Soforthilfe/i })
+    ).toHaveAttribute("href", "/soforthilfe");
+  });
+
   it("HandoutTextPage: rendert Warnsignale-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -102,6 +102,165 @@ function createHandoutTextVersion(
 }
 
 export const handoutTextVersions: HandoutTextVersion[] = [
+  createHandoutTextVersion("notfallplan-krise", {
+    kicker: "Textversion",
+    summary:
+      "Konkrete Orientierung für Angehörige bei Suizidgedanken, Selbstverletzung oder akuter seelischer Krise: Gefahr einschätzen, ruhig bleiben, direkt ansprechen und Hilfe einbeziehen.",
+    intro: [
+      "Diese Seite überträgt den «Notfallplan bei psychischer Krise» in eine lesbare Web-Version. Sie hält die Struktur des PDFs bewusst eng bei, damit die Orientierung auch ohne Vorschau oder Download zugänglich bleibt.",
+      "Der Notfallplan richtet sich an Angehörige, wenn Suizidgedanken, Selbstverletzung oder eine akute psychische Krise im Raum stehen. Er ersetzt keine professionelle Beurteilung, soll aber helfen, in einer belastenden Situation klarer zu handeln.",
+    ],
+    sections: [
+      {
+        title: "Akute Gefahr? Sofort handeln.",
+        intro: "Sofort 144 anrufen, wenn die Person:",
+        bullets: [
+          "sich gerade verletzt",
+          "eine Überdosis eingenommen hat oder eine schwere Intoxikation vermutet wird",
+          "bewusstlos ist",
+          "einen konkreten Suizidplan äussert oder unmittelbar in Gefahr ist",
+        ],
+      },
+      {
+        title: "Wichtige Nummern im Akutfall",
+        cards: [
+          {
+            title: "144 Sanität",
+            text: "Akute Lebensgefahr, laufende Suizidhandlung, schwere Selbstverletzung, Bewusstlosigkeit oder schwere Intoxikation.",
+          },
+          {
+            title: "0800 33 66 55 – Ärztefon",
+            text: "Dringende medizinische oder psychiatrische Notfall-Triage, 24/7.",
+          },
+          {
+            title: "058 384 20 00 – PUK Zürich Notfall Erwachsene",
+            text: "Direkte psychiatrische Notfallstelle, 24/7.",
+          },
+        ],
+      },
+      {
+        title: "Wichtiger Soforthinweis",
+        calloutTitle: "Sicherheit vor Diskussion",
+        calloutText:
+          "Person möglichst nicht allein lassen. Gefährliche Gegenstände, Medikamente, Alkohol oder andere Mittel wenn möglich entfernen. Bei Unsicherheit lieber einmal zu viel Hilfe holen als einmal zu wenig.",
+      },
+      {
+        title:
+          "4 Schritte in der Krise – wenn jemand Suizidgedanken äussert oder sich selbst verletzt",
+        cards: [
+          {
+            title: "1. Ruhe bewahren",
+            text: "Ihre Angst ist verständlich. Panik, hektisches Sprechen oder Druck verstärken die Krise oft zusätzlich. Atmen Sie bewusst, sprechen Sie langsam und bleiben Sie so ruhig wie möglich. Ihre Ruhe kann der betroffenen Person vorübergehend Halt geben.",
+          },
+          {
+            title: "2. Ernst nehmen und direkt ansprechen",
+            text: "Jede Äusserung über Suizid oder Selbstverletzung sollte ernst genommen werden. Sprechen Sie das Thema offen und klar an – das erhöht das Risiko nicht, sondern kann entlastend sein. Beispiele: «Ich habe gehört, was du gesagt hast. Ich nehme das ernst.» und «Denkst du daran, dir etwas anzutun?»",
+          },
+          {
+            title: "3. Zuhören und Gefühle anerkennen",
+            text: "Hören Sie zu, ohne vorschnell zu beruhigen, zu argumentieren oder sofort Lösungen anzubieten. Es geht zuerst darum, die Not wahrzunehmen. Beispiele: «Ich sehe, dass es dir gerade sehr schlecht geht.» und «Du musst das gerade nicht allein aushalten.»",
+          },
+          {
+            title: "4. Professionelle Hilfe einbeziehen",
+            text: "Sie müssen diese Situation nicht allein tragen. Ziehen Sie frühzeitig professionelle Hilfe bei. Informieren Sie wenn möglich die behandelnde Fachperson oder nutzen Sie die Notfallnummern. Suizidgedanken und akute Selbstgefährdung sollten nicht als Geheimnis mitgetragen werden.",
+          },
+        ],
+      },
+      {
+        title: "Das hilft",
+        bullets: [
+          "ruhig bleiben und dableiben",
+          "direkt und klar nachfragen",
+          "Gefühle ernst nehmen und anerkennen",
+          "Gefährdung einschätzen und Hilfe holen",
+          "Fachpersonen oder Notfallstellen einbeziehen",
+          "konkrete Sicherheit vor Diskussion stellen",
+        ],
+      },
+      {
+        title: "Das schadet eher",
+        bullets: [
+          "Panik, Vorwürfe oder Druck",
+          "bagatellisieren oder ablenken",
+          "lange Diskussionen, warum das Leben doch schön sei",
+          "argumentieren oder überzeugen wollen",
+          "drohen oder bestrafen",
+          "die Person trotz akuter Gefahr allein lassen",
+          "Suizidgedanken als Geheimnis für sich behalten",
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Leitsatz für die Akutsituation",
+        calloutText:
+          "«Ich nehme dich ernst. Ich bin da. Und ich hole Hilfe – für dich und für mich.»",
+      },
+      {
+        title: "Nach der akuten Situation",
+        intro:
+          "Auch wenn sich die Lage zunächst beruhigt hat, ist die Krise oft noch nicht vorbei. Wichtig ist danach:",
+        bullets: [
+          "behandelnde Fachperson informieren",
+          "gemeinsam überlegen, was jetzt Sicherheit gibt",
+          "Unterstützung auch für Angehörige organisieren",
+          "nächste Stunden und Nacht nicht dem Zufall überlassen",
+          "Warnzeichen und Auslöser festhalten",
+        ],
+      },
+      {
+        title: "Selbstfürsorge für Angehörige",
+        intro:
+          "Auch Sie brauchen Unterstützung. Krisen belasten Angehörige stark – das ist normal und kein Zeichen von Schwäche.",
+        bullets: [
+          "eigene Belastungsgrenze wahrnehmen",
+          "Gespräch mit eigener Fachperson suchen",
+          "nicht alles allein tragen müssen",
+          "Fachstelle Angehörigenarbeit PUK kontaktieren",
+          "Dargebotene Hand 143 – auch für Angehörige",
+          "eigene Gefühle (Angst, Wut, Erschöpfung) zulassen",
+        ],
+      },
+      {
+        title: "Notfallnummern – Kurzreferenz",
+        cards: [
+          {
+            title: "144 – Sanität",
+            text: "Akute Lebensgefahr.",
+          },
+          {
+            title: "0800 33 66 55 – Ärztefon",
+            text: "Triage 24/7.",
+          },
+          {
+            title: "058 384 20 00 – PUK Notfall Erwachsene",
+            text: "Psychiatrischer Notfall, 24/7.",
+          },
+          {
+            title: "143 – Dargebotene Hand",
+            text: "Anonym, 24/7.",
+          },
+          {
+            title: "117 – Polizei",
+            text: "Bedrohung oder Gewalt.",
+          },
+          {
+            title: "058 384 38 00 – Fachstelle Angehörigenarbeit PUK",
+            text: "Unterstützung für Angehörige.",
+          },
+        ],
+      },
+      {
+        title: "Wichtiger Hinweis",
+        calloutTitle: "Orientierung, kein Ersatz für Notfallbeurteilung",
+        calloutText:
+          "Dieser Notfallplan ersetzt keine professionelle Beurteilung und keine psychiatrische Diagnose. Er dient der Orientierung in einer akuten Situation. Bei akuter Lebensgefahr sofort 144 anrufen.",
+      },
+    ],
+    sourceLine:
+      "Quellen: Gunderson & Berkowitz, BPD Family Guidelines (NEABPD); Project Air Strategy, Understanding Self-Harm & Suicidal Thinking for Families & Carers.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 10.03.2026.",
+  }),
   createHandoutTextVersion("leuchtturm", {
     kicker: "Textversion",
     summary:

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -394,6 +394,24 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Notfallplan Krise",
+    description:
+      "Lesbare Web-Version des Akut-Handouts mit Sofortschritten bei Suizidgedanken, Selbstverletzung und psychischer Krise",
+    keywords: [
+      "textversion",
+      "notfallplan",
+      "suizidgedanken",
+      "selbstverletzung",
+      "psychische krise",
+      "soforthilfe",
+      "angehörige",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/notfallplan-krise",
+    section: "Materialien",
+  },
+  {
     title: "Der Leuchtturm: Ihre Rolle als Angehörige/r",
     description:
       "Infografik: Orientierung, Verlässlichkeit und Selbstschutz in der Angehörigenrolle",


### PR DESCRIPTION
## Was geändert wurde
- eine lesbare Web-Textversion für `notfallplan-krise` in `client/src/content/handoutTextVersions.ts` ergänzt
- Suchindex und Materialsammlung so erweitert, dass der Kern-Flyer jetzt eine `Textversion lesen`-Route unter `/materialien/text/notfallplan-krise` anbietet
- Regressionstests für Source-Mapping, Materialbibliothek und Handout-Render ergänzt

## Warum
Der verbleibende Kern-Flyer im Akutbereich war bisher nur als PDF verfügbar. Dadurch fehlte für Suche, Copy/Paste und barriereärmeres Lesen noch ein konsistenter Web-Pfad, obwohl die übrigen Kern-Handouts bereits als Textversionen vorlagen.

`notfallkarte-zuerich` ist bewusst nicht Teil dieses PRs, weil dafür bereits die bestehende HTML-Notfallkarte `/notfallkarte.html` als zugänglicher Primärpfad existiert.

## Wirkung
- konsistente Textversions-Abdeckung für den letzten noch fehlenden Kern-Flyer im Materialbereich
- bessere Zugänglichkeit für Angehörige in Akutsituationen
- Suchbarkeit des Inhalts ohne PDF-Öffnen

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
