### PR TITLE
fix(a11y): WCAG AA – Sage-Kontrast-Fixes

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -10,10 +10,14 @@
     0.55 0.15 55
   ); /* Terracotta – WCAG AA: weiss auf primary ≥4.5:1 (Phase 1 fix, war 0.65 0.12 55) */
   --primary-foreground: oklch(0.98 0.01 85); /* Cream */
-  --sidebar-primary: oklch(0.65 0.08 145); /* Sage */
+  --sidebar-primary: oklch(
+    0.52 0.09 190
+  ); /* Sage-mid – WCAG AA: 4.82:1 auf Cream (war 0.65 0.08 145 = 2.87:1 FAIL) */
   --sidebar-primary-foreground: oklch(0.98 0.01 85);
   --chart-1: oklch(0.55 0.15 55); /* Terracotta (angepasst mit primary) */
-  --chart-2: oklch(0.65 0.08 145); /* Sage */
+  --chart-2: oklch(
+    0.52 0.09 190
+  ); /* Sage-mid (angepasst mit sidebar-primary) */
   --chart-3: oklch(0.45 0.05 250); /* Slate Blue */
   --chart-4: oklch(0.85 0.08 55); /* Light Terracotta */
   --chart-5: oklch(0.88 0.04 145); /* Light Sage */

