### PR TITLE
[codex] Update artifact upload action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload build artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/public


### PR DESCRIPTION
## Summary
- update the CI artifact upload step from `actions/upload-artifact@v4` to `actions/upload-artifact@v7`

## Why
GitHub Actions reported a Node.js 20 deprecation warning for `actions/upload-artifact@v4`. The official `actions/upload-artifact@v7` action metadata uses `node24`, so this removes the warning before GitHub switches runner defaults.

## Validation
- `npx pnpm prettier --check .github/workflows/ci.yml`
- `git diff --check`
- verified official `actions/upload-artifact@v7` action.yml declares `runs.using: node24`

`actionlint` is not installed locally; the PR CI run is the definitive workflow validation.