### PR TITLE
[codex] replace finite palette inline styles

### DIFF
--- a/client/src/components/interactive/GroundingTimer.tsx
+++ b/client/src/components/interactive/GroundingTimer.tsx
@@ -12,8 +12,8 @@ interface GroundingStep {
   count: number;
   sense: string;
   icon: React.ElementType;
-  color: string;
-  bgColor: string;
+  iconBoxClass: string;
+  containerClass: string;
   instruction: string;
   prompt: string;
 }
@@ -23,8 +23,8 @@ const steps: GroundingStep[] = [
     count: 5,
     sense: "Sehen",
     icon: Eye,
-    color: "var(--color-sage-mid)",
-    bgColor: "var(--color-sage-wash)",
+    iconBoxClass: "bg-sage-mid",
+    containerClass: "bg-sage-wash",
     instruction: "Benennen Sie 5 Dinge, die Sie sehen.",
     prompt: "Schauen Sie sich um. Was fällt Ihnen auf?",
   },
@@ -32,8 +32,8 @@ const steps: GroundingStep[] = [
     count: 4,
     sense: "Hören",
     icon: Ear,
-    color: "var(--color-slate-dark)",
-    bgColor: "var(--color-slate-wash)",
+    iconBoxClass: "bg-slate-dark",
+    containerClass: "bg-slate-wash",
     instruction: "Benennen Sie 4 Dinge, die Sie hören.",
     prompt: "Hören Sie bewusst hin. Welche Geräusche sind da?",
   },
