### PR TITLE
[codex] fix handout text breadcrumbs

### DIFF
--- a/client/src/__tests__/breadcrumbs.test.ts
+++ b/client/src/__tests__/breadcrumbs.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { getPageName, getParentInfo } from "@/components/layout/Breadcrumbs";
+
+describe("Breadcrumb helpers", () => {
+  it("keeps explicit labels for known standalone pages", () => {
+    expect(getPageName("/barrierefreiheit")).toBe("Barrierefreiheit");
+  });
+
+  it("uses the handout title for text-version routes", () => {
+    expect(getPageName("/materialien/text/leuchtturm")).toBe(
+      "Der Leuchtturm – Orientierung für Angehörige"
+    );
+  });
+
+  it("routes text-version pages back to the materials overview", () => {
+    expect(getParentInfo("/materialien/text/leuchtturm")).toEqual({
+      href: "/materialien",
+      label: "Materialien",
+    });
+  });
+
+  it("keeps the supporting pages grouped under Unterstützen", () => {
+    expect(getParentInfo("/unterstuetzen/therapie")).toEqual({
+      href: "/unterstuetzen/uebersicht",
+      label: "Unterstützen",
+    });
+  });
+});

--- a/client/src/components/layout/Breadcrumbs.tsx
+++ b/client/src/components/layout/Breadcrumbs.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "wouter";
 import { getRouteAccent } from "@/components/layout/routeAccent";
+import { getHandoutTextVersionMeta } from "@/content/handoutTextVersions";
 import { ArrowLeft, ChevronRight, Home } from "@/icons/root-icons";
 
 const pageNames: Record<string, string> = {
@@ -31,16 +32,44 @@ const pageNames: Record<string, string> = {
   "/uebungen": "Kommunikations-Übungen",
   "/quellen": "Quellen & Literatur",
   "/fachstelle": "Fachstelle Angehörigenarbeit",
+  "/barrierefreiheit": "Barrierefreiheit",
 };
 
-function getParentInfo(
+function normalizeLocation(location: string) {
+  return location.split("#")[0];
+}
+
+export function getParentInfo(
   location: string
 ): { href: string; label: string } | null {
-  if (location.startsWith("/unterstuetzen/")) {
+  const normalizedLocation = normalizeLocation(location);
+
+  if (normalizedLocation.startsWith("/materialien/text/")) {
+    return { href: "/materialien", label: "Materialien" };
+  }
+
+  if (normalizedLocation.startsWith("/unterstuetzen/")) {
     return { href: "/unterstuetzen/uebersicht", label: "Unterstützen" };
   }
 
   return null;
+}
+
+export function getPageName(location: string) {
+  const normalizedLocation = normalizeLocation(location);
+
+  if (normalizedLocation.startsWith("/materialien/text/")) {
+    const handoutId = decodeURIComponent(
+      normalizedLocation.replace("/materialien/text/", "")
+    );
+    return getHandoutTextVersionMeta(handoutId)?.title ?? "Textversion";
+  }
+
+  return (
+    pageNames[normalizedLocation] ||
+    normalizedLocation.split("/").pop()?.replace(/-/g, " ") ||
+    ""
+  );
 }
 
 export function Breadcrumbs() {
@@ -49,8 +78,7 @@ export function Breadcrumbs() {
 
   if (location === "/") return null;
 
-  const pageName =
-    pageNames[location] || location.split("/").pop()?.replace(/-/g, " ") || "";
+  const pageName = getPageName(location);
   const parent = getParentInfo(location);
   const backHref = parent?.href || "/";
   const backLabel = parent?.label || "Startseite";


### PR DESCRIPTION
## Summary
- fixes breadcrumbs for dynamic handout text-version pages
- routes text-version breadcrumbs back through Materialien instead of Startseite only
- adds an explicit breadcrumb label for Barrierefreiheit
- adds focused regression coverage for breadcrumb helper logic

## Why
A fresh main audit found that handout text pages such as `/materialien/text/leuchtturm` rendered as `Startseite > leuchtturm`, which was both visually raw and navigationally misleading. Mobile also sent users back to `/` instead of the material library.

## Validation
- `npx pnpm test -- client/src/__tests__/breadcrumbs.test.ts client/src/__tests__/handout-text-versions.test.tsx`
- `npx pnpm lint`
- `npx pnpm build`
- local browser check against production build for desktop and mobile breadcrumbs
