### PR TITLE
[codex] add unterstuetzen haltung text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -57,6 +57,12 @@ describe("handout text versions", () => {
     const dreiSaeulenPdf = unterstuetzenItems.find(
       item => item.id === "drei-saeulen"
     )?.pdfUrl;
+    const konsistenzPrinzipPdf = unterstuetzenItems.find(
+      item => item.id === "konsistenz-prinzip"
+    )?.pdfUrl;
+    const beziehungsAchtsamkeitPdf = unterstuetzenItems.find(
+      item => item.id === "beziehungs-achtsamkeit"
+    )?.pdfUrl;
     const vierPhasenPdf = verstehenInfografiken.find(
       item => item.id === "4-phasen"
     )?.pdfUrl;
@@ -87,6 +93,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersion("drei-saeulen")?.path).toBe(
       "/materialien/text/drei-saeulen"
+    );
+    expect(getHandoutTextVersion("konsistenz-prinzip")?.path).toBe(
+      "/materialien/text/konsistenz-prinzip"
+    );
+    expect(getHandoutTextVersion("beziehungs-achtsamkeit")?.path).toBe(
+      "/materialien/text/beziehungs-achtsamkeit"
     );
     expect(getHandoutTextVersion("krisenkommunikation")?.path).toBe(
       "/materialien/text/krisenkommunikation"
@@ -139,6 +151,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(dreiSaeulenPdf)).toBe(
       "/materialien/text/drei-saeulen"
+    );
+    expect(getHandoutTextVersionHrefBySource(konsistenzPrinzipPdf)).toBe(
+      "/materialien/text/konsistenz-prinzip"
+    );
+    expect(getHandoutTextVersionHrefBySource(beziehungsAchtsamkeitPdf)).toBe(
+      "/materialien/text/beziehungs-achtsamkeit"
     );
     expect(getHandoutTextVersionHrefBySource(krisenPdf)).toBe(
       "/materialien/text/krisenkommunikation"

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -182,6 +182,50 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
   });
 
+  it("HandoutTextPage: rendert Konsistenz-Prinzip-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(
+      <HandoutTextPage params={{ handoutId: "konsistenz-prinzip" }} />
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /Konsistenz-Prinzip/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Wenn alle ähnlich reagieren, entsteht Sicherheit – und Eskalationen werden seltener\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Unterstützen/i })
+    ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
+  });
+
+  it("HandoutTextPage: rendert Beziehungs-Achtsamkeit-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(
+      <HandoutTextPage params={{ handoutId: "beziehungs-achtsamkeit" }} />
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /Beziehungs-Achtsamkeit/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Innehalten – wahrnehmen – nicht bewerten – bewusst handeln\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Unterstützen/i })
+    ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
+  });
+
   it("HandoutTextPage: rendert Warnsignale-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");
