### PR TITLE
[codex] ICD-11 Borderline-Pattern-Code präzisieren

### DIFF
--- a/client/src/__tests__/seo-helpers.test.ts
+++ b/client/src/__tests__/seo-helpers.test.ts
@@ -38,7 +38,7 @@ describe("SEO helpers", () => {
     expect(schema["@type"]).toBe("WebSite");
   });
 
-  it("builds medical schema with ICD-11 code 6D11", () => {
+  it("builds medical schema with ICD-11 borderline pattern code", () => {
     const schema = buildMedicalPageSchemaData({
       title: "Borderline verstehen",
       description: "Beschreibung",
@@ -46,7 +46,7 @@ describe("SEO helpers", () => {
     });
 
     expect(schema["@type"]).toBe("MedicalWebPage");
-    expect(schema.about.code.code).toBe("6D11");
+    expect(schema.about.code.code).toBe("6D11.5");
     expect(schema.url).toBe(
       "https://borderline-angehoerige.netlify.app/verstehen"
     );

--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -90,7 +90,7 @@ export function buildMedicalPageSchemaData({
       alternateName: ["Borderline-Muster", "Borderline pattern"],
       code: {
         "@type": "MedicalCode",
-        code: "6D11",
+        code: "6D11.5",
         codingSystem: "ICD-11",
       },
     },

--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -154,7 +154,7 @@ const quellen = [
         titel: "International Classification of Diseases (ICD-11)",
         quelle: "WHO",
         hinweis:
-          "Aktuelle internationale Klassifikation mit Borderline pattern als Spezifier innerhalb der Persönlichkeitsstörungen.",
+          "Aktuelle internationale Klassifikation mit Borderline pattern (6D11.5) als Spezifier innerhalb der Persönlichkeitsstörungen.",
         link: "https://icd.who.int/browse/2025-01/mms/en#2006821354",
       },
     ],

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -307,8 +307,8 @@ export default function Verstehen() {
                   sources={[
                     {
                       label:
-                        "WHO ICD-11: Personality disorder with borderline pattern (6D11)",
-                      href: "https://icd.who.int/browse/2024-01/mms/en#691185432",
+                        "WHO ICD-11: Borderline pattern specifier (6D11.5)",
+                      href: "https://icd.who.int/browse/2025-01/mms/en#2006821354",
                       type: "wissenschaft",
                     },
                     {


### PR DESCRIPTION
## Summary
- aktualisiert die ICD-11-Evidenznotiz auf `6D11.5` und den aktuellen WHO-Browser-Link
- zieht die Quellen-Seite mit derselben Code-Formulierung nach
- korrigiert das MedicalWebPage-Schema auf den präzisen Borderline-pattern-Code
- passt den SEO-Test entsprechend an

## Validation
- npx pnpm test -- client/src/__tests__/seo-helpers.test.ts client/src/__tests__/smoke.test.tsx
- npx pnpm lint
- npx pnpm check
- npx pnpm build

## Notes
- `baseline-browser-mapping` meldet weiterhin die bekannte Aktualitätswarnung beim Lint-Lauf.