### PR TITLE
[codex] reduce static style props in app shell components

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -219,11 +219,7 @@ export default function Layout({ children }: LayoutProps) {
         <Button
           asChild
           variant="default"
-          className="sm:hidden fixed z-50 h-12 px-4 rounded-full bg-alert hover:bg-alert/85 text-white shadow-lg gap-2 text-sm font-semibold"
-          style={{
-            bottom: "calc(4.5rem + env(safe-area-inset-bottom, 0px))",
-            right: "1rem",
-          }}
+          className="sm:hidden fixed right-4 z-50 h-12 px-4 rounded-full bg-alert hover:bg-alert/85 text-white shadow-lg gap-2 text-sm font-semibold bottom-[calc(4.5rem+env(safe-area-inset-bottom,0px))]"
         >
           <Link
             href="/soforthilfe"

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -44,8 +44,7 @@ export function ScrollToTopButton() {
           exit={{ opacity: 0, scale: 0.8, y: 20 }}
           transition={{ duration: 0.4, ease: "easeOut" }}
           onClick={scrollToTop}
-          className={`fixed right-4 z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy hover:bg-navy-light text-white shadow-lg items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
-          style={{ bottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
+          className={`fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy hover:bg-navy-light text-white shadow-lg items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
           aria-label="Nach oben scrollen"
         >
           <ChevronUp className="w-6 h-6" />
@@ -341,8 +340,7 @@ export function TableOfContents() {
       {floatingMode === "content" && showFloatingButton && (
         <motion.button
           onClick={() => setIsOpen(true)}
-          className="min-[1800px]:hidden fixed right-4 z-40 h-11 px-4 rounded-full bg-background border border-border shadow-lg flex items-center gap-2 text-sm font-medium text-foreground"
-          style={{ bottom: "calc(7.5rem + env(safe-area-inset-bottom, 0px))" }}
+          className="min-[1800px]:hidden fixed right-4 bottom-[calc(7.5rem+env(safe-area-inset-bottom,0px))] z-40 h-11 px-4 rounded-full bg-background border border-border shadow-lg flex items-center gap-2 text-sm font-medium text-foreground"
           aria-label="Inhaltsverzeichnis öffnen"
         >
           <List className="w-4 h-4" />
@@ -371,8 +369,7 @@ export function TableOfContents() {
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="min-[1800px]:hidden fixed left-0 right-0 bottom-0 max-h-[70vh] bg-background z-50 rounded-t-2xl shadow-2xl overflow-hidden flex flex-col"
-            style={{ paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+            className="min-[1800px]:hidden fixed left-0 right-0 bottom-0 max-h-[70vh] bg-background z-50 rounded-t-2xl shadow-2xl overflow-hidden flex flex-col pb-[env(safe-area-inset-bottom,0px)]"
           >
             {/* Drawer Handle */}
             <div className="flex justify-center pt-3 pb-1">
@@ -422,14 +419,7 @@ export function TableOfContents() {
       </AnimatePresence>
 
       {/* ─── Desktop: Sticky Sidebar in der linken Gutter-Zone ─── */}
-      <div
-        className="hidden min-[1800px]:block fixed z-30 w-60"
-        style={{
-          left: "max(0.75rem, calc((100vw - 1280px) / 2 - 15rem - 1.5rem))",
-          top: "calc(8rem + env(safe-area-inset-top, 0px))",
-          maxHeight: "calc(100vh - 9.5rem)",
-        }}
-      >
+      <div className="hidden min-[1800px]:block fixed left-[max(0.75rem,calc((100vw-1280px)/2-15rem-1.5rem))] top-[calc(8rem+env(safe-area-inset-top,0px))] z-30 max-h-[calc(100vh-9.5rem)] w-60">
         <div className="flex max-h-full flex-col overflow-hidden rounded-[1.4rem] border border-border/60 bg-background/92 shadow-[0_28px_52px_-36px_rgba(15,23,42,0.45)] backdrop-blur-md">
           <div className="px-4 pt-4 pb-2">
             <div className="flex items-center gap-2.5 rounded-full border border-sage-light/60 bg-sage-wash/80 px-3 py-2">

--- a/client/src/components/layout/RessourcenMenu.tsx
+++ b/client/src/components/layout/RessourcenMenu.tsx
@@ -104,8 +104,7 @@ export function RessourcenMenu({
       {isOpen && (
         <div
           onKeyDown={handleMenuKeyDown}
-          className="absolute right-0 top-full z-50 mt-2 rounded-[1.4rem] border border-border/65 bg-white/92 shadow-[0_34px_64px_-34px_rgba(15,23,42,0.55)] backdrop-blur-md"
-          style={{ width: "min(680px, calc(100vw - 2rem))" }}
+          className="absolute right-0 top-full z-50 mt-2 w-[min(680px,calc(100vw-2rem))] rounded-[1.4rem] border border-border/65 bg-white/92 shadow-[0_34px_64px_-34px_rgba(15,23,42,0.55)] backdrop-blur-md"
           {...menuA11yProps}
         >
           <div className="grid grid-cols-3 gap-0 p-3">

--- a/client/src/components/layout/ScrollToTopButton.tsx
+++ b/client/src/components/layout/ScrollToTopButton.tsx
@@ -29,8 +29,7 @@ export function ScrollToTopButton() {
           behavior: "smooth",
         })
       }
-      className={`fixed right-4 z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy hover:bg-navy-light text-white shadow-lg items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
-      style={{ bottom: "calc(1rem + env(safe-area-inset-bottom, 0px))" }}
+      className={`fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy hover:bg-navy-light text-white shadow-lg items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
       aria-label="Nach oben scrollen"
     >
       <ChevronUp className="w-6 h-6" />


### PR DESCRIPTION
## Was geändert wurde
- ersetzt statische `style={...}`-Props in `Layout`, `ScrollToTopButton`, `RessourcenMenu` und `UXEnhancements` durch Tailwind-Klassen mit Arbitrary Values
- zieht dabei insbesondere Safe-Area-Abstände, feste Dialogbreiten und die Desktop-TOC-Positionierung aus Inline-Styles heraus
- reduziert in diesen vier Dateien die verbleibenden `style={{ ... }}`-Treffer auf null

## Warum
Nach dem Root-Shell-Paket war der nächste sinnvolle CSP-Hygiene-Schritt, die klar statischen React-Style-Props abzubauen. Diese Werte sind nicht dynamisch und lassen sich verlustfrei in Klassen ausdrücken, wodurch der Inline-Style-Bestand weiter schrumpft.

## Verifikation
- `npx pnpm test`
- `npx pnpm build`
- zusätzlicher `rg`-Check auf `style={{ ... }}` in den vier betroffenen Dateien

## Restpunkt
Dynamische Farb- und Zustandsstyles in der App bleiben bewusst unangetastet. Für ein vollständiges Entfernen von `style-src 'unsafe-inline'` braucht es danach noch einen grösseren, thematisch eigenen Refactor.
