### PR TITLE
fix(print): Notfallkarte – eigenständiges A4-Druckdokument

### DIFF
--- a/client/public/notfallkarte-print.html
+++ b/client/public/notfallkarte-print.html
@@ -1,0 +1,654 @@
+<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Persönliche Notfallkarte – Druckversion</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      /* ── Reset & Base ── */
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      :root {
+        --cream: #fbf4e6;
+        --navy: #1a2a3a;
+        --charcoal: #2d3748;
+        --muted: #6b7280;
+        --border: #d1d5db;
+        --border-light: #e5e7eb;
+        --terracotta: #b15300;
+        --sage: #2a6b65;
+        --red: #c0392b;
+        --orange: #d97706;
+        --green: #2a6b65;
+        --lila: #7c3aed;
+        --sos-rot-bg: #fef2f2;
+        --sos-rot-head: #991b1b;
+        --sos-rot-border: #fca5a5;
+        --sos-gelb-bg: #fffbeb;
+        --sos-gelb-head: #92400e;
+        --sos-gelb-border: #fcd34d;
+        --sos-gruen-bg: #f0fdf4;
+        --sos-gruen-head: #14532d;
+        --sos-gruen-border: #86efac;
+      }
+
+      body {
+        font-family:
+          "Inter",
+          system-ui,
+          -apple-system,
+          sans-serif;
+        font-size: 9pt;
+        line-height: 1.4;
+        color: var(--charcoal);
+        background: white;
+      }
+
+      /* ── Page Setup ── */
+      @page {
+        size: A4 portrait;
+        margin: 10mm 12mm 10mm 12mm;
+      }
+
+      /* ── Print trigger ── */
+      @media screen {
+        body {
+          background: var(--cream);
+          padding: 20px;
+        }
+        .page {
+          background: white;
+          max-width: 794px;
+          margin: 0 auto;
+          padding: 20px;
+          box-shadow: 0 2px 12px rgba(0, 0, 0, 0.1);
+          border-radius: 4px;
+        }
+        .print-btn {
+          display: block;
+          margin: 0 auto 20px;
+          padding: 10px 24px;
+          background: var(--terracotta);
+          color: white;
+          border: none;
+          border-radius: 6px;
+          font-size: 14px;
+          font-weight: 600;
+          cursor: pointer;
+          font-family: inherit;
+        }
+        .print-btn:hover {
+          background: #8f4200;
+        }
+      }
+      @media print {
+        body {
+          background: white;
+          padding: 0;
+        }
+        .page {
+          padding: 0;
+          box-shadow: none;
+        }
+        .print-btn {
+          display: none;
+        }
+      }
+
+      /* ── Header ── */
+      .doc-header {
+        text-align: center;
+        padding-bottom: 6pt;
+        border-bottom: 1.5pt solid var(--terracotta);
+        margin-bottom: 8pt;
+      }
+      .doc-header h1 {
+        font-size: 16pt;
+        font-weight: 700;
+        color: var(--navy);
+        margin-bottom: 2pt;
+      }
+      .doc-header p {
+        font-size: 8pt;
+        color: var(--muted);
+      }
+      .doc-header .region-note {
+        font-size: 7.5pt;
+        color: var(--muted);
+        margin-top: 2pt;
+      }
+
+      /* ── Block-Wrapper ── */
+      .block {
+        border: 0.5pt solid var(--border);
+        border-radius: 4pt;
+        margin-bottom: 5pt;
+        overflow: visible;
+        break-inside: avoid;
+      }
+
+      .block-header {
+        display: flex;
+        align-items: center;
+        gap: 6pt;
+        padding: 5pt 8pt;
+        border-radius: 4pt 4pt 0 0;
+        font-weight: 700;
+        font-size: 9.5pt;
+      }
+
+      .block-body {
+        padding: 4pt 8pt 6pt;
+      }
+
+      /* ── Ampel-Farben ── */
+      .block-rot .block-header {
+        background: var(--sos-rot-bg);
+        color: var(--sos-rot-head);
+        border-bottom: 0.5pt solid var(--sos-rot-border);
+      }
+      .block-rot {
+        border-color: var(--sos-rot-border);
+      }
+      .block-gelb .block-header {
+        background: var(--sos-gelb-bg);
+        color: var(--sos-gelb-head);
+        border-bottom: 0.5pt solid var(--sos-gelb-border);
+      }
+      .block-gelb {
+        border-color: var(--sos-gelb-border);
+      }
+      .block-gruen .block-header {
+        background: var(--sos-gruen-bg);
+        color: var(--sos-gruen-head);
+        border-bottom: 0.5pt solid var(--sos-gruen-border);
+      }
+      .block-gruen {
+        border-color: var(--sos-gruen-border);
+      }
+      .block-neutral .block-header {
+        background: #f8fafc;
+        color: var(--navy);
+        border-bottom: 0.5pt solid var(--border);
+      }
+
+      /* ── Kontakt-Zeile ── */
+      .contact-row {
+        display: flex;
+        align-items: baseline;
+        gap: 6pt;
+        padding: 3pt 0;
+        border-bottom: 0.5pt solid var(--border-light);
+      }
+      .contact-row:last-child {
+        border-bottom: none;
+      }
+
+      .contact-label {
+        flex: 1;
+        font-weight: 600;
+        font-size: 8.5pt;
+      }
+      .contact-hint {
+        flex: 2;
+        font-size: 7.5pt;
+        color: var(--muted);
+      }
+      .contact-num {
+        font-weight: 700;
+        font-size: 12pt;
+        white-space: nowrap;
+        color: var(--charcoal);
+      }
+
+      .contact-num-sm {
+        font-weight: 700;
+        font-size: 10pt;
+        white-space: nowrap;
+        color: var(--charcoal);
+      }
+
+      /* ── Persönliche Felder ── */
+      .field-grid {
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr;
+        gap: 4pt 8pt;
+        padding: 3pt 0;
+        border-bottom: 0.5pt solid var(--border-light);
+      }
+      .field-grid:last-child {
+        border-bottom: none;
+      }
+
+      .field-label {
+        font-size: 7.5pt;
+        color: var(--muted);
+        margin-bottom: 1pt;
+      }
+      .field-line {
+        border: none;
+        border-bottom: 0.5pt solid var(--border);
+        width: 100%;
+        font-size: 8.5pt;
+        padding: 1pt 0;
+        background: transparent;
+        font-family: inherit;
+        color: var(--charcoal);
+      }
+      .field-line::placeholder {
+        color: #ccc;
+      }
+
+      /* ── Strategien ── */
+      .strategy-row {
+        display: flex;
+        align-items: center;
+        gap: 6pt;
+        padding: 2.5pt 0;
+        border-bottom: 0.5pt solid var(--border-light);
+        font-size: 8.5pt;
+      }
+      .strategy-row:last-child {
+        border-bottom: none;
+      }
+      .strategy-num {
+        width: 14pt;
+        height: 14pt;
+        border-radius: 50%;
+        background: var(--sage);
+        color: white;
+        font-size: 7pt;
+        font-weight: 700;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+      }
+      .strategy-text {
+        flex: 1;
+        border: none;
+        border-bottom: 0.5pt solid var(--border-light);
+        font-size: 8.5pt;
+        padding: 1pt 0;
+        background: transparent;
+        font-family: inherit;
+        color: var(--charcoal);
+      }
+      .strategy-text::placeholder {
+        color: #ccc;
+      }
+
+      /* ── Notizen ── */
+      .notes-area {
+        width: 100%;
+        border: none;
+        border-bottom: 0.5pt solid var(--border);
+        font-size: 8.5pt;
+        padding: 2pt 0;
+        background: transparent;
+        font-family: inherit;
+        color: var(--charcoal);
+        resize: none;
+        min-height: 28pt;
+      }
+      .notes-area::placeholder {
+        color: #ccc;
+      }
+
+      /* ── Icon ── */
+      .icon {
+        width: 10pt;
+        height: 10pt;
+        flex-shrink: 0;
+      }
+
+      /* ── Footer ── */
+      .doc-footer {
+        margin-top: 6pt;
+        padding-top: 4pt;
+        border-top: 0.5pt solid var(--border);
+        font-size: 7pt;
+        color: var(--muted);
+        text-align: center;
+      }
+
+      /* ── Seitenumbruch ── */
+      .page-break {
+        break-before: page;
+      }
+
+      /* ── Farben erzwingen ── */
+      * {
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+      }
+    </style>
+  </head>
+  <body>
+    <button class="print-btn" onclick="window.print()">
+      🖨 Drucken / Als PDF speichern
+    </button>
+
+    <div class="page">
+      <!-- ── Header ── -->
+      <div class="doc-header">
+        <h1>Persönliche Notfallkarte</h1>
+        <p>
+          Die wichtigsten Nummern und Ihre persönlichen Strategien – alles auf
+          einen Blick.
+        </p>
+        <p class="region-note">
+          <strong>Notfallkontakte: Schweiz (Kanton Zürich)</strong> · Für andere
+          Regionen bitte lokale Notrufnummern nutzen.
+        </p>
+      </div>
+
+      <!-- ── Block 1: Notfallnummern (ROT) ── -->
+      <div class="block block-rot">
+        <div class="block-header">
+          <svg
+            class="icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+          >
+            <path
+              d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.69 12 19.79 19.79 0 0 1 1.61 3.41 2 2 0 0 1 3.6 1.22h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L7.91 8.82a16 16 0 0 0 6.29 6.29l.95-.95a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"
+            />
+          </svg>
+          Notfallnummern
+        </div>
+        <div class="block-body">
+          <div class="contact-row">
+            <span class="contact-label">Rettungsdienst</span>
+            <span class="contact-hint"
+              >Bei akuter Lebensgefahr, Selbstverletzung oder akuter
+              Suizidgefahr</span
+            >
+            <span class="contact-num">144</span>
+          </div>
+          <div class="contact-row">
+            <span class="contact-label">Polizei</span>
+            <span class="contact-hint"
+              >Bei Gewalt oder wenn Sie sich bedroht fühlen</span
+            >
+            <span class="contact-num">117</span>
+          </div>
+          <div class="contact-row">
+            <span class="contact-label">Notruf (wenn unsicher)</span>
+            <span class="contact-hint"
+              >Wenn Sie unsicher sind, welche Nummer – funktioniert immer.</span
+            >
+            <span class="contact-num">112</span>
+          </div>
+          <div class="contact-row">
+            <span class="contact-label">Tox Info Suisse</span>
+            <span class="contact-hint"
+              >Bei Vergiftungsverdacht oder Medikamentenüberdosierung</span
+            >
+            <span class="contact-num">145</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Block 2: PUK Zürich (GELB) ── -->
+      <div class="block block-gelb">
+        <div class="block-header">
+          <svg
+            class="icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+          >
+            <path
+              d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.69 12 19.79 19.79 0 0 1 1.61 3.41 2 2 0 0 1 3.6 1.22h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L7.91 8.82a16 16 0 0 0 6.29 6.29l.95-.95a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"
+            />
+          </svg>
+          Psychiatrische Krise – PUK Zürich (24/7)
+        </div>
+        <div class="block-body">
+          <div class="contact-row">
+            <span class="contact-label"
+              >PUK Kinder &amp; Jugendliche (24/7)</span
+            >
+            <span class="contact-hint"
+              >Für Kinder und Jugendliche bis 18 Jahre – wenn es psychisch akut
+              ist.</span
+            >
+            <span class="contact-num-sm">058 384 66 66</span>
+          </div>
+          <div class="contact-row">
+            <span class="contact-label">PUK Erwachsene (24/7)</span>
+            <span class="contact-hint"
+              >Für Erwachsene ab 18 – akute psychische Krise.</span
+            >
+            <span class="contact-num-sm">058 384 20 00</span>
+          </div>
+          <div class="contact-row">
+            <span class="contact-label">PUK Erwachsene (ab 65) (24/7)</span>
+            <span class="contact-hint"
+              >Für Menschen ab 65 – akute psychische Krise.</span
+            >
+            <span class="contact-num-sm">058 384 46 82</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Block 3: Jemand zum Reden (GRUEN) ── -->
+      <div class="block block-gruen">
+        <div class="block-header">
+          <svg class="icon" viewBox="0 0 24 24" fill="currentColor">
+            <path
+              d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+            />
+          </svg>
+          Jemand zum Reden
+        </div>
+        <div class="block-body">
+          <div class="contact-row">
+            <span class="contact-label">Dargebotene Hand (24/7)</span>
+            <span class="contact-hint"
+              >Anonymes Gesprächs- und Krisenangebot, vertraulich. Es kommt
+              niemand vorbei.</span
+            >
+            <span class="contact-num">143</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Block 4: Meine Kontaktpersonen ── -->
+      <div class="block block-neutral">
+        <div class="block-header">
+          <svg
+            class="icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+          >
+            <path
+              d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.69 12 19.79 19.79 0 0 1 1.61 3.41 2 2 0 0 1 3.6 1.22h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L7.91 8.82a16 16 0 0 0 6.29 6.29l.95-.95a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 16.92z"
+            />
+          </svg>
+          Meine Kontaktpersonen
+        </div>
+        <div class="block-body">
+          <div class="field-grid">
+            <div>
+              <div class="field-label">Name</div>
+              <input class="field-line" type="text" placeholder="Name" />
+            </div>
+            <div>
+              <div class="field-label">Telefon</div>
+              <input
+                class="field-line"
+                type="tel"
+                placeholder="Telefonnummer"
+              />
+            </div>
+            <div>
+              <div class="field-label">Beziehung</div>
+              <input
+                class="field-line"
+                type="text"
+                placeholder="z.B. Therapeut:in"
+              />
+            </div>
+          </div>
+          <div class="field-grid">
+            <div>
+              <input class="field-line" type="text" placeholder="Name" />
+            </div>
+            <div>
+              <input
+                class="field-line"
+                type="tel"
+                placeholder="Telefonnummer"
+              />
+            </div>
+            <div>
+              <input
+                class="field-line"
+                type="text"
+                placeholder="z.B. Psychiater:in"
+              />
+            </div>
+          </div>
+          <div class="field-grid">
+            <div>
+              <input class="field-line" type="text" placeholder="Name" />
+            </div>
+            <div>
+              <input
+                class="field-line"
+                type="tel"
+                placeholder="Telefonnummer"
+              />
+            </div>
+            <div>
+              <input
+                class="field-line"
+                type="text"
+                placeholder="z.B. Vertrauensperson"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Block 5: Beruhigungsstrategien ── -->
+      <div class="block block-neutral">
+        <div class="block-header">
+          <svg
+            class="icon"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            style="color: var(--sage)"
+          >
+            <circle cx="12" cy="12" r="10" fill="var(--sage)" />
+            <path
+              d="M12 8v4l3 3"
+              stroke="white"
+              stroke-width="2"
+              stroke-linecap="round"
+              fill="none"
+            />
+          </svg>
+          Meine Beruhigungsstrategien
+        </div>
+        <div class="block-body">
+          <div class="strategy-row">
+            <div class="strategy-num">1</div>
+            <input
+              class="strategy-text"
+              type="text"
+              value="Langsam ein- und ausatmen (4-7-8)"
+            />
+          </div>
+          <div class="strategy-row">
+            <div class="strategy-num">2</div>
+            <input
+              class="strategy-text"
+              type="text"
+              value="Beide Füsse bewusst auf den Boden stellen"
+            />
+          </div>
+          <div class="strategy-row">
+            <div class="strategy-num">3</div>
+            <input
+              class="strategy-text"
+              type="text"
+              value="Kaltes Wasser über die Handgelenke laufen lassen"
+            />
+          </div>
+          <div class="strategy-row">
+            <div class="strategy-num">4</div>
+            <input
+              class="strategy-text"
+              type="text"
+              placeholder="Eigene Strategie eingeben…"
+            />
+          </div>
+        </div>
+      </div>
+
+      <!-- ── Block 6: Persönliche Notizen ── -->
+      <div class="block block-neutral">
+        <div class="block-header">
+          <svg
+            class="icon"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2.5"
+          >
+            <path
+              d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"
+            />
+            <polyline points="14 2 14 8 20 8" />
+          </svg>
+          Persönliche Notizen
+        </div>
+        <div class="block-body">
+          <textarea
+            class="notes-area"
+            placeholder="z.B. Medikamente, Allergien, wichtige Hinweise für Helfer:innen…"
+            rows="3"
+          ></textarea>
+        </div>
+      </div>
+
+      <!-- ── Footer ── -->
+      <div class="doc-footer">
+        Fachstelle Angehörigenarbeit · PUK Zürich · borderline-angehoerige.ch ·
+        Alle Angaben ohne Gewähr
+      </div>
+    </div>
+    <!-- /page -->
+
+    <script>
+      // Automatisch drucken wenn ?print=1 in der URL
+      if (new URLSearchParams(window.location.search).get("print") === "1") {
+        window.addEventListener("load", () =>
+          setTimeout(() => window.print(), 300)
+        );
+      }
+    </script>
+  </body>
+</html>

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useCallback, useRef } from "react";
-import "./notfallkarte-print.css";
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
 import { Card, CardContent } from "@/components/ui/card";
