### PR TITLE
[codex] Stabileren APA-Guideline-Link verwenden

### DIFF
--- a/client/src/pages/UeberUns.tsx
+++ b/client/src/pages/UeberUns.tsx
@@ -152,7 +152,7 @@ export default function UeberUns() {
                   {
                     label:
                       "APA Practice Guideline for the Treatment of Patients With Borderline Personality Disorder (2024)",
-                    href: "https://psychiatryonline.org/doi/book/10.1176/appi.books.9780890424896",
+                    href: "https://pubmed.ncbi.nlm.nih.gov/39482953/",
                     type: "wissenschaft",
                   },
                   {

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -314,7 +314,7 @@ export default function Verstehen() {
                     {
                       label:
                         "APA Practice Guideline for the Treatment of Patients With Borderline Personality Disorder (2024)",
-                      href: "https://psychiatryonline.org/doi/book/10.1176/appi.books.9780890424896",
+                      href: "https://pubmed.ncbi.nlm.nih.gov/39482953/",
                       type: "wissenschaft",
                     },
                     {


### PR DESCRIPTION
## Summary
- ersetzt den blockierten PsychiatryOnline-Book-Link durch den erreichbaren PubMed-Eintrag zur APA-Guideline 2024
- aktualisiert die Quellenlinks in `Verstehen` und `Über uns` konsistent
- lässt die sichtbare Quellenbeschreibung unverändert

## Validation
- npx pnpm test -- client/src/__tests__/smoke.test.tsx client/src/__tests__/evidence-note.test.tsx
- npx pnpm lint
- npx pnpm check
- npx pnpm build

## Notes
- `baseline-browser-mapping` meldet weiterhin die bekannte Aktualitätswarnung beim Lint-Lauf.