### PR TITLE
[codex] replace result tone inline styles

### DIFF
--- a/client/src/components/Selbsttest.tsx
+++ b/client/src/components/Selbsttest.tsx
@@ -36,8 +36,10 @@ interface Result {
   primaryText: string;
   secondaryLinks: { href: string; text: string }[];
   icon: React.ElementType;
-  color: string;
-  bgColor: string;
+  cardClass: string;
+  surfaceClass: string;
+  accentBgClass: string;
+  buttonClass: string;
 }
 
 const questions: Question[] = [
@@ -166,8 +168,10 @@ const results: Result[] = [
       { href: "/unterstuetzen/krise", text: "Krisenbegleitung lernen" },
     ],
     icon: AlertTriangle,
-    color: "var(--color-alert)",
-    bgColor: "var(--color-sage-wash)",
+    cardClass: "border-alert",
+    surfaceClass: "bg-sage-wash",
+    accentBgClass: "bg-alert",
+    buttonClass: "bg-alert hover:bg-alert/90",
   },
   {
     id: "krise",
@@ -181,8 +185,10 @@ const results: Result[] = [
       { href: "/soforthilfe", text: "Soforthilfe" },
     ],
     icon: Clock,
-    color: "var(--color-sand-mid)",
-    bgColor: "var(--color-sage-wash)",
+    cardClass: "border-sand-mid",
+    surfaceClass: "bg-sage-wash",
+    accentBgClass: "bg-sand-mid",
+    buttonClass: "bg-sand-mid hover:bg-sand-warm",
   },
   {
     id: "kommunizieren",
@@ -196,8 +202,10 @@ const results: Result[] = [
       { href: "/verstehen", text: "Borderline verstehen" },
     ],
     icon: MessageCircle,
-    color: "var(--color-slate-blue)",
-    bgColor: "var(--color-slate-light)",
+    cardClass: "border-slate-blue",
+    surfaceClass: "bg-slate-light",
+    accentBgClass: "bg-slate-blue",
+    buttonClass: "bg-slate-blue hover:bg-slate-dark",
   },
   {
     id: "verstehen",
@@ -211,8 +219,10 @@ const results: Result[] = [
       { href: "/kommunizieren", text: "Kommunikation verbessern" },
     ],
     icon: BookOpen,
-    color: "var(--color-sage)",
-    bgColor: "var(--color-sage-light)",
+    cardClass: "border-sage",
+    surfaceClass: "bg-sage-light",
+    accentBgClass: "bg-sage",
+    buttonClass: "bg-sage hover:bg-sage-dark",
   },
   {
     id: "unterstuetzen",
@@ -226,8 +236,10 @@ const results: Result[] = [
       { href: "/unterstuetzen/therapie", text: "Therapie unterstützen" },
     ],
     icon: Heart,
-    color: "var(--color-sage-dark)",
-    bgColor: "var(--color-sage-light)",
+    cardClass: "border-sage-dark",
+    surfaceClass: "bg-sage-light",
+    accentBgClass: "bg-sage-dark",
+    buttonClass: "bg-sage-dark hover:bg-sage-mid",
   },
   {
     id: "grenzen",
@@ -241,8 +253,10 @@ const results: Result[] = [
       { href: "/kommunizieren", text: "Kommunikationstechniken" },
     ],
     icon: Shield,
-    color: "var(--color-sage-mid)",
-    bgColor: "var(--color-sage-lighter)",
+    cardClass: "border-sage-mid",
+    surfaceClass: "bg-sage-lighter",
+    accentBgClass: "bg-sage-mid",
+    buttonClass: "bg-sage-mid hover:bg-sage-dark",
   },
   {
     id: "selbstfuersorge",
@@ -256,8 +270,10 @@ const results: Result[] = [
       { href: "/materialien", text: "Materialien & Ressourcen" },
     ],
     icon: Sparkles,
-    color: "var(--color-sage-mid)",
-    bgColor: "var(--color-sage-lighter)",
+    cardClass: "border-sage-mid",
+    surfaceClass: "bg-sage-lighter",
+    accentBgClass: "bg-sage-mid",
+    buttonClass: "bg-sage-mid hover:bg-sage-dark",
   },
 ];
 
