### PR TITLE
[codex] add verstehen text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -5,6 +5,7 @@ import {
   getHandoutTextVersionHrefBySource,
 } from "@/content/handoutTextVersions";
 import { materials } from "@/content/materialien";
+import { verstehenInfografiken } from "@/content/verstehen";
 
 describe("handout text versions", () => {
   it("maps known remote handouts to text version routes", () => {
@@ -49,6 +50,12 @@ describe("handout text versions", () => {
     const notfallplanPdf = materials.find(
       item => item.id === "notfallplan-krise"
     )?.downloadUrl;
+    const vierPhasenPdf = verstehenInfografiken.find(
+      item => item.id === "4-phasen"
+    )?.pdfUrl;
+    const gehirnPdf = verstehenInfografiken.find(
+      item => item.id === "gehirn"
+    )?.pdfUrl;
 
     expect(getHandoutTextVersion("notfallplan-krise")?.path).toBe(
       "/materialien/text/notfallplan-krise"
@@ -89,6 +96,12 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersion("dear")?.path).toBe("/materialien/text/dear");
     expect(getHandoutTextVersion("genesung-zahlen")?.path).toBe(
       "/materialien/text/genesung-zahlen"
+    );
+    expect(getHandoutTextVersion("4-phasen")?.path).toBe(
+      "/materialien/text/4-phasen"
+    );
+    expect(getHandoutTextVersion("gehirn")?.path).toBe(
+      "/materialien/text/gehirn"
     );
     expect(getHandoutTextVersion("kinder")?.path).toBe(
       "/materialien/text/kinder"
@@ -131,6 +144,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(genesungZahlenPdf)).toBe(
       "/materialien/text/genesung-zahlen"
+    );
+    expect(getHandoutTextVersionHrefBySource(vierPhasenPdf)).toBe(
+      "/materialien/text/4-phasen"
+    );
+    expect(getHandoutTextVersionHrefBySource(gehirnPdf)).toBe(
+      "/materialien/text/gehirn"
     );
     expect(getHandoutTextVersionHrefBySource(kinderPdf)).toBe(
       "/materialien/text/kinder"

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -271,6 +271,42 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/verstehen");
   });
 
+  it("HandoutTextPage: rendert 4-Phasen-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "4-phasen" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Der 4-Phasen-Zyklus/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Freundlichkeit, Verschlechterung, Explosion und Schweigen/i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Verstehen/i })
+    ).toHaveAttribute("href", "/verstehen");
+  });
+
+  it("HandoutTextPage: rendert Gehirn-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "gehirn" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Das Gehirn verstehen/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Emotionale Überflutung ist keine Absicht/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Verstehen/i })
+    ).toHaveAttribute("href", "/verstehen");
+  });
+
   it("HandoutTextPage: rendert Eisberg-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");
@@ -353,9 +389,19 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/materialien/text/genesung-zahlen");
   });
 