@@ -41,8 +41,8 @@ const steps: GroundingStep[] = [
     count: 3,
     sense: "Fühlen",
     icon: Hand,
-    color: "var(--color-terracotta-mid)",
-    bgColor: "var(--color-terracotta-wash)",
+    iconBoxClass: "bg-terracotta-mid",
+    containerClass: "bg-terracotta-wash",
     instruction:
       "Benennen Sie 3 Dinge, die Sie berühren oder körperlich spüren.",
     prompt: "Achten Sie auf Kontaktflächen, Temperatur oder Druck.",
@@ -51,8 +51,8 @@ const steps: GroundingStep[] = [
     count: 2,
     sense: "Riechen",
     icon: Nose,
-    color: "var(--color-sand-mid)",
-    bgColor: "var(--color-sand-muted)",
+    iconBoxClass: "bg-sand-mid",
+    containerClass: "bg-sand-muted",
     instruction: "Benennen Sie 2 Dinge, die Sie riechen.",
     prompt: "Atmen Sie ruhig ein. Was ist wahrnehmbar?",
   },
@@ -60,8 +60,8 @@ const steps: GroundingStep[] = [
     count: 1,
     sense: "Schmecken",
     icon: Coffee,
-    color: "var(--color-terracotta-dark)",
-    bgColor: "var(--color-terracotta-wash)",
+    iconBoxClass: "bg-terracotta-dark",
+    containerClass: "bg-terracotta-wash",
     instruction: "Benennen Sie 1 Ding, das Sie schmecken.",
     prompt:
       "Vielleicht ist noch ein Geschmack im Mund oder von einem Getränk da.",
@@ -96,13 +96,11 @@ export default function GroundingTimer() {
             return (
               <div
                 key={step.sense}
-                className="rounded-xl border border-border/50 p-4"
-                style={{ backgroundColor: step.bgColor }}
+                className={`rounded-xl border border-border/50 p-4 ${step.containerClass}`}
               >
                 <div className="flex items-start gap-3">
                   <div
-                    className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
-                    style={{ backgroundColor: step.color }}
+                    className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${step.iconBoxClass}`}
                   >
                     <Icon className="w-5 h-5 text-white" />
                   </div>

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -31,9 +31,22 @@ interface FAQItem {
 interface FAQCategory {
   title: string;
   icon: React.ReactNode;
-  color: string;
+  tone: keyof typeof FAQ_CATEGORY_STYLES;
   questions: FAQItem[];
 }
+
+const FAQ_CATEGORY_STYLES = {
+  slate: {
+    navIconClass: "text-slate-mid",
+    iconTileClass: "bg-slate-mid text-white",
+    chipClass: "bg-slate-light text-slate-mid hover:bg-slate-lighter",
+  },
+  sage: {
+    navIconClass: "text-sage-mid",
+    iconTileClass: "bg-sage-mid text-white",
+    chipClass: "bg-sage-wash text-sage-mid hover:bg-sage-light",
+  },
+} as const;
 
 function slugifyCategory(title: string) {
   return title
@@ -51,7 +64,7 @@ export default function FAQ() {
     {
       title: "Diagnose & Krankheitsverständnis",
       icon: <HelpCircle className="w-5 h-5" />,
-      color: "var(--color-slate-mid)",
+      tone: "slate",
       questions: [
         {
           question: "Soll ich die Diagnose ansprechen?",
@@ -86,7 +99,7 @@ export default function FAQ() {
     {
       title: "Kommunikation & Konflikte",
       icon: <MessageCircle className="w-5 h-5" />,
-      color: "var(--color-sage-mid)",
+      tone: "sage",
       questions: [
         {
           question: "Wie reagiere ich auf bedrohlich wirkende Aussagen?",
@@ -122,7 +135,7 @@ export default function FAQ() {
     {
       title: "Grenzen & Selbstschutz",
       icon: <Shield className="w-5 h-5" />,
-      color: "var(--color-sage-mid)",
+      tone: "sage",
       questions: [
         {
           question: "Wann ist eine Einweisung nötig?",
@@ -159,7 +172,7 @@ export default function FAQ() {
     {
       title: "Therapie & Behandlung",
       icon: <Heart className="w-5 h-5" />,
-      color: "var(--color-slate-mid)",
+      tone: "slate",
       questions: [
         {
           question: "Mein Angehöriger will keine Therapie – was tun?",
@@ -199,7 +212,7 @@ export default function FAQ() {
     {
       title: "Alltag & Beziehung",
       icon: <Users className="w-5 h-5" />,
-      color: "var(--color-sage-mid)",
+      tone: "sage",
       questions: [
         {
           question: "Wie erkläre ich die Situation Freunden/Familie?",
@@ -297,86 +310,86 @@ export default function FAQ() {
                 Direkt zum passenden Themenbereich:
               </p>
               <div className="flex flex-wrap gap-2">
-                {faqCategories.map(category => (
-                  <a
-                    key={category.title}
-                    href={`#${slugifyCategory(category.title)}`}
-                    className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/20"
-                  >
-                    <span
-                      className="flex-shrink-0"
-                      style={{ color: category.color }}
+                {faqCategories.map(category => {
+                  const tone = FAQ_CATEGORY_STYLES[category.tone];
+
+                  return (
+                    <a
+                      key={category.title}
+                      href={`#${slugifyCategory(category.title)}`}
+                      className="inline-flex items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground hover:border-foreground/20"
                     >
-                      {category.icon}
-                    </span>
-                    {category.title}
-                  </a>
-                ))}
+                      <span className={`flex-shrink-0 ${tone.navIconClass}`}>
+                        {category.icon}
+                      </span>
+                      {category.title}
+                    </a>
+                  );
+                })}
               </div>
             </nav>
 
-            {faqCategories.map((category, categoryIndex) => (
-              <motion.div
-                key={category.title}
-                id={slugifyCategory(category.title)}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
-                viewport={{ once: true }}
-                transition={{ delay: categoryIndex * 0.1, ease: "easeOut" }}
-                className="mb-8 scroll-mt-28"
-              >
-                <div className="flex items-center gap-3 mb-4">
-                  <div
-                    className="w-10 h-10 rounded-lg flex items-center justify-center text-white"
-                    style={{ backgroundColor: category.color }}
-                  >
-                    {category.icon}
-                  </div>
-                  <h2 className="text-xl md:text-2xl font-normal text-foreground">
-                    {category.title}
-                  </h2>
-                </div>
+            {faqCategories.map((category, categoryIndex) => {
+              const tone = FAQ_CATEGORY_STYLES[category.tone];
 
-                <Accordion type="single" collapsible className="space-y-3">
-                  {category.questions.map((faq, faqIndex) => (
-                    <AccordionItem
-                      key={faqIndex}
-                      value={`${categoryIndex}-${faqIndex}`}
-                      className="border rounded-lg bg-card hover:bg-accent/5 transition-colors"
+              return (
+                <motion.div
+                  key={category.title}
+                  id={slugifyCategory(category.title)}
+                  initial={{ opacity: 0, y: 20 }}
+                  whileInView={{ opacity: 1, y: 0 }}
+                  viewport={{ once: true }}
+                  transition={{ delay: categoryIndex * 0.1, ease: "easeOut" }}
+                  className="mb-8 scroll-mt-28"
+                >
+                  <div className="flex items-center gap-3 mb-4">
+                    <div
+                      className={`w-10 h-10 rounded-lg flex items-center justify-center ${tone.iconTileClass}`}
                     >
-                      <AccordionTrigger className="px-5 py-4 hover:no-underline text-left">
-                        <span className="font-medium text-foreground pr-4">
-                          {faq.question}
-                        </span>
-                      </AccordionTrigger>
-                      <AccordionContent className="px-5 pb-5">
-                        <p className="text-muted-foreground leading-relaxed mb-4">
-                          {faq.answer}
-                        </p>
-                        {faq.links && faq.links.length > 0 && (
-                          <div className="flex flex-wrap gap-2">
-                            {faq.links.map((link, linkIndex) => (
-                              <Link key={linkIndex} href={link.url}>
-                                <span
-                                  className="inline-flex items-center gap-1 text-sm font-medium px-3 py-1.5 rounded-full transition-colors"
-                                  style={{
-                                    backgroundColor: `${category.color}15`,
-                                    color: category.color,
-                                  }}
-                                >
-                                  {link.text}
-                                  <ChevronRight className="w-3 h-3" />
-                                </span>
-                              </Link>
-                            ))}
-                          </div>
-                        )}
-                      </AccordionContent>
-                    </AccordionItem>
-                  ))}
-                </Accordion>
-              </motion.div>
-            ))}
+                      {category.icon}
+                    </div>
+                    <h2 className="text-xl md:text-2xl font-normal text-foreground">
+                      {category.title}
+                    </h2>
+                  </div>
+
+                  <Accordion type="single" collapsible className="space-y-3">
+                    {category.questions.map((faq, faqIndex) => (
+                      <AccordionItem
+                        key={faqIndex}
+                        value={`${categoryIndex}-${faqIndex}`}
+                        className="border rounded-lg bg-card hover:bg-accent/5 transition-colors"
+                      >
+                        <AccordionTrigger className="px-5 py-4 hover:no-underline text-left">
+                          <span className="font-medium text-foreground pr-4">
+                            {faq.question}
+                          </span>
+                        </AccordionTrigger>
+                        <AccordionContent className="px-5 pb-5">
+                          <p className="text-muted-foreground leading-relaxed mb-4">
+                            {faq.answer}
+                          </p>
+                          {faq.links && faq.links.length > 0 && (
+                            <div className="flex flex-wrap gap-2">
+                              {faq.links.map((link, linkIndex) => (
+                                <Link key={linkIndex} href={link.url}>
+                                  <span
+                                    className={`inline-flex items-center gap-1 rounded-full px-3 py-1.5 text-sm font-medium transition-colors ${tone.chipClass}`}
+                                  >
+                                    {link.text}
+                                    <ChevronRight className="w-3 h-3" />
+                                  </span>
+                                </Link>
+                              ))}
+                            </div>
+                          )}
+                        </AccordionContent>
+                      </AccordionItem>
+                    ))}
+                  </Accordion>
+                </motion.div>
+              );
+            })}
 
             <EvidenceNote
               title="Quellen zu Prognose- und Therapieaussagen"

--- a/client/src/pages/Glossar.tsx
+++ b/client/src/pages/Glossar.tsx
@@ -222,24 +222,32 @@ const categoryInfo = {
   therapie: {
     label: "Therapie & Behandlung",
     icon: Brain,
-    color: "var(--color-slate-mid)",
+    activeClass: "bg-slate-mid text-white",
+    stripClass: "bg-slate-mid",
+    iconClass: "text-slate-mid",
   },
   kommunikation: {
     label: "Kommunikation",
     icon: MessageCircle,
-    color: "var(--color-sage-dark)",
+    activeClass: "bg-sage-dark text-white",
+    stripClass: "bg-sage-dark",
+    iconClass: "text-sage-dark",
   },
   symptome: {
     label: "Symptome & Muster",
     icon: AlertTriangle,
-    color: "var(--color-sage-dark)",
+    activeClass: "bg-sage-dark text-white",
+    stripClass: "bg-sage-dark",
+    iconClass: "text-sage-dark",
   },
   selbsthilfe: {
     label: "Selbsthilfe & Angehörige",
     icon: Heart,
-    color: "var(--color-sage-mid)",
+    activeClass: "bg-sage-mid text-white",
+    stripClass: "bg-sage-mid",
+    iconClass: "text-sage-mid",
   },
-};
+} as const;
 
 export default function Glossar() {
   const [searchTerm, setSearchTerm] = useState("");
@@ -350,14 +358,9 @@ export default function Glossar() {
                   }
                   aria-label={info.label}
                   aria-pressed={selectedCategory === key}
-                  style={
-                    selectedCategory === key
-                      ? { backgroundColor: info.color }
-                      : undefined
-                  }
                   className={`px-4 py-2 rounded-lg text-sm font-medium transition-all flex items-center gap-2 ${
                     selectedCategory === key
-                      ? "text-white"
+                      ? info.activeClass
                       : "bg-muted/50 text-muted-foreground hover:bg-muted"
                   }`}
                 >
@@ -397,8 +400,7 @@ export default function Glossar() {
                         <div className="flex flex-col md:flex-row">
                           {/* Category indicator */}
                           <div
-                            className="w-full md:w-2 h-2 md:h-auto"
-                            style={{ backgroundColor: category.color }}
+                            className={`h-2 w-full md:h-auto md:w-2 ${category.stripClass}`}
                           />
 
                           <div className="p-6 flex-1">
@@ -415,8 +417,7 @@ export default function Glossar() {
                                 </h2>
                                 <div className="flex items-center gap-2 mt-1">
                                   <category.icon
-                                    className="w-4 h-4"
-                                    style={{ color: category.color }}
+                                    className={`w-4 h-4 ${category.iconClass}`}
                                   />
                                   <span className="text-sm text-muted-foreground">
                                     {category.label}

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -57,19 +57,19 @@ function StickyAmpelLeiste() {
       id: "block-rot",
       label: "Lebensgefahr",
       sub: "144 · 117 · 112",
-      bg: "var(--color-sos-rot)",
+      buttonClass: "bg-sos-rot",
     },
     {
       id: "block-orange",
       label: "Psychiatr. Krise",
       sub: "PUK 24/7",
-      bg: "var(--color-sos-orange-text)",
+      buttonClass: "bg-sos-orange-text",
     },
     {
       id: "block-gruen",
       label: "Jemand zum Reden",
       sub: "143",
-      bg: "var(--color-sos-gruen-text)",
+      buttonClass: "bg-sos-gruen-text",
     },
   ] as const;
 
@@ -86,8 +86,7 @@ function StickyAmpelLeiste() {
                 type="button"
                 onClick={() => scrollTo(item.id)}
                 aria-label={`Zu Abschnitt: ${item.label}`}
-                className="flex-1 flex flex-col sm:flex-row items-center justify-center gap-0.5 sm:gap-2 px-1.5 sm:px-3 py-2 sm:py-2.5 rounded-lg text-white font-medium text-[10px] sm:text-sm transition-all hover:brightness-90 active:scale-[0.97] shadow-sm min-h-[44px]"
-                style={{ backgroundColor: item.bg }}
+                className={`flex-1 flex min-h-[44px] flex-col items-center justify-center gap-0.5 rounded-lg px-1.5 py-2 text-[10px] font-medium text-white shadow-sm transition-all hover:brightness-90 active:scale-[0.97] sm:flex-row sm:gap-2 sm:px-3 sm:py-2.5 sm:text-sm ${item.buttonClass}`}
               >
                 <span className="font-semibold leading-tight text-center">
                   {item.label}


### PR DESCRIPTION
## Summary
- replace finite inline color styles in FAQ, Glossar, Soforthilfe and GroundingTimer with class-based palette metadata
- keep behaviour and content unchanged while moving fixed variants out of inline style props
- reduce the remaining client/src inline-style count from 28 to 20

## Verification
- npx pnpm lint
- npx pnpm test
- npx pnpm build