@@ -459,6 +503,16 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Drei Säulen hilfreicher Unterstützung/i,
       })
     ).toHaveAttribute("href", "/materialien/text/drei-saeulen");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Konsistenz-Prinzip/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/konsistenz-prinzip");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Beziehungs-Achtsamkeit/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/beziehungs-achtsamkeit");
   });
 
   it("NotFound: rendert 404-Seite", async () => {

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -599,6 +599,139 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),
+  createHandoutTextVersion("konsistenz-prinzip", {
+    kicker: "Textversion",
+    summary:
+      "Wenn Angehörige ähnlich reagieren und gemeinsame Grenzen einhalten, entstehen mehr Sicherheit, Vertrauen und weniger Eskalationen.",
+    intro: [
+      "Diese Seite überträgt die Infografik «Konsistenz-Prinzip – als Team wird es leichter» in eine lesbare Web-Version. Das Handout stellt einen hilfreichen und einen schwierigen Beziehungskreislauf gegenüber.",
+      "Die Grundidee ist einfach: Gleiche Grenzen führen zu mehr Sicherheit. Widersprüchliche Reaktionen machen es leichter, Grenzen gegeneinander auszuspielen, und erhöhen Konflikte.",
+    ],
+    sections: [
+      {
+        title: "Zwei Kreisläufe im Vergleich",
+        intro:
+          "Die Infografik zeigt links einen hilfreichen Kreislauf und rechts einen schwierigen Kreislauf.",
+        cards: [
+          {
+            title: "Konsistenz",
+            text: "Vertrauen, weniger Ausspielen und ein hilfreicher Beziehungskreislauf.",
+          },
+          {
+            title: "Gemeinsame Grenze",
+            text: "Gleiche Grenzen – weniger Streit über die Grenzen.",
+          },
+          {
+            title: "Inkonsistenz",
+            text: "Unsicherheit, mehr Konflikte, Misstrauen und ein schwieriger Beziehungskreislauf.",
+          },
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Worum es beim Konsistenz-Prinzip geht",
+        calloutText:
+          "Wenn alle ähnlich reagieren, entsteht Sicherheit – und Eskalationen werden seltener.",
+      },
+      {
+        title: "Mini-Legende",
+        bullets: [
+          "Kreis = verstärkender Kreislauf",
+          "Grün = hilfreich / Rot = schwierig",
+          "Pfeile = was sich gegenseitig beeinflusst",
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Kurze Absprachen",
+            text: "Machen Sie kurze Absprachen: wer sagt was, wann Pause ist und welche Grenze gemeinsam gilt.",
+          },
+          {
+            title: "2. Gemeinsam dranbleiben",
+            text: "Halten Sie 1–2 gemeinsame Grenzen gleich ein.",
+          },
+          {
+            title: "3. Unterschiede privat besprechen",
+            text: "Besprechen Sie Unterschiede privat – nicht im Streitmoment.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Familienleitlinien/Angehörigen-Psychoedukation.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("beziehungs-achtsamkeit", {
+    kicker: "Textversion",
+    summary:
+      "Innehalten, wahrnehmen, nicht bewerten und bewusst handeln helfen Angehörigen, aus dem Autopiloten auszusteigen und klarer zu reagieren.",
+    intro: [
+      "Diese Seite überträgt die Infografik «Beziehungs-Achtsamkeit – 4 Schritte im Alltag» in eine lesbare Web-Version. Das Handout übersetzt Achtsamkeit in vier konkrete Schritte für Beziehungssituationen.",
+      "Die Struktur ist bewusst alltagsnah: erst stoppen, dann wahrnehmen, nicht vorschnell bewerten und am Schluss bewusst einen nächsten Schritt wählen.",
+    ],
+    sections: [
+      {
+        title: "4 Schritte im Alltag",
+        intro:
+          "Die Grafik beschreibt eine Reihenfolge, die helfen soll, impulsive Reaktionen zu unterbrechen.",
+        cards: [
+          {
+            title: "Innehalten",
+            text: "Moment mal – Stopp.",
+          },
+          {
+            title: "Wahrnehmen",
+            text: "Was passiert gerade – in mir und im Gegenüber?",
+          },
+          {
+            title: "Nicht bewerten",
+            text: "Es ist, wie es ist (noch keine Lösung).",
+          },
+          {
+            title: "Bewusst handeln",
+            text: "Ich wähle: Satz / Grenze / Pause / Hilfe.",
+          },
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Worum es bei Beziehungs-Achtsamkeit geht",
+        calloutText:
+          "Innehalten – wahrnehmen – nicht bewerten – bewusst handeln.",
+      },
+      {
+        title: "Mini-Legende",
+        bullets: [
+          "Pfeile = Reihenfolge",
+          "Jeder Schritt = bewusste Entscheidung",
+          "Ziel = weniger Autopilot, mehr Klarheit",
+        ],
+      },
+      {
+        title: "Action Box",
+        cards: [
+          {
+            title: "1. Täglich üben",
+            text: "Üben Sie Schritt 1–2 täglich in kleinen Situationen.",
+          },
+          {
+            title: "2. Als Anti-Streit-Regel nutzen",
+            text: "Nutzen Sie Schritt 3 als Anti-Streit-Regel: erst später bewerten.",
+          },
+          {
+            title: "3. Konkret entscheiden",
+            text: "Entscheiden Sie Schritt 4 konkret: ein Satz, eine Grenze, ein nächster Schritt.",
+          },
+        ],
+      },
+    ],
+    sourceLine:
+      "Quelle: Achtsamkeitsbasierte Angehörigenarbeit, nach DBT (Linehan, 1993).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
   createHandoutTextVersion("eisberg", {
     kicker: "Textversion",
     summary:

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -497,6 +497,42 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Konsistenz-Prinzip",
+    description:
+      "Lesbare Web-Version zum hilfreichen und schwierigen Beziehungskreislauf mit Merksatz, Legende und 3 Absprachen für Angehörige",
+    keywords: [
+      "textversion",
+      "konsistenz-prinzip",
+      "konsistenz",
+      "grenzen",
+      "vertrauen",
+      "konflikte",
+      "unterstützen",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/konsistenz-prinzip",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Beziehungs-Achtsamkeit",
+    description:
+      "Lesbare Web-Version zu Innehalten, Wahrnehmen, nicht Bewerten und bewusstem Handeln im Alltag",
+    keywords: [
+      "textversion",
+      "beziehungs-achtsamkeit",
+      "achtsamkeit",
+      "innehalten",
+      "wahrnehmen",
+      "bewusst handeln",
+      "unterstützen",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/beziehungs-achtsamkeit",
+    section: "Materialien",
+  },
+  {
     title: "Der Eisberg: Was hinter Wut liegen kann",
     description:
       "Infografik: Hinter sichtbarer Wut liegen oft Schmerz, Angst oder Scham",


### PR DESCRIPTION
## Was sich ändert
- ergänzt zwei neue Textversionen für Unterstützen-Handouts: `konsistenz-prinzip` und `beziehungs-achtsamkeit`
- macht beide bildbasierten PDFs auf der Unterstützen-Übersicht als lesbare Web-Fassung verfügbar
- ergänzt Search-Index-, Mapping- und Smoke-Tests für beide neuen Textversionen

## Warum das nötig ist
Beide Handouts liegen bisher nur als bildbasierte PDFs vor. Dadurch sind Suche, Copy/Paste und Screenreader unnötig eingeschränkt. Mit den Textversionen werden die Inhalte im gleichen Muster wie bei den bereits ergänzten Kern-Handouts zugänglich.

## Auswirkungen
- auf der Unterstützen-Übersicht erscheinen jetzt zusätzliche Textversion-CTAs für `Konsistenz-Prinzip` und `Beziehungs-Achtsamkeit`
- Source-to-Text-Version-Mapping und Suche greifen auch für diese beiden PDFs
- die beiden Merksatz-/Schritt-Handouts sind jetzt testseitig abgesichert

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
