### PR TITLE
fix(css): preserve shared layout utilities on deferred routes

### DIFF
--- a/client/src/styles/deferred-routes.css
+++ b/client/src/styles/deferred-routes.css
@@ -8,11 +8,7 @@
 @source "../pages";
 @source "../components";
 @source not "../pages/Home.tsx";
-@source not "../components/Layout.tsx";
 @source not "../components/ErrorBoundary.tsx";
 @source not "../components/Search.tsx";
 @source not "../components/ScrollToTop.tsx";
-@source not "../components/layout";
-@source not "../components/ui/button.tsx";
-@source not "../components/ui/card.tsx";
 @source not "../components/ui/sonner.tsx";


### PR DESCRIPTION
## Summary
- stop excluding shared layout and shell utility sources from deferred route styles
- prevent late-loaded deferred CSS from overriding desktop header and other responsive shell utilities on content routes
- keep the deferred-route architecture intact while restoring correct desktop navigation on subpages

## Verification
- npm test -- client/src/__tests__/smoke.test.tsx
- npm run build
- manual screenshot checks on /genesung and /selbstfuersorge in dev and preview