### PR TITLE
[codex] reduce wrapper and menu style props

### DIFF
--- a/client/src/components/layout/MobileMenu.tsx
+++ b/client/src/components/layout/MobileMenu.tsx
@@ -47,23 +47,14 @@ export function MobileMenu({
 
   return (
     <div
-      className="lg:hidden border-t border-border/50 bg-[linear-gradient(180deg,rgba(250,250,247,0.96),rgba(247,249,248,1))] overflow-y-auto overscroll-contain"
-      style={{
-        maxHeight: "calc(100dvh - 5rem)",
-        WebkitOverflowScrolling: "touch",
-      }}
+      className="lg:hidden max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain border-t border-border/50 bg-[linear-gradient(180deg,rgba(250,250,247,0.96),rgba(247,249,248,1))] [-webkit-overflow-scrolling:touch]"
       onKeyDown={e => {
         if (e.key === "Escape") {
           closeMenu();
         }
       }}
     >
-      <nav
-        className="container py-4 flex flex-col gap-2"
-        style={{
-          paddingBottom: "calc(16px + env(safe-area-inset-bottom, 0px) + 88px)",
-        }}
-      >
+      <nav className="container flex flex-col gap-2 py-4 pb-[calc(16px+env(safe-area-inset-bottom,0px)+88px)]">
         {navItems.map(item => {
           const Icon = item.icon;
           const isActive = location.startsWith(item.href);

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -1,4 +1,3 @@
-import type { CSSProperties } from "react";
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
@@ -474,8 +473,7 @@ export default function Selbstfuersorge() {
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
-              className="mb-12 wave-divider-top"
-              style={{ "--wave-color": "var(--background)" } as CSSProperties}
+              className="mb-12 wave-divider-top [--wave-color:var(--background)]"
             >
               <Card className="bg-gradient-to-br from-sage-lighter/30 to-sage-light/30 border-transparent">
                 <CardContent className="p-6 text-center">

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -75,8 +75,7 @@ function StickyAmpelLeiste() {
 
   return (
     <div
-      className={`sticky top-16 md:top-20 z-40 transition-all duration-300 ${visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-full pointer-events-none"}`}
-      style={{ marginBottom: 0 }}
+      className={`sticky top-16 md:top-20 z-40 mb-0 transition-all duration-300 ${visible ? "opacity-100 translate-y-0" : "opacity-0 -translate-y-full pointer-events-none"}`}
     >
       <div className="bg-background/95 backdrop-blur-md border-b border-border/50 shadow-sm">
         <div className="container">

--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type CSSProperties } from "react";
+import { useRef, useState } from "react";
 import {
   Download,
   ExternalLink,
@@ -49,8 +49,7 @@ export default function KommunizierenMaterialsSection() {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      className="mb-12 wave-divider-top"
-      style={{ "--wave-color": "var(--background)" } as CSSProperties}
+      className="mb-12 wave-divider-top [--wave-color:var(--background)]"
     >
       <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
         <Download className="w-8 h-8 text-slate-blue" />

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import { motion } from "framer-motion";
 import { Link } from "wouter";
 import {
@@ -56,9 +56,8 @@ export default function VerstehenInfografikenSection() {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      className="mb-12 wave-divider-top"
+      className="mb-12 wave-divider-top [--wave-color:var(--background)]"
       id="materialien"
-      style={{ "--wave-color": "var(--background)" } as CSSProperties}
     >
       <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
         <Download className="w-8 h-8 text-sage-dark" />

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState, type CSSProperties } from "react";
+import { useRef, useState } from "react";
 import {
   BookOpen,
   Brain,
@@ -56,9 +56,8 @@ export default function VerstehenMaterialsSection() {
       initial={{ opacity: 0, y: 20 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
-      className="mb-12 wave-divider-top"
+      className="mb-12 wave-divider-top [--wave-color:var(--background)]"
       id="materialien"
-      style={{ "--wave-color": "var(--background)" } as CSSProperties}
     >
       <h2 className="text-2xl md:text-3xl font-semibold text-foreground mb-6 flex items-center gap-3">
         <Download className="w-8 h-8 text-sage-dark" />


### PR DESCRIPTION
## Was geändert wurde
- ersetzt halb-statische `style={...}`-Props in den thematischen Material-Sektionen, im Mobile-Menü und in der Abschlussfläche von `Selbstfürsorge`
- zieht `--wave-color`-Variablen in Klassen mit Arbitrary Values um
- ersetzt Safe-Area- und Max-Height-Werte im Mobile-Menü durch Klassen
- ersetzt die statische `marginBottom: 0`-Angabe in `Soforthilfe` durch eine normale Utility-Klasse

## Warum
Nach den letzten beiden CSP-Paketen war dies der nächste kleine Restblock mit klar statischen Werten. Diese Props waren nicht fachlich dynamisch und liessen sich ohne Verhaltensänderung in Klassen ausdrücken. Damit schrumpft der verbleibende Inline-Style-Bestand weiter.

## Verifikation
- `npx pnpm prettier --check ...`
- `npx pnpm lint`
- `npx pnpm test`
- `npx pnpm build`
- zusätzlicher `rg`-Check auf die betroffenen Dateien: übrig bleibt dort nur noch der echte dynamische Farbfallback in `Soforthilfe.tsx`

## Restpunkt
Die grösseren dynamischen Farb- und Zustandsstyles in interaktiven Komponenten bleiben bewusst für einen separaten, grösseren Refactor.