@@ -201,7 +200,7 @@ export default function Notfallkarte() {
   }, [data]);
 
   const handlePrint = useCallback(() => {
-    window.print();
+    window.open("/notfallkarte-print.html", "_blank");
   }, []);
 
   const addContact = useCallback(() => {
@@ -287,7 +286,9 @@ export default function Notfallkarte() {
                 gesperrter Speicher. Bitte{" "}
                 <button
                   type="button"
-                  onClick={() => window.print()}
+                  onClick={() =>
+                    window.open("/notfallkarte-print.html", "_blank")
+                  }
                   className="underline font-semibold hover:no-underline"
                 >
                   jetzt drucken


### PR DESCRIPTION
## Problem

Das bestehende Print-CSS der Notfallkarte erzeugte 3 lockere A4-Seiten mit grossem Leerraum und abgeschnittenem Inhalt (Chromium-PDF-Renderer-Bug: `overflow: hidden` + `border-radius` + Framer-Motion-Stacking-Context).

## Lösung

Eigenständiges statisches HTML/CSS-Druckdokument `/notfallkarte-print.html` – identische Strategie wie `/soforthilfe-print.html` (PR #262).

## Änderungen

| Datei | Änderung |
|---|---|
| `client/public/notfallkarte-print.html` | Neu: eigenständiges A4-Druckdokument |
| `client/src/pages/Notfallkarte.tsx` | `handlePrint` + storageError-Banner → `window.open('/notfallkarte-print.html')` |
| `client/src/pages/notfallkarte-print.css` | Entfernt |

## Ergebnis

- **1 kompakte A4-Seite** (statt 3 lockere)
- Alle 6 Blöcke vollständig sichtbar: Notfallnummern, PUK Zürich, Dargebotene Hand, Kontaktpersonen, Beruhigungsstrategien, Notizen
- Ampel-Farbkodierung (Rot/Gelb/Grün) korrekt
- Ausfüllbare Felder für persönliche Kontakte und Strategien

## Build

- typecheck ✅
- lint ✅  
- 90/90 Tests ✅