### PR TITLE
[codex] Ladehinweis der Handout-Textversion vereinfachen

### DIFF
--- a/client/src/pages/HandoutTextPage.tsx
+++ b/client/src/pages/HandoutTextPage.tsx
@@ -87,7 +87,7 @@ export default function HandoutTextPage({
     handout?.description ??
     `${handoutMeta.description} Diese Seite bietet eine lesbare Textversion des Handouts.`;
   const pageSummary =
-    handout?.summary ?? "Die lesbare Web-Version dieses Handouts wird geladen.";
+    handout?.summary ?? "Die Textversion dieses Handouts wird geladen.";
   const pageTopicLabel = handout?.topicLabel ?? handoutMeta.topicLabel;
   const pageTopicHref = handout?.topicHref ?? handoutMeta.topicHref;
   const pageKind = handout?.kind ?? handoutMeta.kind;


### PR DESCRIPTION
## Summary
- ersetzt den letzten Lade-Fallback mit „lesbare Web-Version“ durch „Textversion“
- hält den sichtbaren Handout-Flow sprachlich konsistent mit den polierten Intros

## Validation
- npx pnpm test -- client/src/__tests__/smoke.test.tsx client/src/__tests__/handout-text-versions.test.tsx
- npx pnpm lint
- npx pnpm check
- npx pnpm build

## Notes
- `baseline-browser-mapping` meldet weiterhin die bekannte Aktualitätswarnung beim Lint-Lauf.