### PR TITLE
design(materialien): tighten intro spacing

### DIFF
--- a/client/src/pages/Materialien.tsx
+++ b/client/src/pages/Materialien.tsx
@@ -13,7 +13,7 @@ export default function Materialien() {
         path="/materialien"
       />
 
-      <section className="py-12 md:py-20 bg-gradient-to-b from-sage-light/30 to-background wave-divider">
+      <section className="pt-12 pb-6 md:pt-16 md:pb-8 bg-gradient-to-b from-sage-light/30 to-background wave-divider">
         <div className="container">
           <motion.div
             initial={{ opacity: 0 }}
@@ -27,7 +27,7 @@ export default function Materialien() {
               </div>
             </div>
 
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-6">
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-semibold text-foreground mb-5">
               Materialien für Angehörige
             </h1>
 

--- a/client/src/sections/MaterialienLibrarySection.tsx
+++ b/client/src/sections/MaterialienLibrarySection.tsx
@@ -319,10 +319,10 @@ export default function MaterialienLibrarySection() {
 
   return (
     <>
-      <section className="py-10 wave-divider-top">
+      <section className="pt-4 pb-10 md:pt-6 wave-divider-top">
         <div className="container">
           <div className="max-w-5xl mx-auto">
-            <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6">
+            <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-5">
               Was hilft gerade jetzt?
             </h2>
             <div className="grid md:grid-cols-2 xl:grid-cols-4 gap-4">


### PR DESCRIPTION
## Summary
- reduce the vertical gap between the materials page intro and the quick-start grid
- tighten the top rhythm of the first materials library section for a denser above-the-fold layout
- keep the change intentionally small and layout-only

## Verification
- npm test -- client/src/__tests__/materialien-library.test.tsx
- npm run typecheck
- npm run build