### PR TITLE
[codex] Deferred Route CSS reduzieren

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -61,7 +61,7 @@ export default function Layout({ children }: LayoutProps) {
           <span className="font-medium text-foreground">
             Notfallkontakte: Schweiz (Kanton Zürich)
           </span>
-          <span className="hidden sm:inline">\u2022</span>
+          <span className="hidden sm:inline">•</span>
           <span>Für andere Regionen bitte lokale Notrufnummern nutzen.</span>
           {showInlineSoforthilfeLink && (
             <Link
@@ -91,7 +91,7 @@ export default function Layout({ children }: LayoutProps) {
               <Link href="/" className="flex items-center gap-2 mb-4">
                 <BrandMark variant="dark" />
                 <span className="font-medium text-base text-white">
-                  Borderline \u00b7 Hilfe für Angehörige
+                  Borderline · Hilfe für Angehörige
                 </span>
               </Link>
               <p className="text-white/90 text-sm leading-relaxed">
@@ -169,8 +169,7 @@ export default function Layout({ children }: LayoutProps) {
             }`}
           >
             <p className="text-white/90 text-sm">
-              \u00a9 2026 Borderline \u00b7 Hilfe für Angehörige. Alle Rechte
-              vorbehalten.
+              © 2026 Borderline · Hilfe für Angehörige. Alle Rechte vorbehalten.
             </p>
             <div className="flex flex-wrap gap-x-4 gap-y-1">
               <Link
@@ -223,7 +222,7 @@ export default function Layout({ children }: LayoutProps) {
         >
           <Link
             href="/soforthilfe"
-            aria-label="Soforthilfe \u2013 Notfallnummern und Krisenberatung"
+            aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
           >
             <Phone className="w-4 h-4" />
             Soforthilfe

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -319,7 +319,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                 <span className="flex items-center gap-2">
                   <span>
                     <kbd className="px-1.5 py-0.5 bg-background border border-border rounded text-[10px]">
-                      \u2191\u2193
+                      ↑↓
                     </kbd>{" "}
                     navigieren
                   </span>

--- a/client/src/data/kontakte.ts
+++ b/client/src/data/kontakte.ts
@@ -425,7 +425,7 @@ export const TEXTE = {
   pukEinleitung:
     "Die Psychiatrische Universitätsklinik Zürich (PUK) ist die kantonale Anlaufstelle für psychiatrische Krisen. Rufen Sie hier an, wenn eine akute psychische Krise vorliegt, aber keine unmittelbare Lebensgefahr besteht. Bei Lebensgefahr oder wenn sofort Hilfe vor Ort nötig ist: 144 / 117 / 112.",
   pukTriage:
-    "Am Telefon wird kurz eingeschätzt (Triage), was jetzt am besten hilft – z.\u00A0B. Beratung, weiteres Vorgehen oder Notfallaufnahme.",
+    "Am Telefon wird kurz eingeschätzt (Triage), was jetzt am besten hilft – z. B. Beratung, weiteres Vorgehen oder Notfallaufnahme.",
   gruenGefahrenhinweis:
     "Bei akuter Gefahr für sich oder andere: Immer zuerst 144 / 117 / 112 rufen. Die Nummern oben sind Sorgentelefone – es kommt niemand vorbei.",
   pukLabel:

--- a/client/src/styles/deferred-routes.css
+++ b/client/src/styles/deferred-routes.css
@@ -7,6 +7,9 @@
 
 @source "../pages";
 @source "../components";
+@source not "../components/ui";
+@source "../components/ui/accordion.tsx";
+@source "../components/ui/spinner.tsx";
 @source not "../pages/Home.tsx";
 @source not "../components/ErrorBoundary.tsx";
 @source not "../components/Search.tsx";


### PR DESCRIPTION
## Was geändert wurde

- Deferred-Route-CSS scannt nicht mehr pauschal alle UI-Primitives, sondern schliesst `client/src/components/ui` aus und erlaubt nur die tatsächlich deferred benötigten UI-Dateien `accordion.tsx` und `spinner.tsx`.
- Sichtbare Unicode-Escape-Sequenzen im Notfallhinweis, Footer, Suchdialog und Kontakttext wurden durch echte Zeichen ersetzt.

## Warum

Der Post-Audit hatte `DeferredRouteStyles` als grössten verbleibenden technischen Performance-Rest markiert. Zusätzlich zeigte der visuelle Smoke-Check sichtbare `\u...`-Sequenzen im Footer und Notfallhinweis.

## Messung

- Vorher: `DeferredRouteStyles-B4pSC_RG.css` 140.67 kB raw / 21.45 kB gzip
- Nachher: `DeferredRouteStyles-C-obZviD.css` 88.34 kB raw / 13.62 kB gzip
- Reduktion: ca. 37% raw und ca. 36.5% gzip

## Verifikation

- `npx pnpm test -- client/src/__tests__/smoke.test.tsx client/src/__tests__/layout-keyboard.test.ts client/src/__tests__/materialien-library.test.tsx client/src/__tests__/handout-text-versions.test.tsx`
- `npx pnpm lint`
- `npx pnpm check`
- `npx pnpm build`
- Visueller Smoke-Check: Mobile Home, Mobile Materialien, Mobile Handout Leuchtturm, Desktop Home, mobile Navigation geöffnet

Hinweis: Die bekannte lokale `--localstorage-file`-Warnung im Testlauf ist unverändert und nicht neu.