### PR TITLE
[codex] add unterstuetzen text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -5,6 +5,7 @@ import {
   getHandoutTextVersionHrefBySource,
 } from "@/content/handoutTextVersions";
 import { materials } from "@/content/materialien";
+import { unterstuetzenItems } from "@/content/unterstuetzen";
 import { verstehenInfografiken } from "@/content/verstehen";
 
 describe("handout text versions", () => {
@@ -50,6 +51,12 @@ describe("handout text versions", () => {
     const notfallplanPdf = materials.find(
       item => item.id === "notfallplan-krise"
     )?.downloadUrl;
+    const imKrisenmodusPdf = unterstuetzenItems.find(
+      item => item.id === "im-krisenmodus"
+    )?.pdfUrl;
+    const dreiSaeulenPdf = unterstuetzenItems.find(
+      item => item.id === "drei-saeulen"
+    )?.pdfUrl;
     const vierPhasenPdf = verstehenInfografiken.find(
       item => item.id === "4-phasen"
     )?.pdfUrl;
@@ -74,6 +81,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersion("rolle-klaeren")?.path).toBe(
       "/materialien/text/rolle-klaeren"
+    );
+    expect(getHandoutTextVersion("im-krisenmodus")?.path).toBe(
+      "/materialien/text/im-krisenmodus"
+    );
+    expect(getHandoutTextVersion("drei-saeulen")?.path).toBe(
+      "/materialien/text/drei-saeulen"
     );
     expect(getHandoutTextVersion("krisenkommunikation")?.path).toBe(
       "/materialien/text/krisenkommunikation"
@@ -120,6 +133,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(rolleKlaerenPdf)).toBe(
       "/materialien/text/rolle-klaeren"
+    );
+    expect(getHandoutTextVersionHrefBySource(imKrisenmodusPdf)).toBe(
+      "/materialien/text/im-krisenmodus"
+    );
+    expect(getHandoutTextVersionHrefBySource(dreiSaeulenPdf)).toBe(
+      "/materialien/text/drei-saeulen"
     );
     expect(getHandoutTextVersionHrefBySource(krisenPdf)).toBe(
       "/materialien/text/krisenkommunikation"

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -146,6 +146,42 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/soforthilfe");
   });
 
+  it("HandoutTextPage: rendert Krisenmodus-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "im-krisenmodus" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Im Krisenmodus – Orientierung geben/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /In der Krise hilft weniger Logik – mehr Ruhe, Präsenz und Orientierung\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Unterstützen/i })
+    ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
+  });
+
+  it("HandoutTextPage: rendert Drei-Säulen-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "drei-saeulen" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Drei Säulen hilfreicher Unterstützung/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Präsenz, Stabilität und Grenze sind drei Säulen/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Unterstützen/i })
+    ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
+  });
+
   it("HandoutTextPage: rendert Warnsignale-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");
@@ -407,6 +443,22 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Wenn Mama oder Papa grosse Gefühle hat/i,
       })
     ).toHaveAttribute("href", "/materialien/text/kinder");