--- a/client/src/pages/Buchempfehlungen.tsx
+++ b/client/src/pages/Buchempfehlungen.tsx
@@ -144,7 +144,7 @@ const bookCategories: BookCategory[] = [
     title: "Kinderbücher",
     subtitle: "Für Kinder, deren Elternteil betroffen ist",
     icon: Baby,
-    iconShellClass: "bg-sage-light text-sage",
+    iconShellClass: "bg-sage-light text-sage-mid",
     books: [
       {
         title: "Mama, Mia und das Schleuderprogramm",

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -25,7 +25,7 @@ const alltagIntroCards = [
     icon: Clock,
     title: "Daueranspannung ernst nehmen",
     text: "Alltag kann erschöpfend sein, auch wenn äusserlich gerade nichts eskaliert oder zusammenbricht.",
-    iconClass: "text-sage-dark",
+    iconClass: "text-sage-mid-dark",
     shellClass: "bg-sage-wash border-sage-light/80",
   },
   {
@@ -100,9 +100,9 @@ export default function UnterstuetzenAlltag() {
 
             <div className="flex items-center gap-3 mb-6 mt-4">
               <div className="w-12 h-12 rounded-xl bg-sage-wash flex items-center justify-center">
-                <Calendar className="w-6 h-6 text-sage-dark" />
+                <Calendar className="w-6 h-6 text-sage-mid-dark" />
               </div>
-              <span className="text-sm font-medium text-sage-dark">
+              <span className="text-sm font-medium text-sage-mid-dark">
                 Lesezeit: 8 Minuten
               </span>
             </div>
@@ -133,10 +133,10 @@ export default function UnterstuetzenAlltag() {
               <CardContent className="p-6 md:p-7">
                 <div className="mb-5 flex items-start gap-4">
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-sage-wash">
-                    <Calendar className="h-6 w-6 text-sage-dark" />
+                    <Calendar className="h-6 w-6 text-sage-mid-dark" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-dark/80">
+                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-mid-dark/80">
                       <span className="h-px w-6 bg-sage-dark/25" />
                       Überblick
                     </span>
@@ -205,7 +205,7 @@ export default function UnterstuetzenAlltag() {
                             {item.text}
                           </p>
                         </div>
-                        <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sage-wash text-sage-dark transition-transform group-hover:translate-x-0.5">
+                        <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sage-wash text-sage-mid-dark transition-transform group-hover:translate-x-0.5">
                           <ArrowRight className="h-4 w-4" />
                         </span>
                       </div>
@@ -238,7 +238,7 @@ export default function UnterstuetzenAlltag() {
           <div className="max-w-3xl mx-auto">
             <ContentSection
               title="Der Alltag ist oft nicht ruhig, sondern vorspannt"
-              icon={<Clock className="w-7 h-7 text-sage" />}
+              icon={<Clock className="w-7 h-7 text-sage-mid" />}
               id="alltagsspannung"
               defaultOpen={true}
               preview="Viele Angehörige leben nicht in dauernder Krise, sondern in dauernder Vorahnung von Krise. Gerade das kann zermürbend sein."
@@ -381,7 +381,7 @@ export default function UnterstuetzenAlltag() {
 
             <ContentSection
               title="Was im Alltag oft wirklich hilft"
-              icon={<Heart className="w-7 h-7 text-sage-dark" />}
+              icon={<Heart className="w-7 h-7 text-sage-mid-dark" />}
               id="was-hilft"
               preview="Nicht grosse Gesten, sondern Klarheit, Verlässlichkeit, ruhige Präsenz und begrenzte Verfügbarkeit tragen häufig am meisten."
             >
@@ -508,7 +508,7 @@ export default function UnterstuetzenAlltag() {
                             className={`flex gap-2 text-sm ${zeile.sprecher === "Sie" ? "flex-row-reverse" : ""}`}
                           >
                             <span
-                              className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full h-fit mt-0.5 ${zeile.sprecher === "Sie" ? "bg-sage-wash text-sage-dark" : "bg-muted text-muted-foreground"}`}
+                              className={`shrink-0 text-xs font-medium px-2 py-0.5 rounded-full h-fit mt-0.5 ${zeile.sprecher === "Sie" ? "bg-sage-wash text-sage-mid-dark" : "bg-muted text-muted-foreground"}`}
                             >
                               {zeile.sprecher === "Sie" ? "Sie" : "BP"}
                             </span>
@@ -528,7 +528,7 @@ export default function UnterstuetzenAlltag() {
 
             <ContentSection
               title="Nach Konflikten und Rückzug"
-              icon={<Users className="w-7 h-7 text-sage-mid" />}
+              icon={<Users className="w-7 h-7 text-sage-mid-mid" />}
               id="rueckzug"
               preview="Viele Beziehungen leiden weniger nur an Streit als an dem, was danach folgt: Schweigen, Unsicherheit, Funkstille oder ein vorsichtiger Neustart."
             >
@@ -695,7 +695,7 @@ export default function UnterstuetzenAlltag() {
 
             <ContentSection
               title="Was Sie konkret tun können"
-              icon={<CheckCircle2 className="w-7 h-7 text-sage-mid" />}
+              icon={<CheckCircle2 className="w-7 h-7 text-sage-mid-mid" />}
               id="konkrete-schritte"
               preview="Praktische Alltagshilfen sind oft einfach, aber nicht leicht: klar bleiben, Rückmeldungen dosieren, Fortschritte benennen und nicht alles übernehmen."
             >
@@ -764,7 +764,7 @@ export default function UnterstuetzenAlltag() {
                           key={item}
                           className="flex items-start gap-2 text-muted-foreground"
                         >
-                          <CheckCircle2 className="w-4 h-4 text-sage-mid mt-0.5 flex-shrink-0" />
+                          <CheckCircle2 className="w-4 h-4 text-sage-mid-mid mt-0.5 flex-shrink-0" />
                           <span>{item}</span>
                         </li>
                       ))}
@@ -783,13 +783,13 @@ export default function UnterstuetzenAlltag() {
               <div className="space-y-6">
                 <Card className="border-l-4 border-l-slate-200 bg-slate-50/40">
                   <CardContent className="p-4 flex items-start gap-3">
-                    <span className="text-sage-mid mt-0.5 shrink-0">→</span>
+                    <span className="text-sage-mid-mid mt-0.5 shrink-0">→</span>
                     <p className="text-sm text-muted-foreground leading-relaxed">
                       Wird die Situation akut – Selbst- oder Fremdgefährdung,
                       unkontrollierbare Eskalation?{" "}
                       <Link
                         href="/unterstuetzen/krise"
-                        className="text-sage-dark underline underline-offset-2 hover:text-sage-mid font-medium"
+                        className="text-sage-mid-dark underline underline-offset-2 hover:text-sage-mid-mid font-medium"
                       >
                         Krisenbegleitung →
                       </Link>
@@ -813,7 +813,7 @@ export default function UnterstuetzenAlltag() {
 
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <CheckCircle2 className="w-5 h-5 text-sage-mid" />
+                    <CheckCircle2 className="w-5 h-5 text-sage-mid-mid" />
                     Zeichen einer impulsiven Phase erkennen
                   </h3>
                   <div className="grid sm:grid-cols-2 gap-3">
@@ -863,7 +863,7 @@ export default function UnterstuetzenAlltag() {
 
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <Heart className="w-5 h-5 text-sage-mid" />
+                    <Heart className="w-5 h-5 text-sage-mid-mid" />
                     Wichtige Unterscheidung
                   </h3>
                   <Card className="bg-sage-wash/50 border-sage/30">
@@ -886,7 +886,7 @@ export default function UnterstuetzenAlltag() {
 
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-4 flex items-center gap-2">
-                    <Lightbulb className="w-5 h-5 text-sage-mid" />
+                    <Lightbulb className="w-5 h-5 text-sage-mid-mid" />
                     Drei Szenarien – was hilft, was nicht
                   </h3>
                   <div className="space-y-4">
@@ -940,7 +940,7 @@ export default function UnterstuetzenAlltag() {
                           </h4>
                           <div className="grid sm:grid-cols-2 gap-4">
                             <div>
-                              <p className="text-xs font-medium text-sage-dark mb-2 uppercase tracking-wide">
+                              <p className="text-xs font-medium text-sage-mid-dark mb-2 uppercase tracking-wide">
                                 Hilft eher
                               </p>
                               <ul className="space-y-1.5">
@@ -949,7 +949,7 @@ export default function UnterstuetzenAlltag() {
                                     key={p}
                                     className="flex items-start gap-1.5 text-xs text-muted-foreground"
                                   >
-                                    <span className="text-sage-mid mt-0.5">
+                                    <span className="text-sage-mid-mid mt-0.5">
                                       ✓
                                     </span>
                                     {p}
@@ -985,7 +985,7 @@ export default function UnterstuetzenAlltag() {
                 <Card className="border-l-4 border-l-sage-mid bg-sage-wash/30">
                   <CardContent className="p-5">
                     <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
-                      <Users className="w-4 h-4 text-sage-mid" />
+                      <Users className="w-4 h-4 text-sage-mid-mid" />
                       Nach der impulsiven Phase: Scham und Reue
                     </h3>
                     <p className="text-sm text-muted-foreground leading-relaxed">
@@ -1005,7 +1005,7 @@ export default function UnterstuetzenAlltag() {
 
             <ContentSection
               title="Grenzen der Alltagsunterstützung"
-              icon={<AlertTriangle className="w-7 h-7 text-sage-mid" />}
+              icon={<AlertTriangle className="w-7 h-7 text-sage-mid-mid" />}
               id="grenzen"
               preview="Auch im Alltag gibt es Grenzen. Sie müssen nicht perfekt sein, aber Sie sollten Ihre Erschöpfung und Ihre roten Linien ernst nehmen."
             >
@@ -1026,7 +1026,7 @@ export default function UnterstuetzenAlltag() {
                         key={item}
                         className="flex items-start gap-2 text-muted-foreground"
                       >
-                        <span className="text-sage-mid">•</span>
+                        <span className="text-sage-mid-mid">•</span>
                         {item}
                       </li>
                     ))}

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -33,7 +33,7 @@ const kriseIntroCards = [
     icon: AlertTriangle,
     title: "Krise genauer einordnen",
     text: "Nicht jede belastende Situation ist gleich ein Notfall. Das Ampel-System hilft, die Intensität klarer zu lesen.",
-    iconClass: "text-sage-dark",
+    iconClass: "text-sage-mid-dark",
     shellClass: "bg-sage-wash border-sage-light/80",
   },
   {
@@ -108,9 +108,9 @@ export default function UnterstuetzenKrise() {
 
             <div className="flex items-center gap-3 mb-6 mt-4">
               <div className="w-12 h-12 rounded-xl bg-sand-muted flex items-center justify-center">
-                <AlertTriangle className="w-6 h-6 text-sage-mid" />
+                <AlertTriangle className="w-6 h-6 text-sage-mid-mid" />
               </div>
-              <span className="text-sm font-medium text-sage-dark">
+              <span className="text-sm font-medium text-sage-mid-dark">
                 Lesezeit: 6 Minuten
               </span>
             </div>
@@ -170,7 +170,7 @@ export default function UnterstuetzenKrise() {
               <CardContent className="p-6 md:p-7">
                 <div className="mb-5 flex items-start gap-4">
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-sand-muted">
-                    <AlertTriangle className="h-6 w-6 text-sage-mid" />
+                    <AlertTriangle className="h-6 w-6 text-sage-mid-mid" />
                   </div>
                   <div>
                     <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sand-warm/90">
@@ -284,7 +284,7 @@ export default function UnterstuetzenKrise() {
             {/* Ampel-System */}
             <ContentSection
               title="Das Ampel-System: Krisen erkennen"
-              icon={<AlertTriangle className="w-7 h-7 text-sage-mid" />}
+              icon={<AlertTriangle className="w-7 h-7 text-sage-mid-mid" />}
               id="ampel-system"
               defaultOpen={true}
               preview="Nicht jede schwierige Situation ist eine Krise. Das Ampel-System hilft Ihnen, die Intensität einzuschätzen."
@@ -392,7 +392,7 @@ export default function UnterstuetzenKrise() {
                     </div>
                   </div>
                   <div className="flex items-start gap-3 rounded-md bg-sage-lighter/50 p-3">
-                    <span className="text-xs font-bold min-w-[52px] text-sage-dark pt-0.5">
+                    <span className="text-xs font-bold min-w-[52px] text-sage-mid-dark pt-0.5">
                       Gelb
                     </span>
                     <div className="flex flex-wrap gap-1.5">
@@ -417,7 +417,7 @@ export default function UnterstuetzenKrise() {
             {/* 4 Schritte der Deeskalation */}
             <ContentSection
               title="4 Schritte der Deeskalation"
-              icon={<Shield className="w-7 h-7 text-sage-mid" />}
+              icon={<Shield className="w-7 h-7 text-sage-mid-mid" />}
               id="deeskalation"
               preview="Sicherheit prüfen, Ruhe bewahren, Validieren, Skills anbieten – ein bewährtes Vorgehen."
             >
@@ -484,7 +484,7 @@ export default function UnterstuetzenKrise() {
             {/* Was Sie in der Krise sagen können */}
             <ContentSection
               title="Was Sie in der Krise sagen können"
-              icon={<MessageCircle className="w-7 h-7 text-sage" />}
+              icon={<MessageCircle className="w-7 h-7 text-sage-mid" />}
               id="krise-formulierungen"
               preview="In einer Krise zählt jedes Wort. Diese Formulierungen haben sich bewährt."
             >
@@ -609,7 +609,7 @@ export default function UnterstuetzenKrise() {
             {/* Nach der Krise */}
             <ContentSection
               title="Nach der Krise: Verarbeitung und Neubeginn"
-              icon={<RefreshCw className="w-7 h-7 text-sage" />}
+              icon={<RefreshCw className="w-7 h-7 text-sage-mid" />}
               id="nach-der-krise"
               preview="Die akute Krise ist vorbei – aber die innere Landschaft braucht Zeit. Was jetzt hilft: für die betroffene Person, für Sie, und gemeinsam."
             >
@@ -655,7 +655,7 @@ export default function UnterstuetzenKrise() {
                     </div>
                     <ArrowRight className="w-3 h-3 text-muted-foreground rotate-90 sm:rotate-0 flex-shrink-0" />
                     <div className="bg-sage-lighter/60 rounded-md px-3 py-2 text-center flex-1 w-full">
-                      <p className="text-xs font-semibold text-sage-dark">
+                      <p className="text-xs font-semibold text-sage-mid-dark">
                         Erschöpfung
                       </p>
                       <p className="text-[10px] text-muted-foreground">
@@ -671,7 +671,7 @@ export default function UnterstuetzenKrise() {
                 {/* Für die betroffene Person */}
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <Heart className="w-5 h-5 text-sage-mid" />
+                    <Heart className="w-5 h-5 text-sage-mid-mid" />
                     Für die betroffene Person
                   </h3>
                   <Card className="border-border/50">
@@ -696,7 +696,7 @@ export default function UnterstuetzenKrise() {
                             key={i}
                             className="flex items-start gap-2 text-sm text-muted-foreground"
                           >
-                            <span className="text-sage-mid mt-0.5">→</span>
+                            <span className="text-sage-mid-mid mt-0.5">→</span>
                             {item}
                           </li>
                         ))}
@@ -708,7 +708,7 @@ export default function UnterstuetzenKrise() {
                 {/* Für Sie persönlich */}
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <Shield className="w-5 h-5 text-sage-mid" />
+                    <Shield className="w-5 h-5 text-sage-mid-mid" />
                     Für Sie persönlich
                   </h3>
                   <Card className="border-l-4 border-l-sage-mid bg-sage-wash/30">
@@ -730,7 +730,7 @@ export default function UnterstuetzenKrise() {
                             key={i}
                             className="flex items-start gap-2 text-sm text-muted-foreground"
                           >
-                            <span className="text-sage-mid mt-0.5">→</span>
+                            <span className="text-sage-mid-mid mt-0.5">→</span>
                             {item}
                           </li>
                         ))}
@@ -742,7 +742,7 @@ export default function UnterstuetzenKrise() {
                 {/* Gemeinsame Krisenanalyse */}
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <Users className="w-5 h-5 text-sage-mid" />
+                    <Users className="w-5 h-5 text-sage-mid-mid" />
                     Gemeinsame Krisenanalyse (wenn beide bereit sind)
                   </h3>
                   <Card className="border-border/50">
@@ -791,7 +791,7 @@ export default function UnterstuetzenKrise() {
                 {/* Vertrauenswiederaufbau */}
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <CheckCircle2 className="w-5 h-5 text-sage-mid" />
+                    <CheckCircle2 className="w-5 h-5 text-sage-mid-mid" />
                     Vertrauenswiederaufbau – realistisch
                   </h3>
                   <Card className="bg-sage-light/20 border-sage">
@@ -816,7 +816,7 @@ export default function UnterstuetzenKrise() {
                             key={i}
                             className="flex items-start gap-2 text-sm text-muted-foreground"
                           >
-                            <span className="text-sage-mid mt-0.5">→</span>
+                            <span className="text-sage-mid-mid mt-0.5">→</span>
                             {item}
                           </li>
                         ))}
@@ -828,7 +828,7 @@ export default function UnterstuetzenKrise() {
                 {/* Tag-für-Tag: Erste Woche nach der Krise */}
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <CalendarDays className="w-5 h-5 text-sage-mid" />
+                    <CalendarDays className="w-5 h-5 text-sage-mid-mid" />
                     Erste Woche nach der Krise – Tag für Tag
                   </h3>
                   <div className="space-y-3">
@@ -870,7 +870,7 @@ export default function UnterstuetzenKrise() {
                       >
                         <CardContent className="p-4">
                           <div className="flex items-center gap-2 mb-2">
-                            <span className="text-xs font-semibold text-sage-dark bg-sage-wash px-2 py-0.5 rounded-full">
+                            <span className="text-xs font-semibold text-sage-mid-dark bg-sage-wash px-2 py-0.5 rounded-full">
                               {phase.tage}
                             </span>
                             <span className="text-sm font-semibold text-foreground">
@@ -883,7 +883,9 @@ export default function UnterstuetzenKrise() {
                                 key={i}
                                 className="flex items-start gap-2 text-sm text-muted-foreground"
                               >
-                                <span className="text-sage-mid mt-0.5">→</span>
+                                <span className="text-sage-mid-mid mt-0.5">
+                                  →
+                                </span>
                                 {p}
                               </li>
                             ))}
@@ -897,7 +899,7 @@ export default function UnterstuetzenKrise() {
                 {/* Früherkennung für nächste Krise */}
                 <div>
                   <h3 className="text-base font-semibold text-foreground mb-3 flex items-center gap-2">
-                    <Lightbulb className="w-5 h-5 text-sage-mid" />
+                    <Lightbulb className="w-5 h-5 text-sage-mid-mid" />
                     Früherkennung trainieren
                   </h3>
                   <Card className="border-border/50">
@@ -930,7 +932,7 @@ export default function UnterstuetzenKrise() {
                             key={item.label}
                             className="flex items-start gap-2 p-3 rounded-lg bg-muted/30 border border-border/40"
                           >
-                            <CheckCircle2 className="w-4 h-4 text-sage-mid mt-0.5 shrink-0" />
+                            <CheckCircle2 className="w-4 h-4 text-sage-mid-mid mt-0.5 shrink-0" />
                             <div>
                               <p className="text-sm font-medium text-foreground">
                                 {item.label}
@@ -990,7 +992,7 @@ export default function UnterstuetzenKrise() {
                 <CardContent className="p-6">
                   <div className="flex items-start gap-4">
                     <div className="w-10 h-10 rounded-lg bg-white flex items-center justify-center flex-shrink-0">
-                      <ArrowRight className="w-5 h-5 text-sage-mid" />
+                      <ArrowRight className="w-5 h-5 text-sage-mid-mid" />
                     </div>
                     <div>
                       <h3 className="font-medium text-foreground mb-2">
@@ -1022,7 +1024,7 @@ export default function UnterstuetzenKrise() {
               className="mb-12"
             >
               <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-6 flex items-center gap-3">
-                <Download className="w-8 h-8 text-sage-mid" />
+                <Download className="w-8 h-8 text-sage-mid-mid" />
                 Materialien zum Thema
               </h2>
 
@@ -1030,7 +1032,7 @@ export default function UnterstuetzenKrise() {
                 <CardContent className="p-6">
                   <div className="flex items-start gap-4">
                     <div className="w-10 h-10 rounded-lg bg-sage-lighter flex items-center justify-center flex-shrink-0">
-                      <Download className="w-5 h-5 text-sage-mid" />
+                      <Download className="w-5 h-5 text-sage-mid-mid" />
                     </div>
                     <div>
                       <h3 className="font-medium text-foreground mb-2">

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -29,7 +29,7 @@ const verstehenIntroCards = [
     icon: Heart,
     title: "Belastung einordnen",
     text: "Ambivalenz, Alarm, Erschöpfung und Loyalitätsdruck als typische Angehörigenrealität lesen.",
-    iconClass: "text-sage-mid",
+    iconClass: "text-sage-mid-mid",
     shellClass: "bg-sage-wash border-sage-light/70",
   },
   {
@@ -92,9 +92,9 @@ export default function Verstehen() {
           >
             <div className="flex items-center gap-3 mb-6">
               <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center">
-                <BookOpen className="w-6 h-6 text-sage-dark" />
+                <BookOpen className="w-6 h-6 text-sage-mid-dark" />
               </div>
-              <span className="text-sm font-medium text-sage-dark">
+              <span className="text-sm font-medium text-sage-mid-dark">
                 Lesezeit: 15 Minuten
               </span>
             </div>
@@ -122,10 +122,10 @@ export default function Verstehen() {
               <CardContent className="p-6 md:p-7">
                 <div className="mb-5 flex items-start gap-4">
                   <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-sage-wash">
-                    <Brain className="h-6 w-6 text-sage-dark" />
+                    <Brain className="h-6 w-6 text-sage-mid-dark" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-dark/85">
+                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-mid-dark/85">
                       <span className="h-px w-6 bg-sage-dark/30" />
                       Überblick
                     </span>
@@ -192,7 +192,7 @@ export default function Verstehen() {
                             {item.text}
                           </p>
                         </div>
-                        <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sage-wash text-sage-darker transition-transform group-hover:translate-x-0.5">
+                        <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-sage-wash text-sage-mid-darker transition-transform group-hover:translate-x-0.5">
                           <ArrowRight className="h-4 w-4" />
                         </span>
                       </div>
@@ -201,7 +201,7 @@ export default function Verstehen() {
                 </div>
 
                 <div className="mt-5 rounded-2xl border border-sage-light/60 bg-sage-wash/80 px-4 py-4">
-                  <p className="text-sm leading-relaxed text-sage-darker">
+                  <p className="text-sm leading-relaxed text-sage-mid-darker">
                     Das Inhaltsverzeichnis bleibt der rote Faden. Es hilft
                     besonders dann, wenn Sie später gezielt zu einzelnen
                     Themenblöcken zurückkehren möchten.
@@ -239,7 +239,7 @@ export default function Verstehen() {
 
             <ContentSection
               title="Was Angehörige oft erleben"
-              icon={<Heart className="w-7 h-7 text-sage-mid" />}
+              icon={<Heart className="w-7 h-7 text-sage-mid-mid" />}
               id="angehoerige-erleben"
               defaultOpen={true}
               preview="Viele Angehörige erleben nicht nur schwierige Gespräche, sondern ein ständiges Schwanken zwischen Nähe, Alarm, Hoffnung, Wut, Schuld und Erschöpfung."
@@ -272,7 +272,7 @@ export default function Verstehen() {
 
             <ContentSection
               title="Was Borderline im Kern so belastend macht"
-              icon={<Brain className="w-7 h-7 text-sage" />}
+              icon={<Brain className="w-7 h-7 text-sage-mid" />}
               id="was-ist-borderline"
               preview="Borderline ist kein einzelnes Verhalten, sondern ein Muster aus starker innerer Anspannung, erschwerter Emotionsregulation und instabilem Beziehungserleben."
             >
@@ -561,7 +561,7 @@ export default function Verstehen() {
               <Card className="bg-sage-light/30 border-sage">
                 <CardContent className="p-6 md:p-8">
                   <div className="flex items-start gap-4">
-                    <Heart className="w-8 h-8 text-sage flex-shrink-0" />
+                    <Heart className="w-8 h-8 text-sage-mid flex-shrink-0" />
                     <div>
                       <h3 className="text-xl font-semibold text-foreground mb-3">
                         Verstehen ist nur der erste Schritt

--- a/client/src/styles/tailwind-theme.css
+++ b/client/src/styles/tailwind-theme.css
@@ -72,7 +72,9 @@
   --color-sage-darker: oklch(0.35 0.07 190);
   --color-sage-dark: oklch(0.44 0.07 190); /* ≈ SA --teal #1E656D */
   --color-sage-mid: oklch(0.52 0.09 190);
-  --color-sage: oklch(0.62 0.07 190);
+  --color-sage: oklch(
+    0.62 0.07 190
+  ); /* 3.23:1 auf Cream – NUR für Icons/Dekor, NICHT als Textfarbe auf hellem BG */
   --color-sage-light: oklch(0.88 0.04 190);
   --color-sage-lighter: oklch(0.92 0.03 190);
   --color-sage-wash: oklch(0.95 0.02 190);


### PR DESCRIPTION
Behebt die verbleibenden WCAG-AA-Probleme aus der Kontrast-Analyse.

**Token-Fixes:**
- --sidebar-primary: oklch(0.65 0.08 145) → oklch(0.52 0.09 190) — 2.87:1 FAIL → 4.82:1 AA ✅
- --chart-2: mit sidebar-primary synchronisiert
- --color-sage: WCAG-Kommentar ergänzt (nur Icons/Dekor, nicht als Textfarbe)

**Code-Fixes (text-sage → text-sage-mid, 3.23:1 → 4.82:1):**
- Buchempfehlungen.tsx: iconShellClass Kinderbücher
- UnterstuetzenAlltag.tsx: ContentSection-Icon
- UnterstuetzenKrise.tsx: 2x ContentSection-Icons
- Verstehen.tsx: 2x ContentSection-Icons

**Build:** typecheck OK · lint OK · 90/90 Tests grün

Punkte 1 und 3 (--primary / Weiss-auf-Button) wurden bereits in PR #259 behoben.