### PR TITLE
[codex] harden security header parity and modernize actions

### DIFF
--- a/.github/workflows/auto-merge-claude.yml
+++ b/.github/workflows/auto-merge-claude.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Create or find PR and merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: pnpm

--- a/client/src/__tests__/security-headers.test.ts
+++ b/client/src/__tests__/security-headers.test.ts
@@ -1,0 +1,33 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  CONTENT_SECURITY_POLICY,
+  SECURITY_HEADERS,
+} from "@shared/securityHeaders";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+describe("security headers", () => {
+  it("keeps Netlify headers aligned with the shared server header set", () => {
+    const netlifyConfig = fs.readFileSync(
+      path.join(repoRoot, "netlify.toml"),
+      "utf8"
+    );
+
+    for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+      expect(netlifyConfig).toContain(`${header} = "${value}"`);
+    }
+  });
+
+  it("keeps the CSP tightened with explicit non-embed directives", () => {
+    expect(CONTENT_SECURITY_POLICY).toContain("object-src 'none'");
+    expect(CONTENT_SECURITY_POLICY).toContain("frame-src 'none'");
+    expect(CONTENT_SECURITY_POLICY).toContain("base-uri 'self'");
+    expect(CONTENT_SECURITY_POLICY).toContain("form-action 'self'");
+    expect(CONTENT_SECURITY_POLICY).toContain("manifest-src 'self'");
+  });
+});

--- a/netlify.toml
+++ b/netlify.toml
@@ -25,7 +25,7 @@
     Referrer-Policy = "strict-origin-when-cross-origin"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(self)"
     Strict-Transport-Security = "max-age=31536000; includeSubDomains"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
+    Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; frame-ancestors 'none'; form-action 'self'; manifest-src 'self'; script-src 'self' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com"
 
 [[redirects]]
   from = "/notfallkarte.html"

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import { createServer } from "http";
 import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
+import { SECURITY_HEADERS } from "../shared/securityHeaders";
 import { createMaterialDownloadResponse } from "./material-download";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -15,21 +16,9 @@ async function startServer() {
   // Security headers (aligned with Netlify config)
   app.disable("x-powered-by");
   app.use((_req, res, next) => {
-    res.setHeader("X-Content-Type-Options", "nosniff");
-    res.setHeader("X-Frame-Options", "DENY");
-    res.setHeader("Referrer-Policy", "strict-origin-when-cross-origin");
-    res.setHeader(
-      "Content-Security-Policy",
-      "default-src 'self'; script-src 'self' https://forge.butterfly-effect.dev; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' https://files.manuscdn.com data:; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://forge.butterfly-effect.dev; media-src 'self' https://files.manuscdn.com; frame-ancestors 'none'"
-    );
-    res.setHeader(
-      "Strict-Transport-Security",
-      "max-age=31536000; includeSubDomains"
-    );
-    res.setHeader(
-      "Permissions-Policy",
-      "camera=(), microphone=(), geolocation=(self)"
-    );
+    for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+      res.setHeader(header, value);
+    }
     next();
   });
 

--- a/shared/securityHeaders.ts
+++ b/shared/securityHeaders.ts
@@ -1,0 +1,24 @@
+export const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "frame-src 'none'",
+  "frame-ancestors 'none'",
+  "form-action 'self'",
+  "manifest-src 'self'",
+  "script-src 'self' https://forge.butterfly-effect.dev",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "img-src 'self' https://files.manuscdn.com data:",
+  "font-src 'self' https://fonts.gstatic.com",
+  "connect-src 'self' https://forge.butterfly-effect.dev",
+  "media-src 'self' https://files.manuscdn.com",
+].join("; ");
+
+export const SECURITY_HEADERS = {
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Permissions-Policy": "camera=(), microphone=(), geolocation=(self)",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains",
+  "Content-Security-Policy": CONTENT_SECURITY_POLICY,
+} as const;


### PR DESCRIPTION
## Was geändert wurde
- führt `shared/securityHeaders.ts` als gemeinsame Quelle für die Server-Header ein
- härtet die CSP in `netlify.toml` und im Server-Stack mit expliziten Direktiven wie `base-uri`, `object-src`, `frame-src`, `form-action` und `manifest-src`
- ergänzt einen Test, der Drift zwischen `server/` und `netlify.toml` verhindert
- hebt die verwendeten GitHub Actions auf Node-24-kompatible Major-Versionen an

## Warum
Der aktuelle Audit-Rest lag vor allem im Ops-/Architektur-Bereich: Sicherheitsheader waren in zwei Stellen getrennt gepflegt und damit driftgefährdet, und die GitHub-Actions-Workflows zeigten bereits die Node-20-Deprecation-Warnung. Dieses Paket reduziert genau diese Betriebsrisiken, ohne das UI oder den App-Flow unnötig anzufassen.

## Verifikation
- `npx pnpm check`
- `npx pnpm lint`
- `npx pnpm test`
- `npx pnpm build`

## Restpunkt
`style-src 'unsafe-inline'` bleibt bewusst bestehen, weil die React-App weiterhin echte Inline-Styles verwendet. Das ist ein separater grösserer Refactor und nicht Teil dieses kleinen Ops-Pakets.
