### PR TITLE
[codex] add unterstuetzen alltag text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -63,6 +63,12 @@ describe("handout text versions", () => {
     const beziehungsAchtsamkeitPdf = unterstuetzenItems.find(
       item => item.id === "beziehungs-achtsamkeit"
     )?.pdfUrl;
+    const sechsLeitlinienPdf = unterstuetzenItems.find(
+      item => item.id === "6-leitlinien"
+    )?.pdfUrl;
+    const vierAlltagsTippsPdf = unterstuetzenItems.find(
+      item => item.id === "4-alltags-tipps"
+    )?.pdfUrl;
     const vierPhasenPdf = verstehenInfografiken.find(
       item => item.id === "4-phasen"
     )?.pdfUrl;
@@ -99,6 +105,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersion("beziehungs-achtsamkeit")?.path).toBe(
       "/materialien/text/beziehungs-achtsamkeit"
+    );
+    expect(getHandoutTextVersion("6-leitlinien")?.path).toBe(
+      "/materialien/text/6-leitlinien"
+    );
+    expect(getHandoutTextVersion("4-alltags-tipps")?.path).toBe(
+      "/materialien/text/4-alltags-tipps"
     );
     expect(getHandoutTextVersion("krisenkommunikation")?.path).toBe(
       "/materialien/text/krisenkommunikation"
@@ -157,6 +169,12 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(beziehungsAchtsamkeitPdf)).toBe(
       "/materialien/text/beziehungs-achtsamkeit"
+    );
+    expect(getHandoutTextVersionHrefBySource(sechsLeitlinienPdf)).toBe(
+      "/materialien/text/6-leitlinien"
+    );
+    expect(getHandoutTextVersionHrefBySource(vierAlltagsTippsPdf)).toBe(
+      "/materialien/text/4-alltags-tipps"
     );
     expect(getHandoutTextVersionHrefBySource(krisenPdf)).toBe(
       "/materialien/text/krisenkommunikation"

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -226,6 +226,46 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
   });
 
+  it("HandoutTextPage: rendert 6-Leitlinien-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "6-leitlinien" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /6 Leitlinien für Angehörige/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Nicht alles auf einmal: Wählen Sie eine Leitlinie pro Woche\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Unterstützen/i })
+    ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
+  });
+
+  it("HandoutTextPage: rendert 4-Alltags-Tipps-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "4-alltags-tipps" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /4 Alltags-Tipps/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Kleine Handlungen im Alltag machen den grössten Unterschied\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Unterstützen/i })
+    ).toHaveAttribute("href", "/unterstuetzen/uebersicht");
+  });
+
   it("HandoutTextPage: rendert Warnsignale-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");