-  it("Verstehen: zeigt Textversion für Kinder-Handout", async () => {
+  it("Verstehen: zeigt Textversionen für Verstehen-Handouts", async () => {
     const { default: Verstehen } = await import("@/pages/Verstehen");
     withRouter(<Verstehen />);
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Der 4-Phasen-Zyklus/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/4-phasen");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Das Gehirn verstehen/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/gehirn");
     expect(
       screen.getByRole("link", {
         name: /Textversion lesen: Wenn Mama oder Papa grosse Gefühle hat/i,

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -3,6 +3,7 @@ import {
   type MaterialCategory,
   type MaterialItem,
 } from "./materialien";
+import { verstehenInfografiken } from "./verstehen";
 
 export interface HandoutTextCard {
   title: string;
@@ -52,20 +53,37 @@ const TOPIC_META: Record<
 
 function requireMaterial(id: string) {
   const material = materials.find(item => item.id === id);
-  if (!material) {
-    throw new Error(`Unknown material item: ${id}`);
+  if (material) {
+    const pdfSourceUrl = material.pdfUrl ?? material.downloadUrl;
+    if (!pdfSourceUrl) {
+      throw new Error(`Material item is missing a PDF source: ${id}`);
+    }
+
+    return {
+      title: material.title,
+      description: material.description,
+      category: material.category,
+      kind: material.kind,
+      previewImageUrl: material.url,
+      topic: TOPIC_META[material.category],
+      pdfSourceUrl,
+    };
   }
 
-  const pdfSourceUrl = material.pdfUrl ?? material.downloadUrl;
-  if (!pdfSourceUrl) {
-    throw new Error(`Material item is missing a PDF source: ${id}`);
+  const verstehenMaterial = verstehenInfografiken.find(item => item.id === id);
+  if (verstehenMaterial) {
+    return {
+      title: verstehenMaterial.title,
+      description: verstehenMaterial.description,
+      category: "verstehen" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: verstehenMaterial.webpUrl,
+      topic: TOPIC_META.verstehen,
+      pdfSourceUrl: verstehenMaterial.pdfUrl,
+    };
   }
 
-  return {
-    material,
-    topic: TOPIC_META[material.category],
-    pdfSourceUrl,
-  };
+  throw new Error(`Unknown material item: ${id}`);
 }
 
 function createHandoutTextVersion(
@@ -84,18 +102,26 @@ function createHandoutTextVersion(
     | "pdfSourceUrl"
   >
 ): HandoutTextVersion {
-  const { material, topic, pdfSourceUrl } = requireMaterial(id);
+  const {
+    title,
+    description,
+    category,
+    kind,
+    previewImageUrl,
+    topic,
+    pdfSourceUrl,
+  } = requireMaterial(id);
 
   return {
     id,
     path: `/materialien/text/${id}`,
-    title: material.title,
-    description: material.description,
+    title,
+    description,
     topicLabel: topic.label,
     topicHref: topic.href,
-    category: material.category,
-    kind: material.kind,
-    previewImageUrl: material.url,
+    category,
+    kind,
+    previewImageUrl,
     pdfSourceUrl,
     ...config,
   };
@@ -763,6 +789,163 @@ export const handoutTextVersions: HandoutTextVersion[] = [
       },
     ],
     sourceLine: "Quelle: Porges (2011), Polyvagal-Theorie; Linehan (1993).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("4-phasen", {
+    kicker: "Textversion",
+    summary:
+      "Freundlichkeit, Verschlechterung, Explosion und Schweigen können sich als wiederkehrender Zyklus verstärken. Entscheidend ist, das Muster früh zu erkennen und in Phase 2 anders zu reagieren.",
+    intro: [
+      "Diese Seite überträgt die Infografik «Der 4-Phasen-Zyklus» in eine lesbare Web-Version. Sie zeigt ein wiederkehrendes Muster, das in belasteten Beziehungen immer wieder auftreten kann.",
+      "Die Grafik versteht den Zyklus nicht als fixes Schicksal, sondern als Muster, das erkannt und unterbrochen werden kann. Genau dort liegt der entlastende Kern für Angehörige.",
+    ],
+    sections: [
+      {
+        title: "Die 4 Phasen",
+        intro:
+          "Die Infografik beschreibt vier Zustände, die sich gegenseitig verstärken und im Kreis wiederholen können.",
+        cards: [
+          {
+            title: "Phase 1: Freundlichkeit",
+            text: "Alles scheint gut. Nähe, Harmonie.",
+          },
+          {
+            title: "Phase 2: Verschlechterung",
+            text: "Spannung steigt. Reizbarkeit, Rückzug, Misstrauen.",
+          },
+          {
+            title: "Phase 3: Explosion",
+            text: "Krise. Vorwürfe, Drohungen, Kontrollverlust.",
+          },
+          {
+            title: "Phase 4: Schweigen",
+            text: "Rückzug. Schuldgefühle. Erschöpfung.",
+          },
+        ],
+      },
+      {
+        title: "Verstärkende Schleife",
+        calloutTitle: "Warum sich das Muster so fest anfühlen kann",
+        calloutText:
+          "Die Grafik zeigt den Zyklus als verstärkende Schleife: Jede Phase bereitet oft schon den Boden für die nächste, wenn niemand das Muster bewusst unterbricht.",
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es beim 4-Phasen-Zyklus geht",
+        calloutText:
+          "Der Zyklus wiederholt sich – bis jemand das Muster durchbricht. Das können Sie sein.",
+      },
+      {
+        title: "Legende der Grafik",
+        bullets: [
+          "Sage = Freundlichkeit",
+          "Sand = Verschlechterung",
+          "Terracotta = Explosion",
+          "Slate = Schweigen",
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "Erkennen",
+            text: "In welcher Phase sind wir gerade?",
+          },
+          {
+            title: "Verstehen",
+            text: "Der Zyklus ist ein Muster, kein Schicksal.",
+          },
+          {
+            title: "Verändern",
+            text: "Reagieren Sie in Phase 2 anders als früher.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Mason/Kreger (2014).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("gehirn", {
+    kicker: "Textversion",
+    summary:
+      "Bei emotionaler Überflutung übernimmt das Alarm-System. Das Denken kommt erst zurück, wenn der Körper wieder etwas ruhiger ist.",
+    intro: [
+      "Diese Seite überträgt die Infografik «Das Gehirn verstehen» in eine lesbare Web-Version. Sie erklärt in einfacher Form, was bei emotionaler Überflutung im Gehirn passiert.",
+      "Für Angehörige ist die Grafik vor allem als Einordnungshilfe gedacht: Überflutung ist keine Absicht, sondern eine neurobiologische Reaktion. Deshalb hilft zuerst Beruhigung und erst danach Klärung.",
+    ],
+    sections: [
+      {
+        title: "Die drei Bereiche der Grafik",
+        intro:
+          "Die Infografik stellt drei Hirn-Bereiche mit ihren Funktionen und ihrer Rolle unter Stress gegenüber.",
+        cards: [
+          {
+            title: "Amygdala – Alarm-Zentrale",
+            text: "Reagiert auf Bedrohung. Löst Kampf- oder Flucht aus. Bei BPS: überaktiv, reagiert stärker und schneller.",
+          },
+          {
+            title: "Hippocampus – Erinnerungsspeicher",
+            text: "Ordnet Erlebnisse zeitlich ein. Unterscheidet Vergangenheit von Gegenwart. Bei Stress: Funktion eingeschränkt.",
+          },
+          {
+            title: "Präfrontaler Kortex – Denk-Zentrale",
+            text: "Planung, Impulskontrolle, Reflexion. Bei Überflutung: vorübergehend offline.",
+          },
+        ],
+      },
+      {
+        title: "Was dann oft passiert",
+        cards: [
+          {
+            title: "Überflutet",
+            text: "Die Alarmreaktion übernimmt, und der innere Spielraum wird klein.",
+          },
+          {
+            title: "Beruhigung fehlt",
+            text: "Ohne Beruhigung bleibt das System in Alarm oder Übergang hängen.",
+          },
+          {
+            title: "Beruhigung → Denken kommt zurück",
+            text: "Wenn der Körper ruhiger wird, wird Denken wieder zugänglicher.",
+          },
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es bei der Überflutung geht",
+        calloutText:
+          "Emotionale Überflutung ist keine Absicht, sondern eine neurobiologische Reaktion. Das Gehirn braucht Zeit, um wieder klar zu denken.",
+      },
+      {
+        title: "Legende der Grafik",
+        bullets: [
+          "Terracotta = Alarm",
+          "Sand = Übergang",
+          "Sage = Beruhigung",
+          "Pfeile = Wirkungsrichtung",
+        ],
+      },
+      {
+        title: "3 Schritte zur Beruhigung",
+        cards: [
+          {
+            title: "1. Atmen und Wahrnehmen",
+            text: "4 Sekunden ein, 6 Sekunden aus. Benennen Sie, was Sie spüren.",
+          },
+          {
+            title: "2. Pausieren und Bewegen",
+            text: "Raum wechseln, kurz gehen, Wasser trinken.",
+          },
+          {
+            title: "3. Fokus und Einordnen",
+            text: "Erst wenn der Körper ruhig ist, kann das Gespräch weitergehen.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Porges (2011); LeDoux (1996).",
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -642,6 +642,44 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Der 4-Phasen-Zyklus",
+    description:
+      "Lesbare Web-Version zum wiederkehrenden Beziehungszyklus mit 4 Phasen, Kernaussage und möglichen Ansatzpunkten für Angehörige",
+    keywords: [
+      "textversion",
+      "4-phasen-zyklus",
+      "zyklus",
+      "freundlichkeit",
+      "verschlechterung",
+      "explosion",
+      "schweigen",
+      "verstehen",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/4-phasen",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Das Gehirn verstehen",
+    description:
+      "Lesbare Web-Version zu Amygdala, Hippocampus, präfrontalem Kortex und 3 Schritten zur Beruhigung bei Überflutung",
+    keywords: [
+      "textversion",
+      "gehirn verstehen",
+      "amygdala",
+      "hippocampus",
+      "präfrontaler kortex",
+      "überflutung",
+      "beruhigung",
+      "neurobiologie",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/gehirn",
+    section: "Materialien",
+  },
+  {
     title: "Textversion: Warnsignale der Überlastung",
     description:
       "Lesbare Web-Version des Ampel-Handouts zu Überlastung, Frühwarnzeichen und nächsten Schritten",


### PR DESCRIPTION
## Was geändert wurde
- zwei neue lesbare Web-Textversionen ergänzt: `Der 4-Phasen-Zyklus` und `Das Gehirn verstehen`
- Source-Mapping in `client/src/content/handoutTextVersions.ts` so erweitert, dass neben `materials` auch `verstehenInfografiken` direkt als Handout-Quelle aufgelöst werden können
- Suchindex und Smoke-/Mapping-Tests für die neuen Verstehen-CTAs ergänzt

## Warum
Diese beiden `Verstehen`-Handouts waren bisher nur als bildbasierte PDF/WebP-Fassung eingebunden. Dadurch fehlten Suchbarkeit, Copy/Paste und eine lesbare Web-Alternative, obwohl genau diese Inhalte für Orientierung und Psychoedukation zentral sind.

## Wirkung
- neue Textpfade unter `/materialien/text/4-phasen` und `/materialien/text/gehirn`
- automatische `Textversion`-CTAs im Verstehen-Bereich ohne zusätzlichen UI-Sonderweg
- bessere A11y-Abdeckung für zwei weitere Kern-Infografiken ohne Änderung an der PDF-Auslieferung

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
