### PR TITLE
design(kommunizieren): improve top-of-page architecture

### DIFF
--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -3,7 +3,13 @@ import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { motion } from "framer-motion";
-import { ArrowRight, Heart, Lightbulb, MessageCircle } from "lucide-react";
+import {
+  ArrowRight,
+  Heart,
+  Lightbulb,
+  MessageCircle,
+  ShieldAlert,
+} from "lucide-react";
 import { Link } from "wouter";
 import { TableOfContents } from "@/components/UXEnhancements";
 import ContentSection from "@/components/ContentSection";
@@ -15,7 +21,60 @@ import {
   KommunizierenSituationsSection,
 } from "@/sections/KommunizierenPatternSections";
 
+const kommunizierenIntroCards = [
+  {
+    icon: MessageCircle,
+    title: "Haltung vor Technik",
+    text: "Hilfreiche Kommunikation beginnt meist mit Tempo, Präsenz und innerer Klarheit, nicht mit dem perfekten Satz.",
+    iconClass: "text-slate-blue",
+    shellClass: "bg-slate-wash border-slate-light/80",
+  },
+  {
+    icon: Heart,
+    title: "Validierung zuerst",
+    text: "Erleben ernst nehmen, ohne automatisch zuzustimmen. Genau das senkt oft den Druck für spätere Klärung.",
+    iconClass: "text-terracotta-mid",
+    shellClass: "bg-terracotta-wash border-terracotta-light/80",
+  },
+  {
+    icon: ShieldAlert,
+    title: "Bei Eskalation vereinfachen",
+    text: "Weniger Inhalt, weniger Verteidigung, klarere Grenzen: so bleibt Gespräch eher regulierbar.",
+    iconClass: "text-sand-warm",
+    shellClass: "bg-sand-muted border-sand-border/80",
+  },
+] as const;
+
+const kommunizierenQuickLinks = [
+  {
+    id: "haltung",
+    title: "Kommunikation beginnt nicht mit Technik",
+    text: "Wenn Sie zuerst Ihre Grundhaltung und den Gesprächsrahmen klären möchten.",
+  },
+  {
+    id: "validierung",
+    title: "Validierung: der wichtigste Ausgangspunkt",
+    text: "Wenn Sie einen belastbaren Einstieg in schwierigere Gespräche suchen.",
+  },
+  {
+    id: "eskalation",
+    title: "Wenn Gespräche kippen",
+    text: "Wenn Sie gerade vor allem Orientierung für eskalierende Momente brauchen.",
+  },
+  {
+    id: "situationen",
+    title: "Typische schwierige Situationen",
+    text: "Wenn Sie konkrete Kommunikationsmuster im Alltag besser lesen möchten.",
+  },
+] as const;
+
 export default function Kommunizieren() {
+  const openSection = (sectionId: string) => {
+    window.dispatchEvent(
+      new CustomEvent("open-section", { detail: { sectionId } })
+    );
+  };
+
   return (
     <Layout>
       <SEO
@@ -57,7 +116,108 @@ export default function Kommunizieren() {
         </div>
       </section>
 
-      <section className="py-12 md:py-16 wave-divider-top">
+      <section className="py-8 md:py-10 wave-divider-top">
+        <div className="container">
+          <div className="mx-auto grid max-w-5xl gap-6 lg:grid-cols-[1.06fr_0.94fr]">
+            <Card className="border-slate-light/75 bg-white/92 shadow-[0_28px_56px_-40px_rgba(82,109,158,0.35)]">
+              <CardContent className="p-6 md:p-7">
+                <div className="mb-5 flex items-start gap-4">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-wash">
+                    <MessageCircle className="h-6 w-6 text-slate-blue" />
+                  </div>
+                  <div>
+                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
+                      <span className="h-px w-6 bg-slate-dark/30" />
+                      Überblick
+                    </span>
+                    <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
+                      Was auf dieser Seite besonders wichtig ist
+                    </h2>
+                  </div>
+                </div>
+
+                <p className="max-w-3xl text-sm leading-relaxed text-muted-foreground md:text-base">
+                  Diese Seite ordnet Kommunikation nicht als Sammlung kluger
+                  Formulierungen, sondern als Beziehungsregulation unter
+                  Belastung ein. Relevant sind vor allem Timing, Validierung,
+                  Begrenzung und die Frage, ob überhaupt schon Gesprächsraum da
+                  ist.
+                </p>
+
+                <div className="mt-6 grid gap-3 sm:grid-cols-3">
+                  {kommunizierenIntroCards.map(item => {
+                    const Icon = item.icon;
+                    return (
+                      <div
+                        key={item.title}
+                        className={`rounded-2xl border p-4 ${item.shellClass}`}
+                      >
+                        <Icon className={`mb-3 h-5 w-5 ${item.iconClass}`} />
+                        <h3 className="mb-2 text-sm font-semibold text-foreground">
+                          {item.title}
+                        </h3>
+                        <p className="text-sm leading-relaxed text-muted-foreground">
+                          {item.text}
+                        </p>
+                      </div>
+                    );
+                  })}
+                </div>
+              </CardContent>
+            </Card>
+
+            <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.28)]">
+              <CardContent className="p-6 md:p-7">
+                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
+                  <span className="h-px w-6 bg-slate-dark/30" />
+                  Direkt einsteigen
+                </span>
+                <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+                  Wenn Sie nicht alles am Stück lesen möchten, springen Sie
+                  direkt zum Kommunikationsblock, der Ihre aktuelle Lage am
+                  ehesten trifft.
+                </p>
+
+                <div className="mt-5 space-y-3">
+                  {kommunizierenQuickLinks.map(item => (
+                    <button
+                      key={item.id}
+                      type="button"
+                      onClick={() => openSection(item.id)}
+                      className="group w-full rounded-2xl border border-border/60 bg-white/90 px-4 py-4 text-left transition-all hover:-translate-y-0.5 hover:border-slate-light hover:bg-slate-wash/45 hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-dark/35 focus-visible:ring-offset-2"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <h3 className="text-sm font-semibold text-foreground">
+                            {item.title}
+                          </h3>
+                          <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                            {item.text}
+                          </p>
+                        </div>
+                        <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-slate-wash text-slate-dark transition-transform group-hover:translate-x-0.5">
+                          <ArrowRight className="h-4 w-4" />
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+
+                <div className="mt-5 rounded-2xl border border-slate-light/70 bg-slate-wash/80 px-4 py-4">
+                  <p className="text-sm leading-relaxed text-slate-dark">
+                    Das Inhaltsverzeichnis bleibt die Langform-Navigation. Die
+                    schnellen Einstiege hier sind für Momente gedacht, in denen
+                    Sie sofort zu Haltung, Validierung oder Deeskalation
+                    springen möchten.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </section>
+
+      <section className="pt-4 pb-12 md:pt-6 md:pb-16">
         <div className="container">
           <div className="max-w-3xl mx-auto">
             <ContentSection


### PR DESCRIPTION
## Summary
- add a clearer bridge between the kommunizieren hero and the first long-form sections
- introduce quick-jump cards for the most common communication entry points
- make the page easier to scan before users commit to the long-form content

## Verification
- npm test -- client/src/__tests__/smoke.test.tsx
- npm run typecheck
- npm run build