### PR TITLE
[codex] add genesung text versions

### DIFF
--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -4,6 +4,7 @@ import {
   getHandoutTextVersionBySource,
   getHandoutTextVersionHrefBySource,
 } from "@/content/handoutTextVersions";
+import { genesungItems } from "@/content/genesung";
 import { materials } from "@/content/materialien";
 import { selbstfuersorgeInfografiken } from "@/content/selbstfuersorge";
 import { unterstuetzenItems } from "@/content/unterstuetzen";
@@ -60,6 +61,18 @@ describe("handout text versions", () => {
     const genesungZahlenPdf = materials.find(
       item => item.id === "genesung-zahlen"
     )?.downloadUrl;
+    const fortschrittParadoxPdf = genesungItems.find(
+      item => item.id === "fortschritt-paradox"
+    )?.pdf;
+    const remissionHeilungPdf = genesungItems.find(
+      item => item.id === "remission-heilung"
+    )?.pdf;
+    const genesungFaktorenPdf = genesungItems.find(
+      item => item.id === "5-faktoren-genesung"
+    )?.pdf;
+    const rolleGenesungsprozessPdf = genesungItems.find(
+      item => item.id === "rolle-genesungsprozess"
+    )?.pdf;
     const kinderPdf = materials.find(item => item.id === "kinder")?.downloadUrl;
     const notfallplanPdf = materials.find(
       item => item.id === "notfallplan-krise"
@@ -159,6 +172,18 @@ describe("handout text versions", () => {
     expect(getHandoutTextVersion("genesung-zahlen")?.path).toBe(
       "/materialien/text/genesung-zahlen"
     );
+    expect(getHandoutTextVersion("fortschritt-paradox")?.path).toBe(
+      "/materialien/text/fortschritt-paradox"
+    );
+    expect(getHandoutTextVersion("remission-heilung")?.path).toBe(
+      "/materialien/text/remission-heilung"
+    );
+    expect(getHandoutTextVersion("5-faktoren-genesung")?.path).toBe(
+      "/materialien/text/5-faktoren-genesung"
+    );
+    expect(getHandoutTextVersion("rolle-genesungsprozess")?.path).toBe(
+      "/materialien/text/rolle-genesungsprozess"
+    );
     expect(getHandoutTextVersion("4-phasen")?.path).toBe(
       "/materialien/text/4-phasen"
     );
@@ -236,6 +261,18 @@ describe("handout text versions", () => {
     );
     expect(getHandoutTextVersionHrefBySource(genesungZahlenPdf)).toBe(
       "/materialien/text/genesung-zahlen"
+    );
+    expect(getHandoutTextVersionHrefBySource(fortschrittParadoxPdf)).toBe(
+      "/materialien/text/fortschritt-paradox"
+    );
+    expect(getHandoutTextVersionHrefBySource(remissionHeilungPdf)).toBe(
+      "/materialien/text/remission-heilung"
+    );
+    expect(getHandoutTextVersionHrefBySource(genesungFaktorenPdf)).toBe(
+      "/materialien/text/5-faktoren-genesung"
+    );
+    expect(getHandoutTextVersionHrefBySource(rolleGenesungsprozessPdf)).toBe(
+      "/materialien/text/rolle-genesungsprozess"
     );
     expect(getHandoutTextVersionHrefBySource(vierPhasenPdf)).toBe(
       "/materialien/text/4-phasen"

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -452,6 +452,84 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/genesung");
   });
 
+  it("HandoutTextPage: rendert Fortschritt-Paradox-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(
+      <HandoutTextPage params={{ handoutId: "fortschritt-paradox" }} />
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /Das Fortschritt-Paradox/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Rückschritte sind Teil des Weges – nicht das Ende\./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Genesung/i })
+    ).toHaveAttribute("href", "/genesung");
+  });
+
+  it("HandoutTextPage: rendert Remission-Heilung-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "remission-heilung" }} />);
+    expect(
+      screen.getByRole("heading", {
+        name: /Remission vs\. Heilung/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Remission ist das realistische Ziel – und ein grosser Erfolg\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Genesung/i })
+    ).toHaveAttribute("href", "/genesung");
+  });
+
+  it("HandoutTextPage: rendert 5-Faktoren-Genesung-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(
+      <HandoutTextPage params={{ handoutId: "5-faktoren-genesung" }} />
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /5 Faktoren, die Genesung fördern/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /Sie als Angehörige können bei den beeinflussbaren Faktoren unterstützen\./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Genesung/i })
+    ).toHaveAttribute("href", "/genesung");
+  });
+
+  it("HandoutTextPage: rendert Rolle-im-Genesungsprozess-Textversion", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(
+      <HandoutTextPage params={{ handoutId: "rolle-genesungsprozess" }} />
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: /Ihre Rolle im Genesungsprozess/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Sie können unterstützen\. Sie müssen nicht retten\./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zum Themenbereich Genesung/i })
+    ).toHaveAttribute("href", "/genesung");
+  });
+
   it("HandoutTextPage: rendert Kinder-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");
