### PR TITLE
[codex] add selbstfuersorge text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -5,6 +5,7 @@ import {
   getHandoutTextVersionHrefBySource,
 } from "@/content/handoutTextVersions";
 import { materials } from "@/content/materialien";
+import { selbstfuersorgeInfografiken } from "@/content/selbstfuersorge";
 import { unterstuetzenItems } from "@/content/unterstuetzen";
 import { verstehenInfografiken } from "@/content/verstehen";
 
@@ -34,6 +35,18 @@ describe("handout text versions", () => {
     const warnsignalePdf = materials.find(
       item => item.id === "warnsignale"
     )?.downloadUrl;
+    const sauerstoffmaskePdf = selbstfuersorgeInfografiken.find(
+      item => item.id === "sauerstoffmaske"
+    )?.pdf;
+    const stoppTechnikPdf = selbstfuersorgeInfografiken.find(
+      item => item.id === "stopp-technik"
+    )?.pdf;
+    const energieKontoPdf = selbstfuersorgeInfografiken.find(
+      item => item.id === "energie-konto"
+    )?.pdf;
+    const erlaubnisKartePdf = selbstfuersorgeInfografiken.find(
+      item => item.id === "erlaubnis-karte"
+    )?.pdf;
     const schuldVerantwortungPdf = materials.find(
       item => item.id === "schuld-verantwortung"
     )?.downloadUrl;
@@ -121,6 +134,18 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersion("warnsignale")?.path).toBe(
       "/materialien/text/warnsignale"
     );
+    expect(getHandoutTextVersion("sauerstoffmaske")?.path).toBe(
+      "/materialien/text/sauerstoffmaske"
+    );
+    expect(getHandoutTextVersion("stopp-technik")?.path).toBe(
+      "/materialien/text/stopp-technik"
+    );
+    expect(getHandoutTextVersion("energie-konto")?.path).toBe(
+      "/materialien/text/energie-konto"
+    );
+    expect(getHandoutTextVersion("erlaubnis-karte")?.path).toBe(
+      "/materialien/text/erlaubnis-karte"
+    );
     expect(getHandoutTextVersion("schuld-verantwortung")?.path).toBe(
       "/materialien/text/schuld-verantwortung"
     );
@@ -184,6 +209,18 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(warnsignalePdf)).toBe(
       "/materialien/text/warnsignale"
+    );
+    expect(getHandoutTextVersionHrefBySource(sauerstoffmaskePdf)).toBe(
+      "/materialien/text/sauerstoffmaske"
+    );
+    expect(getHandoutTextVersionHrefBySource(stoppTechnikPdf)).toBe(
+      "/materialien/text/stopp-technik"
+    );
+    expect(getHandoutTextVersionHrefBySource(energieKontoPdf)).toBe(
+      "/materialien/text/energie-konto"
+    );
+    expect(getHandoutTextVersionHrefBySource(erlaubnisKartePdf)).toBe(
+      "/materialien/text/erlaubnis-karte"
     );
     expect(getHandoutTextVersionHrefBySource(schuldVerantwortungPdf)).toBe(
       "/materialien/text/schuld-verantwortung"

--- a/client/src/__tests__/selbstfuersorge-infografiken.test.tsx
+++ b/client/src/__tests__/selbstfuersorge-infografiken.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import SelbstfuersorgeInfografikenSection from "@/sections/SelbstfuersorgeInfografikenSection";
 
 describe("SelbstfuersorgeInfografikenSection", () => {
-  it("shows the new text version link for Radikale Akzeptanz", () => {
+  it("shows text version links for Selbstfürsorge-Handouts", () => {
     render(
       <Router>
         <SelbstfuersorgeInfografikenSection />
@@ -22,6 +22,26 @@ describe("SelbstfuersorgeInfografikenSection", () => {
         name: /Textversion lesen: Radikale Akzeptanz/i,
       })
     ).toHaveAttribute("href", "/materialien/text/radikale-akzeptanz");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Die Sauerstoffmaske/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/sauerstoffmaske");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Die STOPP-Technik/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/stopp-technik");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Ihr Energie-Konto/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/energie-konto");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Erlaubnis-Karte/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/erlaubnis-karte");
     expect(
       screen.getByRole("link", {
         name: /PDF öffnen: Radikale Akzeptanz \(neuer Tab\)/i,

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -4,7 +4,7 @@
  * Ziel: Sicherstellen dass Kernseiten rendern ohne zu crashen
  * und wichtige Inhalte vorhanden sind.
  */
-import { render, screen, cleanup } from "@testing-library/react";
+import { render, screen, cleanup, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeAll, afterEach } from "vitest";
 import { Router } from "wouter";
 
@@ -277,6 +277,84 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toBeInTheDocument();
     expect(
       screen.getByText(/Überlastung kommt nicht plötzlich/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Selbstfürsorge/i })
+    ).toHaveAttribute("href", "/selbstfuersorge");
+  });
+
+  it("HandoutTextPage: rendert Sauerstoffmaske-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "sauerstoffmaske" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Die Sauerstoffmaske/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Im Flugzeug gilt: Erst die eigene Maske aufsetzen, dann anderen helfen\. Für Angehörige gilt dasselbe\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Selbstfürsorge/i })
+    ).toHaveAttribute("href", "/selbstfuersorge");
+  });
+
+  it("HandoutTextPage: rendert STOPP-Technik-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "stopp-technik" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Die STOPP-Technik/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /STOPP gibt Ihnen 30 Sekunden Abstand zwischen Reiz und Reaktion\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Selbstfürsorge/i })
+    ).toHaveAttribute("href", "/selbstfuersorge");
+  });
+
+  it("HandoutTextPage: rendert Energie-Konto-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "energie-konto" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Ihr Energie-Konto/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Ihre Energie ist begrenzt\. Achten Sie darauf, dass Sie regelmässig auftanken – bevor das Konto leer ist\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Selbstfürsorge/i })
+    ).toHaveAttribute("href", "/selbstfuersorge");
+  });
+
+  it("HandoutTextPage: rendert Erlaubnis-Karte-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "erlaubnis-karte" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Erlaubnis-Karte/i,
+        level: 1,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Gültig ab sofort\. Unbefristet\./i)
     ).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: /Zum Themenbereich Selbstfürsorge/i })
@@ -563,6 +641,37 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: 4 Alltags-Tipps/i,
       })
     ).toHaveAttribute("href", "/materialien/text/4-alltags-tipps");
+  });
+
+  it("Selbstfürsorge: zeigt Textversionen für Selbstfürsorge-Handouts", async () => {
+    const { default: Selbstfuersorge } =
+      await import("@/pages/Selbstfuersorge");
+    withRouter(<Selbstfuersorge />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Abschnitt Materialien zum Download aufklappen/i,
+      })
+    );
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Die Sauerstoffmaske/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/sauerstoffmaske");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Die STOPP-Technik/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/stopp-technik");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Ihr Energie-Konto/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/energie-konto");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Erlaubnis-Karte/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/erlaubnis-karte");
   });
 
   it("NotFound: rendert 404-Seite", async () => {

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -3,6 +3,7 @@ import {
   type MaterialCategory,
   type MaterialItem,
 } from "./materialien";
+import { selbstfuersorgeInfografiken } from "./selbstfuersorge";
 import { unterstuetzenItems } from "./unterstuetzen";
 import { verstehenInfografiken } from "./verstehen";
 
@@ -94,6 +95,21 @@ function requireMaterial(id: string) {
       previewImageUrl: unterstuetzenMaterial.url,
       topic: TOPIC_META.unterstuetzen,
       pdfSourceUrl: unterstuetzenMaterial.pdfUrl,
+    };
+  }
+
+  const selbstfuersorgeMaterial = selbstfuersorgeInfografiken.find(
+    item => item.id === id
+  );
+  if (selbstfuersorgeMaterial) {
+    return {
+      title: selbstfuersorgeMaterial.title,
+      description: selbstfuersorgeMaterial.desc,
+      category: "selbstfuersorge" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: selbstfuersorgeMaterial.webp,
+      topic: TOPIC_META.selbstfuersorge,
+      pdfSourceUrl: selbstfuersorgeMaterial.pdf,
     };
   }
 
@@ -1448,6 +1464,327 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     ],
     sourceLine:
       "Quelle: Maslach/Leiter (2016), Burnout-Prävention; Mason/Kreger (2014).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("sauerstoffmaske", {
