### PR TITLE
fix(typography): Source Serif 4 Mobile-Optimierung (375px Gate)

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -110,6 +110,25 @@
     font-weight: 400;
     letter-spacing: -0.018em;
     text-wrap: balance;
+    /* Source Serif 4: optical size axis für kleine Grössen aktivieren */
+    font-optical-sizing: auto;
+  }
+
+  /* ── Mobile Typografie: Source Serif 4 bei kleinen Grössen ── */
+  @media (max-width: 639px) {
+    h1 {
+      /* text-3xl (30px) → etwas kompakterer Zeilenabstand für Serifen auf Mobile */
+      line-height: 1.2;
+    }
+    h2 {
+      /* text-2xl (24px) → Serifen brauchen etwas mehr Luft als Sans-Serif */
+      line-height: 1.35;
+    }
+    .lede {
+      /* Lede auf Mobile etwas kleiner: 1.32rem → 1.15rem */
+      font-size: 1.15rem;
+      line-height: 1.5;
+    }
   }
 
   h1 em,


### PR DESCRIPTION
## Was wurde geändert

**Datei:** `client/src/index.css`

### 1. `font-optical-sizing: auto` für h1/h2
Source Serif 4 Variable hat eine `opsz`-Achse (optical size). Mit `font-optical-sizing: auto` nutzt der Browser diese Achse automatisch – bei kleinen Schriftgrössen (Mobile) werden die Serifen etwas dicker und die Buchstabenabstände weiter gesetzt, was die Lesbarkeit verbessert.

### 2. Mobile Zeilenabstände (max-width: 639px)
| Element | Vorher | Nachher | Begründung |
|---|---|---|---|
| `h1` | Tailwind-Standard (1.1) | `1.2` | Serifen brauchen mehr Luft als Sans-Serif |
| `h2` | Tailwind-Standard (1.25) | `1.35` | Lesbarkeit bei 24px auf Mobile |
| `.lede` | 1.32rem / 1.55 | 1.15rem / 1.5 | Nicht zu wuchtig auf 375px |

## Visuell verifiziert (375px Viewport, Playwright)

| Seite | h1 | Ergebnis |
|---|---|---|
| Home | 36px / lh:1.2 | ✅ klar, nicht wuchtig |
| Verstehen / Genesung / Kommunizieren / Selbstfürsorge | 30px / lh:1.2 | ✅ ruhig, elegant |
| Soforthilfe | 30px / lh:1.25 | ✅ |

## Build-Status
- typecheck ✅
- lint ✅  
- 90/90 Tests ✅