+  });
+
+  it("Unterstützen: zeigt Textversionen für Unterstützen-Handouts", async () => {
+    const { default: UnterstuetzenUebersicht } =
+      await import("@/pages/UnterstuetzenUebersicht");
+    withRouter(<UnterstuetzenUebersicht />);
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Im Krisenmodus – Orientierung geben/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/im-krisenmodus");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Drei Säulen hilfreicher Unterstützung/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/drei-saeulen");
   });
 
   it("NotFound: rendert 404-Seite", async () => {

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -3,6 +3,7 @@ import {
   type MaterialCategory,
   type MaterialItem,
 } from "./materialien";
+import { unterstuetzenItems } from "./unterstuetzen";
 import { verstehenInfografiken } from "./verstehen";
 
 export interface HandoutTextCard {
@@ -80,6 +81,19 @@ function requireMaterial(id: string) {
       previewImageUrl: verstehenMaterial.webpUrl,
       topic: TOPIC_META.verstehen,
       pdfSourceUrl: verstehenMaterial.pdfUrl,
+    };
+  }
+
+  const unterstuetzenMaterial = unterstuetzenItems.find(item => item.id === id);
+  if (unterstuetzenMaterial) {
+    return {
+      title: unterstuetzenMaterial.title,
+      description: unterstuetzenMaterial.title,
+      category: "unterstuetzen" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: unterstuetzenMaterial.url,
+      topic: TOPIC_META.unterstuetzen,
+      pdfSourceUrl: unterstuetzenMaterial.pdfUrl,
     };
   }
 
@@ -462,6 +476,126 @@ export const handoutTextVersions: HandoutTextVersion[] = [
       },
     ],
     sourceLine: "Quelle: Gunderson et al., Family Guidelines; Kreger (2014).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("im-krisenmodus", {
+    kicker: "Textversion",
+    summary:
+      "In der Krise hilft weniger Logik, dafür mehr Ruhe, Präsenz und Orientierung. Ihre ruhige Haltung kann helfen, von Überforderung zu mehr Sicherheit zurückzufinden.",
+    intro: [
+      "Diese Seite überträgt die Infografik «Im Krisenmodus – Orientierung geben» in eine lesbare Web-Version. Die Grafik ist bewusst knapp: Krise und beruhigter Zustand werden gegenübergestellt, verbunden durch Ihre Ruhe und Präsenz.",
+      "Für Angehörige ist die Kernaussage klar: In akuter Überforderung bringt langes Erklären oft wenig. Wichtiger sind ein ruhiger Ton, Präsenz und das Verschieben schwieriger Diskussionen.",
+    ],
+    sections: [
+      {
+        title: "Von Krise zu Beruhigung",
+        intro:
+          "Die Infografik stellt zwei Zustände gegenüber und markiert den Übergang dazwischen.",
+        cards: [
+          {
+            title: "Krise",
+            text: "überwältigt, verängstigt, impulsiv",
+          },
+          {
+            title: "Ihr Beitrag",
+            text: "Ihre Ruhe + Präsenz",
+          },
+          {
+            title: "Beruhigt",
+            text: "orientiert, verbunden, sicherer",
+          },
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Worum es im Krisenmodus geht",
+        calloutText:
+          "In der Krise hilft weniger Logik – mehr Ruhe, Präsenz und Orientierung.",
+      },
+      {
+        title: "Mini-Legende",
+        bullets: [
+          "Symbol = emotionaler Zustand",
+          "Pfeil = Übergang durch Ihr Verhalten",
+          "Herz = beruhigter Zustand",
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Atmen Sie durch",
+            text: "Atmen Sie durch und sprechen Sie leise und langsam.",
+          },
+          {
+            title: "2. Präsenzsatz sagen",
+            text: "Sagen Sie einen Präsenzsatz: «Ich bin da. Wir schaffen das.»",
+          },
+          {
+            title: "3. Diskussion verschieben",
+            text: "Verschieben Sie Diskussionen: «Wir reden später – jetzt beruhigen wir uns.»",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Psychoedukation, Angehörigenarbeit (DBT-nah).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("drei-saeulen", {
+    kicker: "Textversion",
+    summary:
+      "Präsenz, Stabilität und Grenze sind drei Säulen, die Angehörigen Halt geben und die Beziehung stärken. Hilfreiche Unterstützung braucht alle drei zusammen.",
+    intro: [
+      "Diese Seite überträgt die Infografik «Drei Säulen hilfreicher Unterstützung» in eine lesbare Web-Version. Das Handout bündelt Angehörigen-Haltung in drei einfache Grundpfeiler.",
+      "Die Grafik ist als praktische Orientierung gedacht: zugewandt bleiben, innerlich ruhig bleiben und gleichzeitig den eigenen Schutz nicht verlieren.",
+    ],
+    sections: [
+      {
+        title: "Die drei Säulen",
+        intro:
+          "Die Infografik beschreibt drei Haltungen, die sich ergänzen und zusammen tragfähige Unterstützung ermöglichen.",
+        cards: [
+          {
+            title: "Präsenz – Ich bin da.",
+            text: "Gefühl zeigen. Zuverlässig sein.",
+          },
+          {
+            title: "Stabilität – Ich bleibe ruhig.",
+            text: "Klare Haltung. Nicht mitreissen lassen.",
+          },
+          {
+            title: "Grenze – Ich schütze mich.",
+            text: "Eigene Bedürfnisse. Nein sagen können.",
+          },
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es bei den drei Säulen geht",
+        calloutText:
+          "Präsenz, Stabilität und Grenze – drei Säulen, die Angehörigen Halt geben und die Beziehung stärken.",
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Wählen",
+            text: "Wählen Sie eine Säule für diese Woche.",
+          },
+          {
+            title: "2. Üben",
+            text: "Üben Sie in kleinen Situationen.",
+          },
+          {
+            title: "3. Reflektieren",
+            text: "Reflektieren Sie abends: Was hat geholfen?",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Mason/Kreger (2014); Gunderson (2011).",
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -444,6 +444,24 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Im Krisenmodus – Orientierung geben",
+    description:
+      "Lesbare Web-Version zur Deeskalation mit Ruhe, Präsenz, Mini-Legende und 3 konkreten Schritten für Angehörige",
+    keywords: [
+      "textversion",
+      "krisenmodus",
+      "orientierung geben",
+      "präsenz",
+      "ruhe",
+      "deeskalation",
+      "unterstützen",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/im-krisenmodus",
+    section: "Materialien",
+  },
+  {
     title: "Textversion: Ihre Rolle klären",
     description:
       "Lesbare Web-Version zur Angehörigenrolle mit Abgrenzung zwischen eigenem Beitrag, professioneller Hilfe und klaren Grenzen",
@@ -458,6 +476,24 @@ export const searchableContent: SearchEntry[] = [
       "pdf",
     ],
     href: "/materialien/text/rolle-klaeren",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Drei Säulen hilfreicher Unterstützung",
+    description:
+      "Lesbare Web-Version zu Präsenz, Stabilität, Grenze und drei kleinen Übungsschritten für Angehörige",
+    keywords: [
+      "textversion",
+      "drei säulen",
+      "präsenz",
+      "stabilität",
+      "grenze",
+      "unterstützung",
+      "angehörigen-haltung",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/drei-saeulen",
     section: "Materialien",
   },
   {

--- a/client/src/content/unterstuetzen.ts
+++ b/client/src/content/unterstuetzen.ts
@@ -9,6 +9,7 @@ export const unterstuetzenSubcategories = [
 
 export const unterstuetzenItems = [
   {
+    id: "im-krisenmodus",
     title: "Im Krisenmodus – Orientierung geben",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/gOumJSiPiJFGkSFy.webp",
     pdfUrl:
@@ -16,6 +17,7 @@ export const unterstuetzenItems = [
     category: "grundlagen",
   },
   {
+    id: "rolle-klaeren-unterstuetzen",
     title: "Ihre Rolle klären",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WUiQpUWjKIjpSRDC.webp",
     pdfUrl:
@@ -23,6 +25,7 @@ export const unterstuetzenItems = [
     category: "grundlagen",
   },
   {
+    id: "drei-saeulen",
     title: "Drei Säulen hilfreicher Unterstützung",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/WuCBUdnlHakpSnbY.webp",
     pdfUrl:
@@ -30,6 +33,7 @@ export const unterstuetzenItems = [
     category: "grundlagen",
   },
   {
+    id: "konsistenz-prinzip",
     title: "Konsistenz-Prinzip",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/MCMaGcrhifsekEqb.webp",
     pdfUrl:
@@ -37,6 +41,7 @@ export const unterstuetzenItems = [
     category: "haltung",
   },
   {
+    id: "beziehungs-achtsamkeit",
     title: "Beziehungs-Achtsamkeit",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/toOMoXhzHiaZUlBg.webp",
     pdfUrl:
@@ -44,6 +49,7 @@ export const unterstuetzenItems = [
     category: "haltung",
   },
   {
+    id: "6-leitlinien",
     title: "6 Leitlinien für Angehörige",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/OfOPUMQpHXrpSPgw.webp",
     pdfUrl:
@@ -51,6 +57,7 @@ export const unterstuetzenItems = [
     category: "alltag",
   },
   {
+    id: "4-alltags-tipps",
     title: "4 Alltags-Tipps",
     url: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/cwhMoIHSUeEWpyWo.webp",
     pdfUrl:


### PR DESCRIPTION
## Was sich ändert
- ergänzt zwei neue Textversionen für bildbasierte Unterstützen-Handouts: `im-krisenmodus` und `drei-saeulen`
- erweitert den Resolver in `handoutTextVersions.ts`, damit Textversionen direkt aus `unterstuetzenItems` aufgelöst werden können
- ergänzt Search-Index-, Mapping- und Smoke-Tests für beide neuen Textversionen

## Warum das nötig ist
Die zugrunde liegenden PDFs sind bildbasiert und damit für Suche, Copy/Paste und Screenreader schlecht zugänglich. Mit den Textversionen bleibt der Inhalt im gleichen Muster wie bei den bereits ergänzten Kern-Handouts zugänglich.

## Auswirkungen
- auf der Unterstützen-Übersicht erscheinen jetzt Textversion-CTAs für beide Handouts
- Materialsuche und Source-to-Text-Version-Mapping funktionieren für diese PDFs konsistent
- die neuen Inhalte sind testseitig abgesichert

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
