### PR TITLE
[codex] Soften handout textversion intro

### DIFF
--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -125,6 +125,11 @@ describe("Smoke Tests – Kritische Seiten", () => {
       await screen.findByText(/Sie können das Schiff nicht steuern/i)
     ).toBeInTheDocument();
     expect(
+      screen.getByRole("heading", {
+        name: /Worum es in diesem Handout geht/i,
+      })
+    ).toBeInTheDocument();
+    expect(
       screen.getByRole("link", { name: /Zur Materialsammlung/i })
     ).toHaveAttribute("href", "/materialien");
   });

--- a/client/src/pages/HandoutTextPage.tsx
+++ b/client/src/pages/HandoutTextPage.tsx
@@ -200,7 +200,7 @@ export default function HandoutTextPage({
             <Card className="border-sage-light bg-sage-wash/70">
               <CardContent className="p-6">
                 <h2 className="text-lg font-semibold text-foreground mb-3">
-                  Lesbare Web-Version statt bildbasiertem PDF
+                  Worum es in diesem Handout geht
                 </h2>
                 {handout ? (
                   <div className="space-y-3 text-muted-foreground leading-relaxed">


### PR DESCRIPTION
## Summary
- replace the technical intro-card heading on handout text pages with a warmer, content-oriented heading
- add a smoke assertion so the wording stays intentional

## Why
The content-quality scan showed that the textversion page shell still used the phrase `Lesbare Web-Version statt bildbasiertem PDF`. That is accurate, but it foregrounds implementation detail and frames the PDF negatively. `Worum es in diesem Handout geht` is calmer and easier for Angehörige to scan.

## Validation
- `npx pnpm test -- client/src/__tests__/smoke.test.tsx`
- `npx pnpm lint`
- `npx pnpm check`
- `npx pnpm build`

Known non-blocking warning: `baseline-browser-mapping` data is over two months old.