@@ -577,7 +655,7 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/materialien/text/wenn-worte-treffen");
   });
 
-  it("Genesung: zeigt Textversion für Genesung in Zahlen", async () => {
+  it("Genesung: zeigt Textversionen für Genesung-Handouts", async () => {
     const { default: Genesung } = await import("@/pages/Genesung");
     withRouter(<Genesung />);
     expect(
@@ -585,6 +663,26 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Genesung in Zahlen/i,
       })
     ).toHaveAttribute("href", "/materialien/text/genesung-zahlen");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Das Fortschritt-Paradox/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/fortschritt-paradox");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Remission vs\. Heilung/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/remission-heilung");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: 5 Faktoren, die Genesung fördern/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/5-faktoren-genesung");
+    expect(
+      screen.getByRole("link", {
+        name: /Textversion lesen: Ihre Rolle im Genesungsprozess/i,
+      })
+    ).toHaveAttribute("href", "/materialien/text/rolle-genesungsprozess");
   });
 
   it("Verstehen: zeigt Textversionen für Verstehen-Handouts", async () => {

--- a/client/src/content/genesung.ts
+++ b/client/src/content/genesung.ts
@@ -1,13 +1,23 @@
 export type GenesungKategorie = "alle" | "verstehen" | "handeln";
 
+export interface GenesungItem {
+  id: string;
+  title: string;
+  desc: string;
+  img: string;
+  pdf: string;
+  category: Exclude<GenesungKategorie, "alle">;
+}
+
 export const genesungCategories = [
   { id: "alle", label: "Alle" },
   { id: "verstehen", label: "Verstehen" },
   { id: "handeln", label: "Handeln" },
 ] as const;
 
-export const genesungItems = [
+export const genesungItems: GenesungItem[] = [
   {
+    id: "genesung-zahlen",
     title: "Genesung in Zahlen",
     desc: "Orientierungs-Tracker mit Langzeitdaten",
     img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/tyFTHNjsUagqrXiS.webp",
@@ -15,6 +25,7 @@ export const genesungItems = [
     category: "verstehen",
   },
   {
+    id: "fortschritt-paradox",
     title: "Das Fortschritt-Paradox",
     desc: "Warum Rückfälle zum Weg gehören",
     img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/DPkqytVYFcreeBlC.webp",
@@ -22,6 +33,7 @@ export const genesungItems = [
     category: "verstehen",
   },
   {
+    id: "remission-heilung",
     title: "Remission vs. Heilung",
     desc: "Was Besserung wirklich bedeutet",
     img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/HPRsNmCUFirjnraj.webp",
@@ -29,6 +41,7 @@ export const genesungItems = [
     category: "verstehen",
   },
   {
+    id: "5-faktoren-genesung",
     title: "5 Faktoren, die Genesung fördern",
     desc: "Säulen-Modell: Was positiv beeinflusst",
     img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/mFhtxtPMBkCEVPII.webp",
@@ -36,10 +49,11 @@ export const genesungItems = [
     category: "handeln",
   },
   {
+    id: "rolle-genesungsprozess",
     title: "Ihre Rolle im Genesungsprozess",
     desc: "Was Sie tun können (und was nicht)",
     img: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/GhgPDkJhqlqJkYzE.webp",
     pdf: "https://files.manuscdn.com/user_upload_by_module/session_file/310419663031008193/CZdiDaadpIWNOBFb.pdf",
     category: "handeln",
   },
-] as const;
+];

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -3,6 +3,7 @@ import {
   type MaterialCategory,
   type MaterialItem,
 } from "./materialien";
+import { genesungItems } from "./genesung";
 import { selbstfuersorgeInfografiken } from "./selbstfuersorge";
 import { unterstuetzenItems } from "./unterstuetzen";
 import { verstehenInfografiken } from "./verstehen";
@@ -110,6 +111,19 @@ function requireMaterial(id: string) {
       previewImageUrl: selbstfuersorgeMaterial.webp,
       topic: TOPIC_META.selbstfuersorge,
       pdfSourceUrl: selbstfuersorgeMaterial.pdf,
+    };
+  }
+
+  const genesungMaterial = genesungItems.find(item => item.id === id);
+  if (genesungMaterial) {
+    return {
+      title: genesungMaterial.title,
+      description: genesungMaterial.desc,
+      category: "genesung" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: genesungMaterial.img,
+      topic: TOPIC_META.genesung,
+      pdfSourceUrl: genesungMaterial.pdf,
     };
   }
 
@@ -2197,6 +2211,252 @@ export const handoutTextVersions: HandoutTextVersion[] = [
     ],
     sourceLine:
       "Quelle: Zanarini et al. (2012), McLean Study; Gunderson et al. (2011).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("fortschritt-paradox", {
+    kicker: "Textversion",
+    summary:
+      "Genesung verläuft nicht linear. Rückschläge gehören zum Weg und entwerten bereits Erreichtes nicht automatisch.",
+    intro: [
+      "Diese Seite überträgt das Handout «Das Fortschritt-Paradox – Warum Rückschritte zum Weg gehören» in eine lesbare Web-Version. Es richtet sich an Angehörige, die Einbrüche realistischer einordnen möchten.",
+      "Die Struktur bleibt eng am Original: zuerst die Kernaussage, dann drei kurze Einordnungen und zum Schluss drei konkrete Hinweise für den Alltag.",
+    ],
+    sections: [
+      {
+        title: "Kernaussage",
+        calloutTitle: "Zentraler Satz des Handouts",
+        calloutText:
+          "Genesung verläuft nicht linear. Rückschritte sind Teil des Weges – nicht das Ende.",
+      },
+      {
+        title: "Wichtige Einordnungen",
+        cards: [
+          {
+            title: "Veränderung braucht Zeit",
+            text: "Veränderung braucht Zeit und Geduld.",
+          },
+          {
+            title: "Rückschläge entwerten nicht alles",
+            text: "Jeder Rückschlag ist kürzer als der vorherige.",
+          },
+          {
+            title: "Der Weg zurück",
+            text: "Der Weg zurück wird schneller.",
+          },
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        bullets: [
+          "Sehen Sie Rückfälle als Teil des Prozesses.",
+          "Vergleichen Sie mit früher, nicht mit gestern.",
+          "Feiern Sie kleine Fortschritte.",
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Zanarini et al. (2012); Mason/Kreger (2014).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("remission-heilung", {
+    kicker: "Textversion",
+    summary:
+      "Remission ist oft das realistische Ziel: Symptome können deutlich abnehmen, Alltag und Beziehungen stabiler werden, auch wenn nicht alles vollständig verschwindet.",
+    intro: [
+      "Diese Seite überträgt das Handout «Remission vs. Heilung – Was realistisch ist» in eine lesbare Web-Version. Es hilft Angehörigen, Besserung differenzierter und weniger schwarz-weiss einzuordnen.",
+      "Das Original stellt Heilung und Remission bewusst gegenüber und ergänzt die Einordnung mit einer knappen Kernaussage und drei alltagsnahen Hinweisen.",
+    ],
+    sections: [
+      {
+        title: "Heilung",
+        bullets: [
+          "Alle Symptome gelöst.",
+          "Keine Therapie mehr nötig.",
+          "Persönlichkeit verändert.",
+          "Selten realistisch.",
+        ],
+      },
+      {
+        title: "Remission",
+        bullets: [
+          "Symptome deutlich reduziert.",
+          "Stabilität im Alltag.",
+          "Fähigkeit zu Beziehungen.",
+          "Realistisches Ziel.",
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Zentraler Satz des Handouts",
+        calloutText:
+          "Remission ist das realistische Ziel – und ein grosser Erfolg.",
+      },
+      {
+        title: "Was können Sie tun?",
+        bullets: [
+          "Setzen Sie realistische Erwartungen: Besserung ja, Perfektion nein.",
+          "Feiern Sie kleine Fortschritte, statt auf die komplette Heilung zu warten.",
+          "Akzeptieren Sie, dass manche Muster bleiben können – aber handhabbar werden.",
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Zanarini et al. (2012); Paris (2020).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("5-faktoren-genesung", {
+    kicker: "Textversion",
+    summary:
+      "Genesung wird eher gefördert, wenn Behandlung, Medikation, Beziehungen, Lebensqualität und Zeit zusammenspielen. Angehörige können vor allem das Beeinflussbare unterstützen.",
+    intro: [
+      "Diese Seite überträgt das Handout «5 Faktoren der Genesung – Was Forschung zeigt» in eine lesbare Web-Version. Es richtet sich an Angehörige, die Hoffnung mit einem realistischen Blick auf wirksame Einflussfaktoren verbinden möchten.",
+      "Die Struktur folgt dem Original: fünf Faktoren, eine Kernaussage und drei Hinweise dazu, wie Angehörige den Prozess hilfreich begleiten können.",
+    ],
+    sections: [
+      {
+        title: "Die fünf Faktoren",
+        cards: [
+          {
+            title: "Therapie",
+            text: "Professionelle Behandlung als Säule.",
+          },
+          {
+            title: "Medikation",
+            text: "Unterstützend, nicht allein.",
+          },
+          {
+            title: "Soziales Netz",
+            text: "Verlässliche Beziehungen.",
+          },
+          {
+            title: "Lebensqualität",
+            text: "Sinnvolle Aktivitäten und Struktur.",
+          },
+          {
+            title: "Zeit",
+            text: "Genesung braucht Jahre, nicht Wochen.",
+          },
+        ],
+      },
+      {
+        title: "Kernaussage",
+        calloutTitle: "Zentraler Satz des Handouts",
+        calloutText:
+          "Genesung ist möglich – und Sie als Angehörige können bei den beeinflussbaren Faktoren unterstützen.",
+      },
+      {
+        title: "Was können Sie tun?",
+        bullets: [
+          "Prüfen Sie: Welchen Faktor können Sie unterstützen?",
+          "Konzentrieren Sie sich auf das Beeinflussbare.",
+          "Geben Sie nicht auf – Veränderung braucht Zeit.",
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Zanarini et al. (2012); Paris (2020).",
+    standLine:
+      "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
+  }),
+  createHandoutTextVersion("rolle-genesungsprozess", {
+    kicker: "Textversion",
+    summary:
+      "Angehörige können Genesung unterstützen, aber nicht herstellen. Der wichtigste Beitrag ist oft die eigene Stabilität, nicht das Retten.",
+    intro: [
+      "Diese Seite überträgt das Handout «Ihre Rolle im Genesungsprozess – Was Sie tun können – und was nicht» in eine lesbare Web-Version. Es hilft Angehörigen, ihren Beitrag klarer von Überverantwortung zu unterscheiden.",
+      "Die Originalstruktur bleibt erhalten: hilfreiche Beiträge, klare Nicht-Aufgaben, die Kernaussage des Blatts, die Farblegende und drei kurze Selbstchecks für den Alltag.",
+    ],
+    sections: [
+      {
+        title: "Was Sie tun können",
+        cards: [
+          {
+            title: "Konsistenz",
+            text: "Berechenbar und verlässlich bleiben.",
+          },
+          {
+            title: "Realistische Hoffnung",
+            text: "Genesung ist möglich – vermitteln Sie das.",
+          },
+          {
+            title: "Eigene Grenzen",
+            text: "Klar und konsequent bleiben.",
+          },
+          {
+            title: "Fortschritte benennen",
+            text: "Kleine Erfolge sichtbar machen.",
+          },
+          {
+            title: "Professionelle Hilfe unterstützen",
+            text: "Therapie fördern, nicht ersetzen.",
+          },
+        ],
+      },
+      {
+        title: "Was nicht Ihre Aufgabe ist",
+        cards: [
+          {
+            title: "Therapie ersetzen",
+            text: "Das ist Aufgabe der Fachpersonen.",
+          },
+          {
+            title: "Veränderung erzwingen",
+            text: "Genesung braucht eigene Motivation.",
+          },
+          {
+            title: "Immer verfügbar sein",
+            text: "Sie brauchen auch Pausen.",
+          },
+          {
+            title: "Eigene Bedürfnisse zurückstellen",
+            text: "Ihre Gesundheit zählt.",
+          },
+          {
+            title: "Für Genesung verantwortlich sein",
+            text: "Das liegt nicht in Ihrer Hand.",
+          },
+        ],
+      },
+      {
+        title: "Merksätze",
+        cards: [
+          {
+            title: "Ihre Stabilität",
+            text: "Ihre Stabilität ist Teil der Genesung.",
+          },
+          {
+            title: "Kernaussage",
+            text: "Sie können unterstützen. Sie müssen nicht retten.",
+          },
+        ],
+      },
+      {
+        title: "Legende",
+        cards: [
+          {
+            title: "Sage",
+            text: "Ihr Beitrag.",
+          },
+          {
+            title: "Terracotta",
+            text: "Nicht Ihre Aufgabe.",
+          },
+          {
+            title: "Slate",
+            text: "Kernbotschaft.",
+          },
+        ],
+      },
+      {
+        title: "Was können Sie tun?",
+        bullets: [
+          "Prüfen Sie regelmässig: Bin ich in meiner Rolle oder rutsche ich ab?",
+          "Sprechen Sie mit Fachpersonen, wenn Sie unsicher sind.",
+          "Erinnern Sie sich: Ihre Stabilität ist Ihr wichtigster Beitrag.",
+        ],
+      },
+    ],
+    sourceLine: "Quelle: Gunderson et al., Family Guidelines; Kreger (2014).",
     standLine:
       "Für Angehörige – Fachstelle Angehörigenarbeit, PUK Zürich – Ch. Egger | Stand: 03.02.2026.",
   }),

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -958,6 +958,74 @@ export const searchableContent: SearchEntry[] = [
     section: "Materialien",
   },
   {
+    title: "Textversion: Das Fortschritt-Paradox",
+    description:
+      "Lesbare Web-Version dazu, warum Rückschläge zum Genesungsweg gehören und Fortschritt nicht linear verläuft",
+    keywords: [
+      "textversion",
+      "fortschritt paradox",
+      "rückschläge",
+      "genesung",
+      "nicht linear",
+      "rückfälle",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/fortschritt-paradox",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Remission vs. Heilung",
+    description:
+      "Lesbare Web-Version zur Unterscheidung von Remission, Heilung, realistischer Besserung und alltagsbezogener Stabilität",
+    keywords: [
+      "textversion",
+      "remission",
+      "heilung",
+      "genesung",
+      "stabilität",
+      "realistische erwartungen",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/remission-heilung",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: 5 Faktoren, die Genesung fördern",
+    description:
+      "Lesbare Web-Version zu Therapie, Medikation, sozialem Netz, Lebensqualität und Zeit als günstige Faktoren der Genesung",
+    keywords: [
+      "textversion",
+      "5 faktoren",
+      "genesung fördern",
+      "therapie",
+      "medikation",
+      "soziales netz",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/5-faktoren-genesung",
+    section: "Materialien",
+  },
+  {
+    title: "Textversion: Ihre Rolle im Genesungsprozess",
+    description:
+      "Lesbare Web-Version zu hilfreichen Angehörigenbeiträgen, klaren Nicht-Aufgaben und realistischer Rollenklarheit",
+    keywords: [
+      "textversion",
+      "rolle im genesungsprozess",
+      "angehörige",
+      "rollenklarheit",
+      "nicht retten",
+      "stabilität",
+      "handout",
+      "pdf",
+    ],
+    href: "/materialien/text/rolle-genesungsprozess",
+    section: "Materialien",
+  },
+  {
     title: "Textversion: Wenn Mama oder Papa grosse Gefühle hat",
     description:
       "Lesbare Web-Version zu altersgerechter Erklärung von Borderline, Entlastung von Kindern und Schutzfaktoren im Familiensystem",


### PR DESCRIPTION
## Summary
- add four OCR-backed Genesung text versions for the remaining Genesung handouts
- wire the new handouts into the text-version resolver and search index
- extend smoke and source-mapping coverage for the new Genesung links

## Testing
- ./node_modules/.bin/tsc --noEmit
- ./node_modules/.bin/eslint client/src/ server/
- ./node_modules/.bin/vitest run --config vitest.config.ts
- ./node_modules/.bin/vite build
- ./node_modules/.bin/esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist