### PR TITLE
[codex] fix mobile emergency access and branding

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -58,7 +58,6 @@
       href="https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Inter:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="/fallback.css" />
     <style>
       #route-prerender {
         display: none;
@@ -103,10 +102,22 @@
         text-decoration: none;
       }
 
-      .route-prerender-brand img {
+      .route-prerender-mark {
         width: 2.5rem;
         height: 2.5rem;
-        border-radius: 999px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border-radius: 1rem;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        background: rgba(255, 255, 255, 0.1);
+        box-shadow: 0 18px 32px -24px rgba(15, 23, 42, 0.85);
+      }
+
+      .route-prerender-mark svg {
+        width: 1.15rem;
+        height: 1.15rem;
+        color: rgba(255, 255, 255, 0.92);
       }
 
       .route-prerender-body {
@@ -275,6 +286,17 @@
         border-color: #b5412f;
         color: #fff;
       }
+
+      .fallback-noscript {
+        padding: 2rem;
+        text-align: center;
+        font-family: system-ui, sans-serif;
+        color: #333;
+      }
+
+      .fallback-noscript a {
+        color: #7f4434;
+      }
     </style>
   </head>
 
@@ -284,7 +306,21 @@
       <div class="route-prerender-shell">
         <div class="route-prerender-topbar">
           <a class="route-prerender-brand" href="/">
-            <img src="/favicon-192.png" alt="" width="40" height="40" />
+            <span class="route-prerender-mark" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path
+                  d="m16.24 7.76-1.804 5.411a2 2 0 0 1-1.265 1.265L7.76 16.24l1.804-5.411a2 2 0 0 1 1.265-1.265z"
+                />
+                <circle cx="12" cy="12" r="10" />
+              </svg>
+            </span>
             <span>Borderline · Hilfe für Angehörige</span>
           </a>
         </div>

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -4,6 +4,7 @@ const Search = lazy(() => import("@/components/Search"));
 import { Button } from "@/components/ui/button";
 import { HeaderNav } from "@/components/layout/HeaderNav";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
+import { BrandMark } from "@/components/layout/BrandMark";
 import { navItems, ressourcenItems } from "@/components/layout/navigationData";
 import { ScrollToTopButton } from "@/components/layout/ScrollToTopButton";
 import { getMobileFloatingMode as _getMobileFloatingMode } from "@/domain/floating-ui";
@@ -22,8 +23,11 @@ export default function Layout({ children }: LayoutProps) {
   const [location] = useLocation();
   const [searchOpen, setSearchOpen] = useState(false);
   const floatingMode = _getMobileFloatingMode(location);
-  const hasMobileSoforthilfeFab = location !== "/soforthilfe";
-  void floatingMode;
+  const isSoforthilfePage = location === "/soforthilfe";
+  const hasMobileSoforthilfeFab =
+    !isSoforthilfePage && floatingMode === "default";
+  const showInlineSoforthilfeLink =
+    !isSoforthilfePage && !hasMobileSoforthilfeFab;
 
   // Keyboard shortcut for search (Ctrl/Cmd + K) + ESC closes dropdown
   useEffect(() => {
@@ -59,6 +63,14 @@ export default function Layout({ children }: LayoutProps) {
           </span>
           <span className="hidden sm:inline">\u2022</span>
           <span>Für andere Regionen bitte lokale Notrufnummern nutzen.</span>
+          {showInlineSoforthilfeLink && (
+            <Link
+              href="/soforthilfe"
+              className="sm:hidden inline-flex min-h-9 items-center rounded-full border border-alert/25 bg-alert/10 px-3 py-1 text-sm font-medium text-alert transition-colors hover:bg-alert/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alert/40 focus-visible:ring-offset-2"
+            >
+              Zur Soforthilfe
+            </Link>
+          )}
         </div>
       </aside>
 
@@ -77,15 +89,7 @@ export default function Layout({ children }: LayoutProps) {
             {/* Brand + Absender */}
             <div className="lg:col-span-1">
               <Link href="/" className="flex items-center gap-2 mb-4">
-                <img
-                  src="/favicon-192.png"
-                  alt="Startseite"
-                  className="w-10 h-10 rounded-full"
-                  width={40}
-                  height={40}
-                  loading="lazy"
-                  decoding="async"
-                />
+                <BrandMark variant="dark" />
                 <span className="font-medium text-base text-white">
                   Borderline \u00b7 Hilfe für Angehörige
                 </span>
@@ -210,7 +214,7 @@ export default function Layout({ children }: LayoutProps) {
         </div>
       </footer>
 
-      {/* Mobile Soforthilfe-FAB: auf allen Seiten ausser /soforthilfe selbst */}
+      {/* Mobile Soforthilfe-FAB: nur auf kurzen Standardseiten, damit lange Inhalte frei bedienbar bleiben */}
       {hasMobileSoforthilfeFab && (
         <Button
           asChild

--- a/client/src/components/layout/BrandMark.tsx
+++ b/client/src/components/layout/BrandMark.tsx
@@ -1,0 +1,37 @@
+import { Compass } from "@/icons/root-icons";
+import { cn } from "@/lib/utils";
+
+interface BrandMarkProps {
+  className?: string;
+  iconClassName?: string;
+  variant?: "light" | "dark";
+}
+
+export function BrandMark({
+  className,
+  iconClassName,
+  variant = "light",
+}: BrandMarkProps) {
+  const isDark = variant === "dark";
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn(
+        "inline-flex h-10 w-10 items-center justify-center rounded-2xl",
+        isDark
+          ? "border border-white/15 bg-white/10 text-white shadow-[0_16px_28px_-22px_rgba(15,23,42,0.9)] ring-1 ring-white/10"
+          : "border border-border/60 bg-white/90 text-sage-darker shadow-sm shadow-black/5 ring-1 ring-white/70",
+        className
+      )}
+    >
+      <Compass
+        className={cn(
+          "h-5 w-5",
+          isDark ? "text-white/90" : "text-sage-darker",
+          iconClassName
+        )}
+      />
+    </span>
+  );
+}

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -5,6 +5,7 @@ import { MobileMenu } from "@/components/layout/MobileMenu";
 import { navItems } from "@/components/layout/navigationData";
 import { RessourcenMenu } from "@/components/layout/RessourcenMenu";
 import { getRouteAccent } from "@/components/layout/routeAccent";
+import { BrandMark } from "@/components/layout/BrandMark";
 import { Menu, Phone, Search as SearchIcon, X } from "@/icons/root-icons";
 
 interface HeaderNavProps {
@@ -38,17 +39,10 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
       <div className="container">
         <div className="flex min-h-16 items-center justify-between gap-2 py-2 md:min-h-20 md:gap-4 md:py-3">
           <Link href="/" className="flex items-center gap-3 group shrink-0">
-            <span className="inline-flex h-10 w-10 items-center justify-center rounded-2xl border border-border/60 bg-white/90 shadow-sm shadow-black/5 ring-1 ring-white/70 md:h-11 md:w-11">
-              <img
-                src="/favicon-192.png"
-                alt="Startseite"
-                className="h-8 w-8 rounded-full md:h-9 md:w-9"
-                width={40}
-                height={40}
-                loading="eager"
-                decoding="async"
-              />
-            </span>
+            <BrandMark
+              className="md:h-11 md:w-11"
+              iconClassName="md:h-[22px] md:w-[22px]"
+            />
             <span className="hidden xl:flex flex-col leading-tight">
               <span className="text-sm font-medium text-foreground transition-colors group-hover:text-sage-darker whitespace-nowrap">
                 Borderline · Hilfe für Angehörige


### PR DESCRIPTION
## Was geändert wurde
- reduziert den mobilen Notfall-Overhead auf langen Inhaltsseiten, indem der feste `Soforthilfe`-FAB dort entfällt
- ersetzt die bisherige Favicon-als-Logo-Nutzung durch ein eigenes kleines BrandMark mit bestehendem Kompass-Motiv
- räumt die Root-Fallback-Hülle im Einstieg auf, damit Branding und Notfall-Zugriff konsistenter wirken

## Warum
Die Audit-Funde zeigten zwei sichtbare UX-Probleme: Der feste mobile Notfall-CTA überlagerte auf Inhaltsseiten andere interaktive Elemente, und das Favicon wurde an mehreren Stellen als eigentliche Wort-/Bildmarke missbraucht. Dieses Paket behebt genau diese beiden Punkte ohne grösseren Architektur-Eingriff.

## Verifikation
- `npm run typecheck`
- `npm test -- client/src/__tests__/smoke.test.tsx`
- `npm run build`