@@ -513,6 +553,16 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Beziehungs-Achtsamkeit/i,
       })
     ).toHaveAttribute("href", "/materialien/text/beziehungs-achtsamkeit");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: 6 Leitlinien für Angehörige/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/6-leitlinien");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: 4 Alltags-Tipps/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/4-alltags-tipps");
   });
 
   it("NotFound: rendert 404-Seite", async () => {

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -732,6 +732,143 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),
+  createHandoutTextVersion("6-leitlinien", {
+    kicker: "Textversion",
+    summary:
+      "Sechs alltagsnahe Leitlinien helfen Angehörigen, ruhig, klar und gemeinsam zu unterstützen, ohne vorschnelle Erwartungen oder unnötige Eskalationen.",
+    intro: [
+      "Diese Seite überträgt das Handout «6 Leitlinien für Angehörige – So können Sie unterstützen» in eine lesbare Web-Version. Die Vorlage bündelt evidenzbasierte Empfehlungen nach Gunderson in sechs konkrete Alltagshinweise.",
+      "Die Aussagen bleiben bewusst praktisch: Erwartungen realistisch halten, Sicherheit fördern, zuhören, Selbstverletzung ernst nehmen, als Familie gemeinsam handeln und Grenzen durchhaltbar setzen.",
+    ],
+    sections: [
+      {
+        title: "Die 6 Leitlinien",
+        intro:
+          "Die Grafik zeigt sechs konkrete Empfehlungen, die Angehörige im Alltag Schritt für Schritt umsetzen können.",
+        cards: [
+          {
+            title: "1. Veränderung braucht Zeit",
+            text: "Senken Sie Ihre Erwartungen an schnelle Fortschritte.",
+          },
+          {
+            title: "2. Ruhige Umgebung schaffen",
+            text: "Routinen und Vorhersehbarkeit geben Sicherheit.",
+          },
+          {
+            title: "3. Zuhören statt verteidigen",
+            text: "Hören Sie zu, ohne sich zu verteidigen – auch wenn Vorwürfe unfair erscheinen.",
+          },
+          {
+            title: "4. Selbstverletzung ernst nehmen",
+            text: "Nicht ignorieren, nicht dramatisieren, Hilfe anbieten.",
+          },
+          {
+            title: "5. Gemeinsam handeln",
+            text: "Handeln Sie als Familie gemeinsam – gleiche Regeln, weniger Konflikte.",
+          },
+          {
+            title: "6. Klare Grenzen setzen",
+            text: "Setzen Sie klare Grenzen – aber nur solche, die Sie auch durchhalten können.",
+          },
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Worum es bei den Leitlinien geht",
+        calloutText:
+          "Nicht alles auf einmal: Wählen Sie eine Leitlinie pro Woche.",
+      },
+      {
+        title: "Mini-Legende",
+        bullets: [
+          "Jede Kachel = eine konkrete Empfehlung",
+          "Farben = Themenbereiche",
+          "Haken = zum Abhaken",
+        ],
+      },
+      {
+        title: "Action",
+        cards: [
+          {
+            title: "1. Leitlinie wählen",
+            text: "Wählen Sie eine Leitlinie für diese Woche.",
+          },
+          {
+            title: "2. Gemeinsam besprechen",
+            text: "Besprechen Sie sie mit Ihrer Familie oder Gruppe.",
+          },
+          {
+            title: "3. Reflektieren",
+            text: "Reflektieren Sie: Was hat sich verändert?",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Gunderson et al., Family Guidelines for BPD.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("4-alltags-tipps", {
+    kicker: "Textversion",
+    summary:
+      "Kleine, konkrete Handlungen im Alltag helfen oft mehr als grosse Reden: mitüben, Fortschritte würdigen, verlässlich bleiben und gemeinsam Lösungen entwickeln.",
+    intro: [
+      "Diese Seite überträgt das Handout «Was Sie konkret tun können – 4 Alltags-Tipps» in eine lesbare Web-Version. Die Vorlage fokussiert bewusst auf wenige, direkt umsetzbare Unterstützungsformen.",
+      "Das Handout bleibt praktisch: Sie müssen nicht alles übernehmen. Oft reicht es, verlässlich präsent zu sein, kleine Fortschritte sichtbar zu machen und hilfreiche Fragen zu stellen.",
+    ],
+    sections: [
+      {
+        title: "4 Alltags-Tipps",
+        intro:
+          "Die Grafik bündelt vier konkrete Handlungsfelder für den Alltag mit einer nahestehenden Person.",
+        cards: [
+          {
+            title: "Übungspartner sein",
+            text: "Helfen Sie beim Üben neuer Skills. Unterstützen Sie aktiv.",
+          },
+          {
+            title: "Fortschritte anerkennen",
+            text: "Auch kleine Schritte würdigen. Positives benennen.",
+          },
+          {
+            title: "Vorhersehbar sein",
+            text: "Klare Routinen und Absprachen. Verlässlichkeit zeigen.",
+          },
+          {
+            title: "Gemeinsam Probleme lösen",
+            text: "Fragen statt Lösungen vorgeben. Unterstützen statt übernehmen.",
+          },
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Worum es im Alltag geht",
+        calloutText:
+          "Kleine Handlungen im Alltag machen den grössten Unterschied.",
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Einen Tipp wählen",
+            text: "Wählen Sie einen Tipp für diese Woche.",
+          },
+          {
+            title: "2. In Ruhe üben",
+            text: "Üben Sie in ruhigen Momenten.",
+          },
+          {
+            title: "3. Hilfreich fragen",
+            text: "Fragen Sie: Was wäre jetzt hilfreich?",
+          },
+        ],
+      },
+    ],
+    sourceLine:
+      "Quelle: DBT-handlungsbasiert; Fruzzetti (2006), Family Psychoeducation.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
   createHandoutTextVersion("eisberg", {
     kicker: "Textversion",
     summary:

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -533,6 +533,42 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: 6 Leitlinien für Angehörige",
+    description:
+      "Lesbare Web-Version mit sechs evidenzbasierten Empfehlungen, Merksatz und drei Reflexionsschritten für Angehörige",
+    keywords: [
+      "textversion",
+      "6 leitlinien",
+      "gunderson",
+      "family guidelines",
+      "unterstützen",
+      "grenzen",
+      "familie",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/6-leitlinien",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: 4 Alltags-Tipps",
+    description:
+      "Lesbare Web-Version zu Übungspartner sein, Fortschritte anerkennen, Vorhersehbarkeit und gemeinsamem Problemlösen",
+    keywords: [
+      "textversion",
+      "4 alltags-tipps",
+      "alltag",
+      "fortschritte anerkennen",
+      "vorhersehbar",
+      "unterstützen",
+      "skills",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/4-alltags-tipps",
+    section: "Materialien",
+  },
+  {
     title: "Der Eisberg: Was hinter Wut liegen kann",
     description:
       "Infografik: Hinter sichtbarer Wut liegen oft Schmerz, Angst oder Scham",


### PR DESCRIPTION
## Was sich ändert
- ergänzt zwei weitere Textversionen für Unterstützen-Handouts: `6-leitlinien` und `4-alltags-tipps`
- macht damit auch die letzten beiden bildbasierten Alltagshandouts im Unterstützen-Bereich als lesbare Web-Fassungen verfügbar
- ergänzt Search-Index-, Mapping- und Smoke-Tests für beide neuen Textversionen

## Warum das nötig ist
Diese beiden Handouts lagen bisher nur als bildbasierte PDFs vor. Damit waren Suche, Copy/Paste und Screenreader unnötig eingeschränkt. Mit diesem PR ist der Unterstützen-Bereich jetzt vollständig im gleichen Textversions-Muster erschlossen.

## Auswirkungen
- auf der Unterstützen-Übersicht erscheinen jetzt zusätzliche Textversion-CTAs für `6 Leitlinien für Angehörige` und `4 Alltags-Tipps`
- Source-to-Text-Version-Mapping und Suche greifen auch für die letzten Unterstützen-PDFs
- der Unterstützen-Bereich ist jetzt als Serie konsistent testseitig abgesichert

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