@@ -362,18 +378,11 @@ export default function Selbsttest() {
         aria-live="polite"
         role="status"
       >
-        <Card
-          className="border-2 overflow-hidden"
-          style={{ borderColor: result.color }}
-        >
-          <div
-            className="p-6 md:p-8"
-            style={{ backgroundColor: result.bgColor }}
-          >
+        <Card className={`overflow-hidden border-2 ${result.cardClass}`}>
+          <div className={`p-6 md:p-8 ${result.surfaceClass}`}>
             <div className="flex items-center gap-4 mb-4">
               <div
-                className="w-14 h-14 rounded-2xl flex items-center justify-center"
-                style={{ backgroundColor: result.color }}
+                className={`flex h-14 w-14 items-center justify-center rounded-2xl ${result.accentBgClass}`}
               >
                 <Icon className="w-7 h-7 text-white" />
               </div>
@@ -394,8 +403,7 @@ export default function Selbsttest() {
             <div className="flex flex-col sm:flex-row gap-3 mb-6">
               <Button
                 size="lg"
-                className="w-full sm:w-auto text-white"
-                style={{ backgroundColor: result.color }}
+                className={`w-full text-white sm:w-auto ${result.buttonClass}`}
                 asChild
               >
                 <Link href={result.primaryLink}>

--- a/client/src/components/interactive/ValidierungsStufenleiter.tsx
+++ b/client/src/components/interactive/ValidierungsStufenleiter.tsx
@@ -15,7 +15,9 @@ interface Stufe {
   title: string;
   subtitle: string;
   icon: React.ElementType;
-  color: string;
+  badgeClass: string;
+  iconClass: string;
+  exampleClass: string;
   ziel: string;
   soGehts: string[];
   beispielsaetze: string[];
@@ -32,7 +34,10 @@ const stufen: Stufe[] = [
     title: "Aufmerksam sein",
     subtitle: "«Ich bin jetzt wirklich da.»",
     icon: Eye,
-    color: "var(--color-sand-border)",
+    badgeClass: "bg-sand-border text-white",
+    iconClass: "text-sand-border",
+    exampleClass:
+      "bg-[color-mix(in_oklch,var(--color-sand-border)_10%,white)] text-sand-border",
     ziel: "Sicherheit durch Präsenz.",
     soGehts: [
       "Kurz innehalten, Blick und Körper zuwenden",
@@ -54,7 +59,10 @@ const stufen: Stufe[] = [
     title: "Spiegeln",
     subtitle: "«Ich habe verstanden, was du meinst.»",
     icon: MessageSquare,
-    color: "var(--color-sage-dark)",
+    badgeClass: "bg-sage-dark text-white",
+    iconClass: "text-sage-dark",
+    exampleClass:
+      "bg-[color-mix(in_oklch,var(--color-sage-dark)_10%,white)] text-sage-dark",
     ziel: "Missverständnisse reduzieren, Tempo rausnehmen.",
     soGehts: [
       "In eigenen Worten zusammenfassen",
@@ -76,7 +84,10 @@ const stufen: Stufe[] = [
     title: "Zwischen den Zeilen verstehen",
     subtitle: "«Kann es sein, dass…?»",
     icon: Sparkles,
-    color: "var(--color-sand-mid)",
+    badgeClass: "bg-sand-mid text-white",
+    iconClass: "text-sand-mid",
+    exampleClass:
+      "bg-[color-mix(in_oklch,var(--color-sand-mid)_10%,white)] text-sand-mid",
     ziel: "Das Gefühl hinter der Reaktion erkennen.",
     soGehts: [
       "Vorsichtige Vermutung äussern",
@@ -98,7 +109,10 @@ const stufen: Stufe[] = [
     title: "Nachvollziehen",
     subtitle: "«Es macht Sinn, dass dich das trifft.»",
     icon: History,
-    color: "var(--color-sage-mid)",
+    badgeClass: "bg-sage-mid text-white",
+    iconClass: "text-sage-mid",
+    exampleClass:
+      "bg-[color-mix(in_oklch,var(--color-sage-mid)_10%,white)] text-sage-mid",
     ziel: "Bedeutung geben, ohne zu bewerten.",
     soGehts: [
       "Stress, Vorgeschichte oder Überforderung mitdenken",
@@ -120,7 +134,10 @@ const stufen: Stufe[] = [
     title: "Das Gültige anerkennen",
     subtitle: "«Diesen Teil kann ich gut nachvollziehen.»",
     icon: Users,
-    color: "var(--color-sage-dark)",
+    badgeClass: "bg-sage-dark text-white",
+    iconClass: "text-sage-dark",
+    exampleClass:
+      "bg-[color-mix(in_oklch,var(--color-sage-dark)_10%,white)] text-sage-dark",
     ziel: "Den verständlichen Kern benennen, ohne alles zu billigen.",
     soGehts: [
       "Gefühl oder Bedürfnis anerkennen",
@@ -142,7 +159,10 @@ const stufen: Stufe[] = [
     title: "Auf Augenhöhe bleiben",
     subtitle: "«Wir sind zwei gleichwertige Menschen.»",
     icon: Star,
-    color: "var(--color-sage-dark)",
+    badgeClass: "bg-sage-dark text-white",
+    iconClass: "text-sage-dark",
+    exampleClass:
+      "bg-[color-mix(in_oklch,var(--color-sage-dark)_10%,white)] text-sage-dark",
     ziel: "Respektvoll bleiben, ohne zu belehren oder zu psychologisieren.",
     soGehts: [
       "Klar, ruhig und respektvoll sprechen",
@@ -177,16 +197,14 @@ export default function ValidierungsStufenleiter() {
             <CardContent className="p-5">
               <div className="flex items-start gap-3 mb-4">
                 <div
-                  className="w-10 h-10 rounded-full text-white text-sm font-bold flex items-center justify-center flex-shrink-0"
-                  style={{ backgroundColor: stufe.color }}
+                  className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold ${stufe.badgeClass}`}
                 >
                   {stufe.level}
                 </div>
                 <div className="flex-1">
                   <div className="flex items-center gap-2 mb-1">
                     <Icon
-                      className="w-4 h-4"
-                      style={{ color: stufe.color }}
+                      className={`h-4 w-4 ${stufe.iconClass}`}
                       aria-hidden="true"
                     />
                     <h4 className="font-semibold text-foreground">
@@ -248,11 +266,7 @@ export default function ValidierungsStufenleiter() {
                   {stufe.beispielsaetze.map((satz, i) => (
                     <div
                       key={i}
-                      className="rounded-md px-3 py-2 text-sm font-medium"
-                      style={{
-                        backgroundColor: `color-mix(in oklch, ${stufe.color} 10%, white)`,
-                        color: stufe.color,
-                      }}
+                      className={`rounded-md px-3 py-2 text-sm font-medium ${stufe.exampleClass}`}
                     >
                       {satz}
                     </div>

--- a/client/src/pages/Buchempfehlungen.tsx
+++ b/client/src/pages/Buchempfehlungen.tsx
@@ -29,7 +29,7 @@ interface BookCategory {
   title: string;
   subtitle: string;
   icon: React.ComponentType<{ className?: string }>;
-  color: string;
+  iconShellClass: string;
   books: Book[];
 }
 
@@ -39,7 +39,7 @@ const bookCategories: BookCategory[] = [
     title: "Für Partner & Ehepartner",
     subtitle: "Wenn Ihr Partner oder Ihre Partnerin betroffen ist",
     icon: Heart,
-    color: "var(--color-sage-dark)",
+    iconShellClass: "bg-sage-wash text-sage-dark",
     books: [
       {
         title: "Schluss mit dem Eiertanz",
@@ -98,7 +98,7 @@ const bookCategories: BookCategory[] = [
     title: "Für Eltern",
     subtitle: "Wenn Ihr Kind (Jugendliche oder Erwachsene) betroffen ist",
     icon: Users,
-    color: "var(--color-slate-mid)",
+    iconShellClass: "bg-slate-light text-slate-mid",
     books: [
       {
         title: "DBT-Familienskills: Ein Praxisleitfaden",
@@ -144,7 +144,7 @@ const bookCategories: BookCategory[] = [
     title: "Kinderbücher",
     subtitle: "Für Kinder, deren Elternteil betroffen ist",
     icon: Baby,
-    color: "var(--color-sage)",
+    iconShellClass: "bg-sage-light text-sage",
     books: [
       {
         title: "Mama, Mia und das Schleuderprogramm",
@@ -196,7 +196,7 @@ const bookCategories: BookCategory[] = [
     title: "Erfahrungsberichte",
     subtitle: "Persönliche Geschichten von Betroffenen und Angehörigen",
     icon: Sparkles,
-    color: "var(--color-sage-dark)",
+    iconShellClass: "bg-sage-wash text-sage-dark",
     books: [
       {
         title: "Leben auf der Grenze",
@@ -332,11 +332,7 @@ export default function Buchempfehlungen() {
                 {/* Category Header */}
                 <div className="flex items-start gap-4 mb-8">
                   <div
-                    className="w-14 h-14 rounded-xl flex items-center justify-center flex-shrink-0"
-                    style={{
-                      backgroundColor: `${category.color}20`,
-                      color: category.color,
-                    }}
+                    className={`flex h-14 w-14 flex-shrink-0 items-center justify-center rounded-xl ${category.iconShellClass}`}
                   >
                     <category.icon className="w-7 h-7" />
                   </div>

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -302,42 +302,31 @@ export default function UnterstuetzenKrise() {
                     description:
                       "Alltägliche Stimmungsschwankungen, normale Belastungen",
                     action: "Präsent sein, zuhören, Routinen beibehalten",
-                    color: "var(--color-sage-mid)",
-                    bgColor: "var(--color-sage-lighter)",
+                    cardClass: "border-sage-mid bg-sage-lighter",
                   },
                   {
                     level: "Gelb – Angespannt",
                     description:
                       "Erhöhte Reizbarkeit, Rückzug, erkennbare Trigger",
                     action: "Validieren, Skills anbieten, Raum geben",
-                    color: "var(--color-sand-mid)",
-                    bgColor: "var(--color-sand-muted)",
+                    cardClass: "border-sand-mid bg-sand-muted",
                   },
                   {
                     level: "Orange – Eskalierend",
                     description:
                       "Starke Emotionen, verbale Aggression, Kontrollverlust",
                     action: "Deeskalieren, Sicherheit prüfen, Grenzen setzen",
-                    color: "var(--color-sage-mid)",
-                    bgColor: "var(--color-sage-wash)",
+                    cardClass: "border-sage-mid bg-sage-wash",
                   },
                   {
                     level: "Rot – Akute Krise",
                     description:
                       "Suizidgedanken, Selbstverletzung, akute Gefahr",
                     action: "Professionelle Hilfe holen, Notruf wenn nötig",
-                    color: "var(--color-alert)",
-                    bgColor: "var(--color-sage-wash)",
+                    cardClass: "border-alert bg-sage-wash",
                   },
                 ].map((item, index) => (
-                  <Card
-                    key={index}
-                    style={{
-                      borderColor: item.color,
-                      backgroundColor: item.bgColor,
-                    }}
-                    className="border-l-4"
-                  >
+                  <Card key={index} className={`border-l-4 ${item.cardClass}`}>
                     <CardContent className="p-5">
                       <h3 className="font-semibold text-foreground mb-2">
                         {item.level}


### PR DESCRIPTION
## Summary
- replace fixed inline tone styles in Selbsttest, Validierungsstufenleiter, Buchempfehlungen and Unterstützen Krise with class-based metadata
- keep behaviour unchanged while moving finite border, surface and accent variants out of inline style props
- reduce the remaining client/src inline-style count from 20 to 11

## Verification
- npx pnpm lint
- npx pnpm test
- npx pnpm build
