### PR TITLE
design(nav): polish shared navigation surfaces

### DIFF
--- a/client/src/components/layout/Breadcrumbs.tsx
+++ b/client/src/components/layout/Breadcrumbs.tsx
@@ -1,4 +1,5 @@
 import { Link, useLocation } from "wouter";
+import { getRouteAccent } from "@/components/layout/routeAccent";
 import { ArrowLeft, ChevronRight, Home } from "@/icons/root-icons";
 
 const pageNames: Record<string, string> = {
@@ -44,6 +45,7 @@ function getParentInfo(
 
 export function Breadcrumbs() {
   const [location] = useLocation();
+  const accent = getRouteAccent(location);
 
   if (location === "/") return null;
 
@@ -54,22 +56,29 @@ export function Breadcrumbs() {
   const backLabel = parent?.label || "Startseite";
 
   return (
-    <div className="border-b border-border/40 bg-background/60">
-      <nav className="container py-3" aria-label="Breadcrumb">
-        <div className="flex items-center justify-between">
+    <div className="border-b border-border/40 bg-[linear-gradient(180deg,rgba(250,250,247,0.82),rgba(248,250,249,0.92))]">
+      <nav className="container py-3 md:py-4" aria-label="Breadcrumb">
+        <div className="flex items-center justify-between gap-3">
           <Link
             href={backHref}
-            className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors group sm:hidden"
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium shadow-sm shadow-black/5 transition-colors group sm:hidden ${accent.breadcrumbBack}`}
           >
             <ArrowLeft className="w-4 h-4" />
             <span>{backLabel}</span>
           </Link>
 
-          <ol className="hidden sm:flex items-center gap-2 text-sm text-muted-foreground">
+          <span
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium sm:hidden ${accent.breadcrumbChip}`}
+          >
+            <span className={`h-2 w-2 rounded-full ${accent.dot}`} />
+            {pageName}
+          </span>
+
+          <ol className="hidden sm:flex items-center gap-2 rounded-full border border-border/60 bg-white/88 px-3 py-2 text-sm text-muted-foreground shadow-sm shadow-black/5 backdrop-blur-sm">
             <li>
               <Link
                 href="/"
-                className="flex items-center gap-1 hover:text-foreground transition-colors"
+                className="flex items-center gap-1.5 rounded-full px-2 py-1 transition-colors hover:bg-muted/60 hover:text-foreground"
               >
                 <Home className="w-4 h-4" />
                 <span>Startseite</span>
@@ -83,7 +92,7 @@ export function Breadcrumbs() {
                 />
                 <Link
                   href={parent.href}
-                  className="hover:text-foreground transition-colors"
+                  className={`transition-colors ${accent.textAccent}`}
                 >
                   {parent.label}
                 </Link>
@@ -94,7 +103,12 @@ export function Breadcrumbs() {
                 className="w-4 h-4 text-muted-foreground/50"
                 aria-hidden="true"
               />
-              <span className="text-foreground font-medium">{pageName}</span>
+              <span
+                className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-medium ${accent.breadcrumbChip}`}
+              >
+                <span className={`h-2 w-2 rounded-full ${accent.dot}`} />
+                {pageName}
+              </span>
             </li>
           </ol>
         </div>

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { MobileMenu } from "@/components/layout/MobileMenu";
 import { navItems } from "@/components/layout/navigationData";
 import { RessourcenMenu } from "@/components/layout/RessourcenMenu";
+import { getRouteAccent } from "@/components/layout/routeAccent";
 import { Menu, Phone, Search as SearchIcon, X } from "@/icons/root-icons";
 
 interface HeaderNavProps {
@@ -15,6 +16,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [mobileRessourcenOpen, setMobileRessourcenOpen] = useState(false);
   const [ressourcenOpen, setRessourcenOpen] = useState(false);
+  const currentAccent = getRouteAccent(location);
 
   useEffect(() => {
     setRessourcenOpen(false);
@@ -32,38 +34,46 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
   }, [mobileMenuOpen]);
 
   return (
-    <header className="sticky top-0 z-50 bg-background/95 backdrop-blur-sm border-b border-border/50">
+    <header className="sticky top-0 z-50 border-b border-border/60 bg-background/88 backdrop-blur-xl shadow-[0_10px_34px_-28px_rgba(15,23,42,0.45)]">
       <div className="container">
-        <div className="flex items-center justify-between gap-2 lg:gap-4 h-16 md:h-20">
-          <Link href="/" className="flex items-center gap-2 group shrink-0">
-            <img
-              src="/favicon-192.png"
-              alt="Startseite"
-              className="w-8 h-8 md:w-10 md:h-10 rounded-full"
-              width={40}
-              height={40}
-              loading="eager"
-              decoding="async"
-            />
-            <span className="hidden 2xl:inline font-medium text-sm text-muted-foreground group-hover:text-foreground transition-colors whitespace-nowrap">
-              Borderline · Hilfe für Angehörige
+        <div className="flex min-h-16 items-center justify-between gap-2 py-2 md:min-h-20 md:gap-4 md:py-3">
+          <Link href="/" className="flex items-center gap-3 group shrink-0">
+            <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-white/90 shadow-sm shadow-black/5 ring-1 ring-white/70 md:h-11 md:w-11">
+              <img
+                src="/favicon-192.png"
+                alt="Startseite"
+                className="h-8 w-8 rounded-full md:h-9 md:w-9"
+                width={40}
+                height={40}
+                loading="eager"
+                decoding="async"
+              />
+            </span>
+            <span className="hidden xl:flex flex-col leading-tight">
+              <span className="text-sm font-medium text-foreground transition-colors group-hover:text-sage-darker whitespace-nowrap">
+                Borderline · Hilfe für Angehörige
+              </span>
+              <span className="text-[11px] text-muted-foreground whitespace-nowrap">
+                Orientierung für belastete Beziehungssituationen
+              </span>
             </span>
           </Link>
 
           <nav
-            className="hidden lg:flex items-center bg-muted/50 rounded-full px-1.5 py-1 gap-0.5 shrink-0"
+            className="hidden lg:flex items-center gap-0.5 rounded-full border border-border/70 bg-white/82 px-2 py-1 shadow-[0_18px_34px_-30px_rgba(15,23,42,0.55)] backdrop-blur-sm shrink-0"
             aria-label="Hauptnavigation"
           >
             {navItems.map(item => {
               const isActive =
                 location === item.href || location.startsWith(item.href + "/");
+              const accent = getRouteAccent(item.href);
               return (
                 <Link
                   key={item.href}
                   href={item.href}
                   className={`px-2.5 lg:px-3 xl:px-3.5 py-1.5 rounded-full text-sm font-medium transition-all duration-300 whitespace-nowrap ${
                     isActive
-                      ? "bg-sage-dark text-white shadow-sm"
+                      ? accent.navActive
                       : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
                   }`}
                 >
@@ -83,7 +93,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             <button
               type="button"
               onClick={onSearchOpen}
-              className="hidden sm:flex items-center gap-2 px-3 py-1.5 rounded-lg border border-border/50 text-muted-foreground hover:text-foreground hover:border-border transition-colors text-sm"
+              className="hidden sm:flex h-10 items-center gap-2 rounded-full border border-border/70 bg-white/82 px-4 text-sm text-muted-foreground shadow-sm shadow-black/5 transition-colors hover:border-border hover:text-foreground"
               aria-label="Suchen"
             >
               <SearchIcon className="w-4 h-4" />
@@ -93,7 +103,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             <button
               type="button"
               onClick={onSearchOpen}
-              className="sm:hidden p-2.5 -m-0.5 rounded-lg text-muted-foreground hover:text-foreground hover:bg-muted transition-all"
+              className="sm:hidden inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-white/82 text-muted-foreground shadow-sm shadow-black/5 transition-all hover:text-foreground hover:bg-muted"
               aria-label="Suche öffnen"
             >
               <SearchIcon className="w-5 h-5" />
@@ -103,7 +113,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               asChild
               variant="default"
               size="sm"
-              className="bg-alert hover:bg-alert/85 text-white hidden sm:flex"
+              className="hidden sm:flex h-10 rounded-full bg-alert px-4 text-white shadow-[0_18px_34px_-22px_rgba(197,95,61,0.75)] hover:bg-alert/85"
             >
               <Link
                 href="/soforthilfe"
@@ -117,7 +127,9 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             <button
               type="button"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className="lg:hidden p-2.5 -m-0.5 rounded-lg hover:bg-muted transition-colors"
+              className={`lg:hidden inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/70 bg-white/82 shadow-sm shadow-black/5 transition-colors ${
+                mobileMenuOpen ? currentAccent.surfaceActive : "hover:bg-muted"
+              }`}
               aria-label={mobileMenuOpen ? "Menü schliessen" : "Menü öffnen"}
             >
               {mobileMenuOpen ? (

--- a/client/src/components/layout/MobileMenu.tsx
+++ b/client/src/components/layout/MobileMenu.tsx
@@ -6,6 +6,7 @@ import {
   Search as SearchIcon,
 } from "@/icons/root-icons";
 import { navItems, ressourcenItems } from "@/components/layout/navigationData";
+import { getRouteAccent } from "@/components/layout/routeAccent";
 
 interface MobileMenuProps {
   isOpen: boolean;
@@ -38,6 +39,7 @@ export function MobileMenu({
   const isRessourcenActive = ressourcenItems.some(item =>
     location.startsWith(item.href.split("#")[0])
   );
+  const currentAccent = getRouteAccent(location);
 
   const groupedRessourcen = groupRessourcenItems(ressourcenItems);
 
@@ -45,7 +47,7 @@ export function MobileMenu({
 
   return (
     <div
-      className="lg:hidden border-t border-border/50 bg-background overflow-y-auto overscroll-contain"
+      className="lg:hidden border-t border-border/50 bg-[linear-gradient(180deg,rgba(250,250,247,0.96),rgba(247,249,248,1))] overflow-y-auto overscroll-contain"
       style={{
         maxHeight: "calc(100dvh - 5rem)",
         WebkitOverflowScrolling: "touch",
@@ -65,15 +67,16 @@ export function MobileMenu({
         {navItems.map(item => {
           const Icon = item.icon;
           const isActive = location.startsWith(item.href);
+          const accent = getRouteAccent(item.href);
           return (
             <Link
               key={item.href}
               href={item.href}
               onClick={closeMenu}
-              className={`flex items-center gap-3 px-4 py-3.5 rounded-lg text-base font-medium transition-all ${
+              className={`flex items-center gap-3 px-4 py-3.5 rounded-2xl border text-base font-medium transition-all ${
                 isActive
-                  ? "bg-sage-wash text-sage-darker"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                  ? accent.surfaceActive
+                  : "border-transparent bg-white/70 text-muted-foreground hover:text-foreground hover:bg-muted"
               }`}
             >
               <Icon className="w-5 h-5" />
@@ -88,10 +91,10 @@ export function MobileMenu({
             onClick={() => setMobileRessourcenOpen(!mobileRessourcenOpen)}
             aria-expanded={mobileRessourcenOpen}
             aria-controls="mobile-ressourcen-menu"
-            className={`flex items-center justify-between w-full px-4 py-3 rounded-lg text-base font-medium transition-all ${
+            className={`flex items-center justify-between w-full px-4 py-3 rounded-2xl border text-base font-medium transition-all ${
               isRessourcenActive
-                ? "bg-sage-wash text-sage-darker"
-                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                ? currentAccent.surfaceActive
+                : "border-transparent bg-white/70 text-muted-foreground hover:text-foreground hover:bg-muted"
             }`}
           >
             <span className="flex items-center gap-3">
@@ -123,6 +126,7 @@ export function MobileMenu({
                         const Icon = item.icon;
                         const normalizedHref = item.href.split("#")[0];
                         const isActive = location === normalizedHref;
+                        const accent = getRouteAccent(item.href);
 
                         return (
                           <Link
@@ -132,10 +136,10 @@ export function MobileMenu({
                               closeMenu();
                               setMobileRessourcenOpen(false);
                             }}
-                            className={`flex items-center gap-3 px-4 py-2.5 rounded-lg text-sm font-medium transition-all ${
+                            className={`flex items-center gap-3 px-4 py-2.5 rounded-xl border text-sm font-medium transition-all ${
                               isActive
-                                ? "bg-sage-wash/50 text-sage-darker"
-                                : "text-muted-foreground hover:text-foreground hover:bg-muted"
+                                ? accent.surfaceActive
+                                : "border-transparent text-muted-foreground hover:text-foreground hover:bg-muted"
                             }`}
                           >
                             <Icon className="w-4 h-4" />
@@ -154,7 +158,7 @@ export function MobileMenu({
         <Link
           href="/soforthilfe"
           onClick={closeMenu}
-          className="flex items-center gap-3 px-4 py-3 rounded-lg text-base font-medium bg-alert text-white mt-2"
+          className="mt-2 flex items-center gap-3 rounded-2xl bg-alert px-4 py-3 text-base font-medium text-white shadow-[0_18px_32px_-22px_rgba(197,95,61,0.8)]"
         >
           <Phone className="w-5 h-5" />
           Soforthilfe
@@ -166,7 +170,7 @@ export function MobileMenu({
             closeMenu();
             onSearchOpen();
           }}
-          className="flex items-center gap-3 px-4 py-3 rounded-lg text-base font-medium text-muted-foreground hover:text-foreground hover:bg-muted mt-2 border border-border/50"
+          className="mt-2 flex items-center gap-3 rounded-2xl border border-border/60 bg-white/70 px-4 py-3 text-base font-medium text-muted-foreground hover:text-foreground hover:bg-muted"
           aria-label="Suche öffnen"
         >
           <SearchIcon className="w-5 h-5" />

--- a/client/src/components/layout/RessourcenMenu.tsx
+++ b/client/src/components/layout/RessourcenMenu.tsx
@@ -1,5 +1,6 @@
 import { Link } from "wouter";
 import { ressourcenItems } from "@/components/layout/navigationData";
+import { getRouteAccent } from "@/components/layout/routeAccent";
 import { useRessourcenMenuA11y } from "@/components/layout/useRessourcenMenuA11y";
 import type { NavigationItem } from "@/domain/content-types";
 import { ChevronDown } from "@/icons/root-icons";
@@ -48,6 +49,7 @@ export function RessourcenMenu({
   const isRessourcenActive = ressourcenItems.some(item =>
     location.startsWith(item.href.split("#")[0])
   );
+  const currentAccent = getRouteAccent(location);
 
   const groups = groupItems(ressourcenItems);
 
@@ -88,7 +90,7 @@ export function RessourcenMenu({
         }}
         className={`flex items-center gap-1 px-2.5 lg:px-3 xl:px-3.5 py-1.5 rounded-full text-sm font-medium transition-all duration-300 whitespace-nowrap ${
           isRessourcenActive || isOpen
-            ? "bg-sage-dark text-white shadow-sm"
+            ? currentAccent.navActive
             : "text-muted-foreground hover:text-foreground hover:bg-muted/60"
         }`}
         {...triggerA11yProps}
@@ -102,21 +104,23 @@ export function RessourcenMenu({
       {isOpen && (
         <div
           onKeyDown={handleMenuKeyDown}
-          className="absolute right-0 top-full mt-1 bg-background border border-border/60 rounded-xl shadow-lg shadow-black/8 z-50"
+          className="absolute right-0 top-full z-50 mt-2 rounded-[1.4rem] border border-border/65 bg-white/92 shadow-[0_34px_64px_-34px_rgba(15,23,42,0.55)] backdrop-blur-md"
           style={{ width: "min(680px, calc(100vw - 2rem))" }}
           {...menuA11yProps}
         >
-          <div className="grid grid-cols-3 gap-0 p-2">
+          <div className="grid grid-cols-3 gap-0 p-3">
             {groups.map((group, groupIdx) => (
               <div
                 key={group.name}
                 className={
-                  groupIdx > 0 ? "border-l border-border/40 pl-2" : undefined
+                  groupIdx > 0 ? "border-l border-border/40 pl-3" : undefined
                 }
               >
-                <div className="flex items-center gap-2.5 px-3 pt-2 pb-2">
-                  <span className="w-5 h-px bg-sage-dark/30" />
-                  <span className="text-[11px] font-semibold tracking-[0.08em] uppercase text-sage-dark/85 whitespace-nowrap">
+                <div className="flex items-center gap-2.5 px-3 pt-2 pb-2.5">
+                  <span className={`w-5 h-px ${currentAccent.dot}`} />
+                  <span
+                    className={`text-[11px] font-semibold tracking-[0.08em] uppercase whitespace-nowrap ${currentAccent.groupLabel}`}
+                  >
                     {group.name}
                   </span>
                 </div>
@@ -128,6 +132,7 @@ export function RessourcenMenu({
                     const isActive =
                       location === normalizedHref ||
                       location.startsWith(`${normalizedHref}/`);
+                    const accent = getRouteAccent(item.href);
                     const idx = flatIndex(groups, groupIdx, itemIdx);
 
                     return (
@@ -143,10 +148,10 @@ export function RessourcenMenu({
                           onMenuItemFocus(idx);
                         }}
                         onClick={closeDropdown}
-                        className={`flex items-center gap-2.5 px-3 py-2 text-[13px] rounded-lg transition-all outline-none focus-visible:ring-2 focus-visible:ring-sage-dark/40 focus-visible:ring-inset ${
+                        className={`flex items-center gap-2.5 rounded-xl border px-3 py-2.5 text-[13px] transition-all outline-none focus-visible:ring-2 focus-visible:ring-sage-dark/40 focus-visible:ring-inset ${
                           isActive
-                            ? "bg-sage-wash/50 text-sage-darker font-medium"
-                            : "text-muted-foreground hover:text-foreground hover:bg-muted/60 focus:text-foreground focus:bg-muted/60"
+                            ? `${accent.surfaceActive} font-medium`
+                            : "border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/60 focus:text-foreground focus:bg-muted/60"
                         }`}
                       >
                         <Icon className="w-4 h-4 shrink-0" />

--- a/client/src/components/layout/routeAccent.ts
+++ b/client/src/components/layout/routeAccent.ts
@@ -1,0 +1,144 @@
+export interface RouteAccent {
+  navActive: string;
+  surfaceActive: string;
+  breadcrumbChip: string;
+  breadcrumbBack: string;
+  textAccent: string;
+  dot: string;
+  groupLabel: string;
+}
+
+const accents = {
+  sage: {
+    navActive:
+      "bg-sage-dark text-white shadow-[0_16px_30px_-18px_rgba(31,101,109,0.9)]",
+    surfaceActive: "border-sage-light/70 bg-sage-wash text-sage-darker",
+    breadcrumbChip: "border-sage-light/70 bg-sage-wash/95 text-sage-darker",
+    breadcrumbBack:
+      "border-sage-light/60 bg-white/90 text-sage-darker hover:bg-sage-wash/80",
+    textAccent: "text-sage-darker",
+    dot: "bg-sage-dark",
+    groupLabel: "text-sage-dark/85",
+  },
+  terracotta: {
+    navActive:
+      "bg-terracotta text-white shadow-[0_16px_30px_-18px_rgba(165,97,55,0.9)]",
+    surfaceActive:
+      "border-terracotta-light/80 bg-terracotta-wash text-terracotta-darker",
+    breadcrumbChip:
+      "border-terracotta-light/80 bg-terracotta-wash/95 text-terracotta-darker",
+    breadcrumbBack:
+      "border-terracotta-light/70 bg-white/90 text-terracotta-darker hover:bg-terracotta-wash/85",
+    textAccent: "text-terracotta-darker",
+    dot: "bg-terracotta",
+    groupLabel: "text-terracotta-dark/85",
+  },
+  slate: {
+    navActive:
+      "bg-slate-dark text-white shadow-[0_16px_30px_-18px_rgba(82,109,158,0.85)]",
+    surfaceActive: "border-slate-light/85 bg-slate-wash text-slate-dark",
+    breadcrumbChip: "border-slate-light/85 bg-slate-wash/95 text-slate-dark",
+    breadcrumbBack:
+      "border-slate-light/80 bg-white/90 text-slate-dark hover:bg-slate-wash/85",
+    textAccent: "text-slate-dark",
+    dot: "bg-slate-blue",
+    groupLabel: "text-slate-dark/85",
+  },
+  sand: {
+    navActive:
+      "bg-sand-warm text-white shadow-[0_16px_30px_-18px_rgba(161,126,56,0.88)]",
+    surfaceActive: "border-sand-border/85 bg-sand-muted text-sand-warm",
+    breadcrumbChip: "border-sand-border/85 bg-sand-muted/95 text-sand-warm",
+    breadcrumbBack:
+      "border-sand-border/80 bg-white/90 text-sand-warm hover:bg-sand-muted/90",
+    textAccent: "text-sand-warm",
+    dot: "bg-sand-accent",
+    groupLabel: "text-sand-warm/85",
+  },
+  selfCare: {
+    navActive:
+      "bg-sage-mid text-white shadow-[0_16px_30px_-18px_rgba(59,127,117,0.88)]",
+    surfaceActive: "border-sage-light/80 bg-sage-pale text-sage-darker",
+    breadcrumbChip: "border-sage-light/80 bg-sage-pale text-sage-darker",
+    breadcrumbBack:
+      "border-sage-light/70 bg-white/90 text-sage-darker hover:bg-sage-pale",
+    textAccent: "text-sage-darker",
+    dot: "bg-sage-mid",
+    groupLabel: "text-sage-darker/85",
+  },
+  alert: {
+    navActive:
+      "bg-alert text-white shadow-[0_16px_30px_-18px_rgba(197,95,61,0.9)]",
+    surfaceActive: "border-alert-light/85 bg-alert-wash text-alert-dark",
+    breadcrumbChip: "border-alert-light/85 bg-alert-wash/95 text-alert-dark",
+    breadcrumbBack:
+      "border-alert-light/80 bg-white/90 text-alert-dark hover:bg-alert-wash/85",
+    textAccent: "text-alert-dark",
+    dot: "bg-alert",
+    groupLabel: "text-alert-dark/85",
+  },
+  navy: {
+    navActive:
+      "bg-navy text-white shadow-[0_16px_30px_-18px_rgba(34,52,85,0.88)]",
+    surfaceActive: "border-slate-light/85 bg-slate-pale text-navy",
+    breadcrumbChip: "border-slate-light/85 bg-slate-pale text-navy",
+    breadcrumbBack:
+      "border-slate-light/80 bg-white/90 text-navy hover:bg-slate-pale/90",
+    textAccent: "text-navy",
+    dot: "bg-navy-light",
+    groupLabel: "text-navy/80",
+  },
+} satisfies Record<string, RouteAccent>;
+
+function normalizePath(path: string) {
+  return path.split("#")[0];
+}
+
+function matches(path: string, prefixes: string[]) {
+  return prefixes.some(
+    prefix => path === prefix || path.startsWith(`${prefix}/`)
+  );
+}
+
+export function getRouteAccent(pathOrHref: string): RouteAccent {
+  const path = normalizePath(pathOrHref);
+
+  if (
+    matches(path, ["/soforthilfe", "/notfallkarte"]) ||
+    path === "/unterstuetzen/krise"
+  ) {
+    return accents.alert;
+  }
+
+  if (matches(path, ["/kommunizieren", "/uebungen", "/genesung"])) {
+    return accents.slate;
+  }
+
+  if (matches(path, ["/grenzen"])) {
+    return accents.sand;
+  }
+
+  if (matches(path, ["/selbstfuersorge", "/selbsttest"])) {
+    return accents.selfCare;
+  }
+
+  if (matches(path, ["/unterstuetzen", "/beratung", "/selbsthilfegruppen"])) {
+    return accents.terracotta;
+  }
+
+  if (
+    matches(path, [
+      "/verstehen",
+      "/materialien",
+      "/wegweiser",
+      "/faq",
+      "/glossar",
+      "/buchempfehlungen",
+      "/quellen",
+    ])
+  ) {
+    return accents.sage;
+  }
+
+  return accents.navy;
+}


### PR DESCRIPTION
## Summary
- refine the shared header surface with stronger desktop and mobile navigation affordances
- give breadcrumbs and resource navigation route-aware accent styles so subpages feel less generic
- improve the upper-page rhythm on subpages without touching individual page content

## Verification
- npm test -- client/src/__tests__/smoke.test.tsx
- npm run typecheck
- npm run build