### PR TITLE
[codex] Improve handout textversion readability

### DIFF
--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -807,6 +807,20 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toBeInTheDocument();
   });
 
+  it("HandoutTextPage: gibt dichten Karten mehr Leseraum", async () => {
+    const { default: HandoutTextPage } =
+      await import("@/pages/HandoutTextPage");
+    withRouter(<HandoutTextPage params={{ handoutId: "spaltung" }} />);
+
+    const denseCardText = await screen.findByText(
+      /Erkennen Sie das Muster – bei Ihrem Angehörigen und bei sich selbst/i
+    );
+    const cardGrid = denseCardText.closest(".grid");
+
+    expect(cardGrid).toHaveClass("md:grid-cols-2");
+    expect(cardGrid).not.toHaveClass("xl:grid-cols-3");
+  });
+
   it("HandoutTextPage: rendert Alarm-Modus-Textversion", async () => {
     const { default: HandoutTextPage } =
       await import("@/pages/HandoutTextPage");

--- a/client/src/pages/HandoutTextPage.tsx
+++ b/client/src/pages/HandoutTextPage.tsx
@@ -7,7 +7,10 @@ import {
   getHandoutTextVersionMeta,
   loadHandoutTextVersion,
 } from "@/content/handoutTextVersions";
-import type { HandoutTextVersion } from "@/content/handoutTextVersionTypes";
+import type {
+  HandoutTextCard,
+  HandoutTextVersion,
+} from "@/content/handoutTextVersionTypes";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
@@ -26,6 +29,24 @@ import {
 type HandoutTextPageParams = {
   handoutId?: string;
 };
+
+const LONG_CARD_TEXT_THRESHOLD = 210;
+
+function getCardGridClass(cards: HandoutTextCard[]) {
+  const hasDenseText = cards.some(
+    card => card.text.length >= LONG_CARD_TEXT_THRESHOLD
+  );
+
+  if (cards.length <= 1) {
+    return "grid gap-4";
+  }
+
+  if (cards.length === 2 || cards.length === 4 || hasDenseText) {
+    return "grid gap-4 md:grid-cols-2";
+  }
+
+  return "grid gap-4 md:grid-cols-2 xl:grid-cols-3";
+}
 
 export default function HandoutTextPage({
   params,
@@ -232,7 +253,7 @@ export default function HandoutTextPage({
                       ) : null}
 
                       {section.cards?.length ? (
-                        <div className="grid gap-4 md:grid-cols-3">
+                        <div className={getCardGridClass(section.cards)}>
                           {section.cards.map(card => (
                             <div
                               key={`${section.title}-${card.title}`}
@@ -241,7 +262,7 @@ export default function HandoutTextPage({
                               <h3 className="font-semibold text-foreground mb-2">
                                 {card.title}
                               </h3>
-                              <p className="text-sm leading-relaxed text-muted-foreground">
+                              <p className="text-sm md:text-base leading-relaxed text-muted-foreground">
                                 {card.text}
                               </p>
                             </div>
@@ -254,7 +275,7 @@ export default function HandoutTextPage({
                           {section.bullets.map(item => (
                             <li
                               key={item}
-                              className="rounded-xl border border-border/60 bg-background px-4 py-3 text-sm text-muted-foreground"
+                              className="rounded-xl border border-border/60 bg-background px-4 py-3 text-sm md:text-base text-muted-foreground"
                             >
                               {item}
                             </li>


### PR DESCRIPTION
## Summary
- adapt the card grid on handout text pages so dense or four-card sections use two columns instead of a cramped three-column layout
- increase card and bullet body text at medium viewports for better on-page readability
- add a smoke test that protects the dense-card layout for the Spaltung textversion

## Why
The website/handout quality scan showed that the handout textversion data is structurally complete, but several content-heavy cards became visually squeezed by the fixed three-column grid. This keeps the content unchanged while making the reading surface calmer and more accessible.

## Validation
- npx pnpm test -- client/src/__tests__/smoke.test.tsx
- npx pnpm lint
- npx pnpm check
- npx pnpm build

Known non-blocking warning: baseline-browser-mapping data is over two months old.