+    kicker: "Textversion",
+    summary:
+      "Selbstfürsorge ist keine Selbstsucht. Wer zuerst die eigene Maske aufsetzt, hat mehr Energie, weniger Schuldgefühle und kann verlässlicher unterstützen.",
+    intro: [
+      "Diese Seite überträgt das Handout «Die Sauerstoffmaske – Warum Selbstfürsorge keine Selbstsucht ist» in eine lesbare Web-Version. Die Bildidee aus dem Flugzeug bleibt erhalten: erst die eigene Maske aufsetzen, dann anderen helfen.",
+      "Die Grafik stellt zwei Kreisläufe gegenüber. Links zeigt sie, wie Überforderung und Schuldgefühle entstehen, wenn Angehörige nur noch für andere da sind. Rechts zeigt sie den hilfreicheren Kreislauf, wenn Selbstfürsorge bewusst Platz bekommt.",
+    ],
+    sections: [
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es bei der Sauerstoffmaske geht",
+        calloutText:
+          "Im Flugzeug gilt: Erst die eigene Maske aufsetzen, dann anderen helfen. Für Angehörige gilt dasselbe.",
+      },
+      {
+        title: "Negativer Kreislauf",
+        intro:
+          "Die linke Seite der Grafik beschreibt einen Kreislauf, in dem Selbstfürsorge ausfällt und die Belastung zunimmt.",
+        cards: [
+          {
+            title: "Nur für andere da sein",
+            text: "Der ganze Fokus liegt auf dem Gegenüber, nicht mehr auch auf Ihnen selbst.",
+          },
+          {
+            title: "Eigene Bedürfnisse ignorieren",
+            text: "Pausen, Schlaf oder Unterstützung werden aufgeschoben oder weggedrückt.",
+          },
+          {
+            title: "Schuldgefühle",
+            text: "Es entsteht das Gefühl, nie genug zu tun und trotzdem nicht zu genügen.",
+          },
+          {
+            title: "Erschöpfung und Gereiztheit",
+            text: "Die Belastung steigt, die Kraft sinkt und hilfreiche Unterstützung wird schwerer.",
+          },
+        ],
+      },
+      {
+        title: "Hilfreicher Kreislauf",
+        intro:
+          "Die rechte Seite zeigt, was sich verändert, wenn Selbstfürsorge nicht als Egoismus, sondern als Voraussetzung verstanden wird.",
+        cards: [
+          {
+            title: "Eigene Maske zuerst aufsetzen",
+            text: "Sie nehmen Ihre Bedürfnisse ernst und sorgen bewusst für Stabilität.",
+          },
+          {
+            title: "Weniger Schuldgefühle",
+            text: "Selbstfürsorge entlastet innerlich und macht klarer, was realistisch möglich ist.",
+          },
+          {
+            title: "Energie und Klarheit",
+            text: "Mit mehr Kraft und Übersicht reagieren Sie ruhiger und gezielter.",
+          },
+          {
+            title: "Bessere Unterstützung möglich",
+            text: "Gerade weil Sie auf sich achten, können Sie verlässlicher für andere da sein.",
+          },
+        ],
+      },
+      {
+        title: "Legende",
+        bullets: [
+          "Rot = negativer Kreislauf",
+          "Grün = hilfreicher Kreislauf",
+          "Wendepunkt = Ihre Entscheidung",
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Etwas nur für sich planen",
+            text: "Planen Sie eine Aktivität nur für sich.",
+          },
+          {
+            title: "2. Den Bedarf aussprechen",
+            text: "Sagen Sie: Ich brauche das, damit ich für dich da sein kann.",
+          },
+          {
+            title: "3. Hilfe annehmen üben",
+            text: "Üben Sie, Hilfe anzunehmen.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Mason/Kreger (2014), Angehörigen-Psychoedukation.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("stopp-technik", {
+    kicker: "Textversion",
+    summary:
+      "Die STOPP-Technik schafft in etwa 30 Sekunden Abstand zwischen Reiz und Reaktion. Das gibt Körper und Kopf wieder etwas mehr Handlungsspielraum.",
+    intro: [
+      "Diese Seite überträgt das Handout «Die STOPP-Technik – 5 Schritte aus der Stressspirale» in eine lesbare Web-Version. Das Original fasst die DBT-Technik so zusammen, dass sie im Alltag schnell nutzbar bleibt.",
+      "Die fünf Buchstaben bilden eine feste Reihenfolge: stoppen, atmen, orientieren, Perspektive wechseln und dann erst eine konkrete Handlung planen.",
+    ],
+    sections: [
+      {
+        title: "Zentraler Satz",
+        calloutTitle: "Worum es bei STOPP geht",
+        calloutText:
+          "Wenn die Emotionen überkochen: STOPP gibt Ihnen 30 Sekunden Abstand zwischen Reiz und Reaktion.",
+      },
+      {
+        title: "Die 5 STOPP-Schritte",
+        intro:
+          "Die Grafik zeigt die Technik als kurze Folge von fünf Schritten, die Sie in hoher Anspannung abrufen können.",
+        cards: [
+          {
+            title: "S = STOPP",
+            text: "Halten Sie inne. Tun Sie nichts.",
+          },
+          {
+            title: "T = TIEF ATMEN",
+            text: "Drei tiefe Atemzüge. 4–4–4.",
+          },
+          {
+            title: "O = ORIENTIEREN",
+            text: "Was passiert gerade wirklich?",
+          },
+          {
+            title: "P = PERSPEKTIVE",
+            text: "Wie sehe ich das in einer Woche?",
+          },
+          {
+            title: "P = PLAN",
+            text: "Wählen Sie EINE konkrete Handlung.",
+          },
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Mehrmals üben",
+            text: "Üben Sie STOPP dreimal diese Woche.",
+          },
+          {
+            title: "2. Anker-Satz bereitlegen",
+            text: "Anker-Satz: Ich habe 30 Sekunden.",
+          },
+          {
+            title: "3. Abends notieren",
+            text: "Notieren Sie abends: Wann hätte STOPP geholfen?",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Linehan (1993), DBT Skills Training.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("energie-konto", {
+    kicker: "Textversion",
+    summary:
+      "Ihre Energie ist begrenzt. Wenn Sie im Blick behalten, was auftankt und was Energie kostet, können Sie früher gegensteuern statt erst im Leerlauf zu reagieren.",
+    intro: [
+      "Diese Seite überträgt das Handout «Ihr Energie-Konto – Was füllt, was leert» in eine lesbare Web-Version. Die Grafik arbeitet mit einer Batterie-Metapher: Energie kann gefüllt, entleert und auch bis in den Burnout-Bereich erschöpft werden.",
+      "Die Grundidee ist bewusst praktisch. Statt nur über Belastung nachzudenken, hilft die Gegenüberstellung von Energiegebern und Energiefressern dabei, konkrete Veränderungen im Alltag zu planen.",
+    ],
+    sections: [
+      {
+        title: "Kernaussage",
+        calloutTitle: "Worum es beim Energie-Konto geht",
+        calloutText:
+          "Ihre Energie ist begrenzt. Achten Sie darauf, dass Sie regelmässig auftanken – bevor das Konto leer ist.",
+      },
+      {
+        title: "Was füllt",
+        intro:
+          "Die linke Spalte nennt typische Energiegeber, die das Konto wieder auffüllen können.",
+        cards: [
+          {
+            title: "Bewegung und Sport",
+            text: "Körperliche Aktivität kann spürbar Energie zurückgeben.",
+          },
+          {
+            title: "Soziale Kontakte pflegen",
+            text: "Tragender Kontakt kann entlasten und verbinden.",
+          },
+          {
+            title: "Hobbys und Interessen",
+            text: "Eigene Interessen erinnern daran, dass Ihr Leben mehr umfasst als Belastung.",
+          },
+          {
+            title: "Natur und Ruhe",
+            text: "Rückzug, Stille und Natur können Nervensystem und Gedanken beruhigen.",
+          },
+          {
+            title: "Professionelle Unterstützung",
+            text: "Begleitung von aussen kann entlasten und strukturieren.",
+          },
+          {
+            title: "Schlaf und Erholung",
+            text: "Regeneration ist kein Luxus, sondern Grundversorgung.",
+          },
+        ],
+      },
+      {
+        title: "Was leert",
+        intro:
+          "Die rechte Spalte zeigt typische Belastungen, die das Energie-Konto nach unten ziehen.",
+        cards: [
+          {
+            title: "Krisen begleiten",
+            text: "Akute Belastung kostet Kraft, auch wenn Hilfe nötig und sinnvoll ist.",
+          },
+          {
+            title: "Ständige Erreichbarkeit",
+            text: "Dauerbereitschaft verhindert echte Erholung.",
+          },
+          {
+            title: "Schuldgefühle und Grübeln",
+            text: "Innere Kreise ohne Lösung verbrauchen viel Energie.",
+          },
+          {
+            title: "Konflikte und Vorwürfe",
+            text: "Wiederholte Auseinandersetzungen ziehen Kraft und Ruhe ab.",
+          },
+          {
+            title: "Isolation und Rückzug",
+            text: "Allein mit allem zu bleiben entlastet selten dauerhaft.",
+          },
+          {
+            title: "Eigene Bedürfnisse ignorieren",
+            text: "Wer sich selbst ständig übergeht, leert das Konto weiter.",
+          },
+        ],
+      },
+      {
+        title: "Legende",
+        bullets: [
+          "Grüne Pfeile = Energie geben",
+          "Rote Pfeile = Energie kosten",
+          "Batterie-Icon = aktueller Stand",
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Ehrlich prüfen",
+            text: "Prüfen Sie ehrlich: Wie voll ist Ihr Konto gerade?",
+          },
+          {
+            title: "2. Auftank-Aktivität planen",
+            text: "Planen Sie diese Woche eine konkrete Auftank-Aktivität.",
+          },
+          {
+            title: "3. Einen Energiefresser streichen",
+            text: "Streichen Sie eine energiefressende Gewohnheit – nur eine.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Maslach und Leiter (2016), Burnout-Prävention.",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("erlaubnis-karte", {
+    kicker: "Textversion",
+    summary:
+      "Die Erlaubnis-Karte bündelt neun Sätze, die Angehörigen oft guttun: eigene Bedürfnisse ernst nehmen, Grenzen setzen und ein eigenes Leben behalten.",
+    intro: [
+      "Diese Seite überträgt das Handout «Ihre Erlaubnis-Karte – Was Sie sich erlauben dürfen» in eine lesbare Web-Version. Das Original ist bewusst als persönliches Zertifikat aufgebaut: nicht als Pflichtliste, sondern als Erlaubnis zum Ankreuzen.",
+      "Der Fokus ist entlastend. Die Grafik erinnert daran, dass Selbstfürsorge, Grenzen und eigene Gefühle nicht gegen die Beziehung stehen, sondern zu gesunder Angehörigenarbeit dazugehören.",
+    ],
+    sections: [
+      {
+        title: "Erlaubnis",
+        intro:
+          "Die Karte nennt neun Dinge, die Sie sich ausdrücklich erlauben dürfen.",
+        bullets: [
+          "Nein sagen, ohne sich schuldig zu fühlen.",
+          "Eigene Bedürfnisse haben und äussern.",
+          "Pausen machen, wenn es zu viel wird.",
+          "Hilfe annehmen und um Hilfe bitten.",
+          "Wütend, traurig oder überfordert sein.",
+          "Grenzen setzen, auch wenn es Widerstand gibt.",
+          "Sich zurückziehen, ohne Erklärung.",
+          "Freude empfinden, auch wenn es dem Angehörigen schlecht geht.",
+          "Ihr eigenes Leben leben.",
+        ],
+      },
+      {
+        title: "Merksatz",
+        calloutTitle: "Gültigkeit",
+        calloutText: "Gültig ab sofort. Unbefristet.",
+      },
+      {
+        title: "Legende",
+        bullets: [
+          "Checkbox = Erlaubnis zum Ankreuzen",
+          "Zertifikat = Ihre persönliche Genehmigung",
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        cards: [
+          {
+            title: "1. Sichtbar machen",
+            text: "Drucken Sie diese Karte aus und hängen Sie sie sichtbar auf.",
+          },
+          {
+            title: "2. Heute ankreuzen",
+            text: "Kreuzen Sie an, was Ihnen heute besonders schwer fällt.",
+          },
+          {
+            title: "3. Täglich erinnern",
+            text: "Erinnern Sie sich täglich: Diese Erlaubnis gilt.",
+          },
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Selbstfürsorge-Konzept, nach Mason/Kreger (2014).",
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -805,6 +805,74 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Die Sauerstoffmaske",
+    description:
+      "Lesbare Web-Version zum negativen und hilfreichen Kreislauf der Selbstfürsorge mit drei konkreten Schritten",
+    keywords: [
+      "textversion",
+      "sauerstoffmaske",
+      "selbstfürsorge",
+      "schuldgefühle",
+      "erschöpfung",
+      "kreislauf",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/sauerstoffmaske",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Die STOPP-Technik",
+    description:
+      "Lesbare Web-Version zur 5-Schritte-Technik aus der Stressspirale mit Anker-Satz und Alltagsübung",
+    keywords: [
+      "textversion",
+      "stopp-technik",
+      "stopp",
+      "stressspirale",
+      "dbt",
+      "selbstfürsorge",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/stopp-technik",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Ihr Energie-Konto",
+    description:
+      "Lesbare Web-Version zu Energiegebern, Energiefressern, Batteriestand und drei Auftank-Schritten",
+    keywords: [
+      "textversion",
+      "energie-konto",
+      "energie",
+      "burnout",
+      "auftanken",
+      "selbstfürsorge",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/energie-konto",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Ihre Erlaubnis-Karte",
+    description:
+      "Lesbare Web-Version mit neun entlastenden Erlaubnissen, persönlicher Genehmigung und drei kleinen Alltagsschritten",
+    keywords: [
+      "textversion",
+      "erlaubnis-karte",
+      "erlaubnis",
+      "grenzen",
+      "eigene bedürfnisse",
+      "selbstfürsorge",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/erlaubnis-karte",
+    section: "Materialien",
+  },
+  {
     title: "Textversion: Schuld, Verantwortung und was dazwischen liegt",
     description:
       "Lesbare Web-Version zu Schuldgefühlen, Verantwortung, Entlastung und typischen Selbstvorwürfen von Angehörigen",


### PR DESCRIPTION
## Was sich ändert
- ergänzt vier neue Textversionen für Selbstfürsorge-Handouts: `sauerstoffmaske`, `stopp-technik`, `energie-konto` und `erlaubnis-karte`
- erweitert den Resolver in `handoutTextVersions.ts`, damit Textversionen direkt aus `selbstfuersorgeInfografiken` aufgelöst werden können
- ergänzt Search-Index-, Mapping-, Section- und Smoke-Tests für alle vier neuen Textversionen

## Warum das nötig ist
Diese vier Selbstfürsorge-Handouts liegen bisher nur als bildbasierte PDFs vor. Damit sind Suche, Copy/Paste und Screenreader unnötig eingeschränkt. Mit diesem PR wird der Selbstfürsorge-Bereich deutlich vollständiger als lesbare Web-Fassung zugänglich.

## Auswirkungen
- auf der Selbstfürsorge-Seite erscheinen jetzt Textversion-CTAs für `Die Sauerstoffmaske`, `Die STOPP-Technik`, `Ihr Energie-Konto` und `Erlaubnis-Karte`
- Source-to-Text-Version-Mapping funktioniert jetzt auch für `selbstfuersorgeInfografiken`
- die neuen Inhalte und CTA-Pfade sind testseitig explizit abgesichert

## Validierung
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run --config vitest.config.ts`
- `./node_modules/.bin/vite build`
- `./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist`
