### PR TITLE
feat(editorial): Phase 2 – Hero-Redesign auf 5 Seiten + Invitation-Sektion

### DIFF
--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -190,25 +190,25 @@ export default function Genesung() {
             transition={{ duration: 0.6, ease: "easeOut" }}
             className="max-w-3xl"
           >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-wash flex items-center justify-center">
-                <Sparkles className="w-6 h-6 text-sage-darker" />
-              </div>
-            </div>
+            <span className="kicker text-sage-dark">
+              Genesung
+              <span aria-hidden="true"> · </span>
+              Langzeitverlauf &amp; Hoffnung
+            </span>
 
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-6">
-              Genesung ist möglich
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-4">
+              Genesung ist <em>möglich</em>
             </h1>
 
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Hoffnung ist bei Borderline berechtigt. Gleichzeitig verläuft
-              Entwicklung selten glatt, schnell oder vorhersehbar. Für
-              Angehörige ist deshalb beides wichtig: Zuversicht und eine
-              realistische Sicht auf Zeit, Rückschritte und Grenzen des eigenen
-              Einflusses.
+            <hr className="rule rule-narrow mb-6" />
+
+            <p className="lede">
+              Hoffnung ist bei Borderline berechtigt – und gleichzeitig verläuft
+              Entwicklung selten glatt oder vorhersehbar. Für Angehörige ist
+              beides wichtig: Zuversicht und eine realistische Sicht auf Zeit.
             </p>
 
-            <LastVerifiedBadge date="16.04.2026" className="mt-4" />
+            <LastVerifiedBadge date="16.04.2026" className="mt-6" />
           </motion.div>
         </div>
       </section>

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import AnimatedStat from "@/components/AnimatedStat";
 import Erfahrungsberichte from "@/components/Erfahrungsberichte";
+import { kontaktByIdStrict, emailByIdStrict } from "@/data/kontakte";
 import {
   AlertTriangle,
   ArrowRight,
@@ -13,7 +14,6 @@ import {
   Compass,
   Download,
   FileText,
-  Heart,
   MessageCircle,
   MessageSquare,
   Phone,
@@ -116,6 +116,9 @@ const approachHighlights = [
   },
 ];
 
+const fachstelleTel = kontaktByIdStrict("INFO_FACHSTELLE");
+const fachstelleEmail = emailByIdStrict("EMAIL_ANGEHOERIGEN");
+
 export default function Home() {
   return (
     <Layout>
@@ -140,63 +143,61 @@ export default function Home() {
 
         <div className="container relative z-10 py-20 md:py-24 lg:py-28">
           <div className="max-w-3xl">
-            <div>
-              <span className="inline-block px-3 py-1 rounded-full bg-sage-dark text-white text-[11px] font-semibold tracking-[0.12em] uppercase mb-5">
-                Für Angehörige von Menschen mit Borderline
-              </span>
+            <p className="text-[11px] font-medium tracking-[0.14em] uppercase text-white/60 mb-5">
+              Fachstelle Angehörigenarbeit
+              <span aria-hidden="true"> · </span>
+              Psychiatrische Universitätsklinik Zürich
+            </p>
 
-              <h1 className="text-4xl md:text-5xl lg:text-[52px] font-normal leading-[1.12] tracking-tight mb-4">
-                Orientierung in belasteten{" "}
-                <span className="text-sage-light">Beziehungen</span>
-              </h1>
+            <h1 className="text-4xl md:text-5xl lg:text-[52px] font-normal leading-[1.12] tracking-tight mb-4">
+              Wenn jemand, den Sie lieben, eine{" "}
+              <em className="text-sage-light not-italic">
+                Borderline-Persönlichkeitsstörung
+              </em>{" "}
+              hat
+            </h1>
 
-              <p className="text-base md:text-lg text-white/90 leading-relaxed mb-8 max-w-2xl font-light">
-                Wenn Beziehungen von starker Anspannung, Eskalation, Rückzug,
-                Schuld oder Erschöpfung geprägt sind, hilft nicht noch mehr
-                Druck, sondern ein klarer nächster Schritt. Diese Website
-                unterstützt Angehörige dabei, Dynamiken zu verstehen,
-                hilfreicher zu reagieren und sich selbst nicht zu verlieren.
-              </p>
+            <p className="text-base md:text-lg text-white/85 leading-relaxed mb-8 max-w-2xl font-light italic">
+              Eine Begleitung für Partnerinnen, Eltern, Geschwister und
+              erwachsene Kinder – die dabei oft vergessen werden.
+            </p>
 
-              <div className="flex flex-col sm:flex-row gap-3 mb-4">
-                <Button
-                  size="lg"
-                  className="bg-sage-dark hover:bg-sage-mid text-white w-full sm:w-auto"
-                  asChild
-                >
-                  <Link href="/verstehen">
-                    <BookOpen className="w-5 h-5 mr-2" />
-                    Borderline besser verstehen
-                    <ArrowRight className="w-4 h-4 opacity-80" />
-                  </Link>
-                </Button>
-                <Button
-                  size="lg"
-                  variant="outline"
-                  className="border-white/25 text-white hover:bg-white/10 w-full sm:w-auto"
-                  asChild
-                >
-                  <Link href="/unterstuetzen/uebersicht">
-                    <Heart className="w-5 h-5 mr-2" />
-                    Was hilft in meiner Lage?
-                    <ArrowRight className="w-4 h-4 opacity-80" />
-                  </Link>
-                </Button>
-              </div>
-
-              <Link
-                href="/soforthilfe"
-                className="inline-flex items-center gap-3 text-white/90 hover:text-white font-medium transition-colors group text-sm"
+            <div className="flex flex-col sm:flex-row gap-3 mb-4">
+              <Button
+                size="lg"
+                className="bg-sage-dark hover:bg-sage-mid text-white w-full sm:w-auto"
+                asChild
               >
-                <span className="inline-flex items-center gap-2">
-                  <Phone className="w-4 h-4" />
-                  <span>Akute Krise? Soforthilfe</span>
-                </span>
-                <span className="inline-flex w-7 h-7 items-center justify-center rounded-full border border-white/20 bg-white/8 transition-all group-hover:translate-x-0.5 group-hover:bg-white/14">
-                  <ArrowRight className="w-3.5 h-3.5" />
-                </span>
-              </Link>
+                <Link href="/wegweiser">
+                  Wo soll ich anfangen?
+                  <ArrowRight className="w-4 h-4 opacity-80" />
+                </Link>
+              </Button>
+              <Button
+                size="lg"
+                variant="outline"
+                className="border-white/25 text-white hover:bg-white/10 w-full sm:w-auto"
+                asChild
+              >
+                <Link href="/verstehen">
+                  Direkt zu «Verstehen»
+                  <ArrowRight className="w-4 h-4 opacity-80" />
+                </Link>
+              </Button>
             </div>
+
+            <Link
+              href="/soforthilfe"
+              className="inline-flex items-center gap-3 text-white/90 hover:text-white font-medium transition-colors group text-sm"
+            >
+              <span className="inline-flex items-center gap-2">
+                <Phone className="w-4 h-4" />
+                <span>Akute Krise? Soforthilfe</span>
+              </span>
+              <span className="inline-flex w-7 h-7 items-center justify-center rounded-full border border-white/20 bg-white/8 transition-all group-hover:translate-x-0.5 group-hover:bg-white/14">
+                <ArrowRight className="w-3.5 h-3.5" />
+              </span>
+            </Link>
           </div>
         </div>
       </section>
@@ -517,6 +518,41 @@ export default function Home() {
       <div className="home-section-divider h-6" />
 
       <Erfahrungsberichte />
+
+      <div className="home-section-divider h-6" />
+
+      {/* Invitation-Sektion */}
+      <section className="py-14 md:py-20 bg-background">
+        <div className="container">
+          <div className="max-w-2xl mx-auto text-center">
+            <span className="kicker">Sie dürfen anrufen</span>
+            <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-4">
+              Sie müssen nicht wissen, was Sie sagen wollen.
+            </h2>
+            <hr className="rule rule-narrow rule-center mb-6" />
+            <p className="text-muted-foreground leading-relaxed mb-8 max-w-prose mx-auto">
+              Die Fachstelle Angehörigenarbeit berät auch Sie – nicht nur die
+              erkrankte Person. Orientierung, Gespräch und Materialien für
+              Partnerinnen, Eltern, Geschwister und erwachsene Kinder.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <a
+                href={`tel:${fachstelleTel.tel}`}
+                className="inline-flex items-center justify-center gap-2.5 rounded-lg bg-sage-dark px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-sage-darker"
+              >
+                <Phone className="w-4 h-4" />
+                {fachstelleTel.nummer}
+              </a>
+              <a
+                href={`mailto:${fachstelleEmail.adresse}`}
+                className="inline-flex items-center justify-center gap-2.5 rounded-lg border border-border px-6 py-3 text-sm font-medium text-foreground transition-colors hover:bg-muted"
+              >
+                {fachstelleEmail.adresse}
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
 
       <div className="home-section-divider h-6" />
 

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -92,25 +92,21 @@ export default function Kommunizieren() {
             transition={{ duration: 0.6, ease: "easeOut" }}
             className="max-w-3xl"
           >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-slate-light flex items-center justify-center">
-                <MessageCircle className="w-6 h-6 text-slate-blue" />
-              </div>
-              <span className="text-sm font-medium text-slate-blue">
-                Lesezeit: 14 Minuten
-              </span>
-            </div>
-
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-6">
+            <span className="kicker text-slate-blue">
               Kommunizieren
+              <span aria-hidden="true"> · </span>
+              Lesezeit: 14 Minuten
+            </span>
+
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-4">
+              Gespräche in <em>belasteten Beziehungen</em>
             </h1>
 
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Kommunikation löst keine Grunddynamik. Sie kann aber Eskalation
-              bremsen, Missverständnisse begrenzen und Ihre eigene Position
-              klarer machen. Gerade in belasteten Beziehungen ist deshalb nicht
-              nur wichtig, was Sie sagen, sondern wann, in welchem Ton und mit
-              welcher inneren Haltung.
+            <hr className="rule rule-narrow mb-6" />
+
+            <p className="lede">
+              Kommunikation löst keine Grunddynamik – sie kann aber Eskalation
+              bremsen und Ihre eigene Position klärer machen.
             </p>
           </motion.div>
         </div>

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -93,36 +93,28 @@ export default function Selbstfuersorge() {
             transition={{ duration: 0.6, ease: "easeOut" }}
             className="max-w-3xl"
           >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-lighter flex items-center justify-center">
-                <Sparkles className="w-6 h-6 text-sage-mid" />
-              </div>
-              <span className="text-sm font-medium text-sage-mid">
-                Lesezeit: 12 Minuten
-              </span>
-            </div>
+            <span className="kicker text-sage-mid">
+              Selbstfürsorge
+              <span aria-hidden="true"> · </span>
+              Lesezeit: 12 Minuten
+            </span>
 
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-6">
-              Selbstfürsorge für Angehörige
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-4">
+              Selbstfürsorge für <em>Angehörige</em>
             </h1>
 
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-6">
-              Wer dauerhaft mit Krisen, Unsicherheit und Loyalitätskonflikten
-              lebt, braucht eigene Regeneration. Selbstfürsorge ist nicht
-              Nebenbei-Pflege, sondern eine fachlich wichtige Grundlage, damit
-              Sie handlungsfähig und innerlich beweglich bleiben.
+            <hr className="rule rule-narrow mb-6" />
+
+            <p className="lede">
+              Wer dauerhaft mit Krisen und Loyalitätskonflikten lebt, braucht
+              eigene Regeneration – nicht als Luxus, sondern als Grundlage.
             </p>
 
-            <Card className="bg-sage-lighter/20 border-sage-mid">
-              <CardContent className="p-5">
-                <p className="text-foreground leading-relaxed italic">
-                  "Viele Angehörige merken erst spät, wie erschöpft sie geworden
-                  sind. Selbstfürsorge beginnt oft nicht mit grossen
-                  Veränderungen, sondern damit, die eigene Belastung überhaupt
-                  ernst zu nehmen."
-                </p>
-              </CardContent>
-            </Card>
+            <blockquote className="mt-6 border-l-2 border-sage-mid/40 pl-4 text-sm text-muted-foreground italic">
+              «Viele Angehörige merken erst spät, wie erschöpft sie geworden
+              sind. Selbstfürsorge beginnt damit, die eigene Belastung überhaupt
+              ernst zu nehmen.»
+            </blockquote>
           </motion.div>
         </div>
       </section>

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -6,7 +6,6 @@ import {
   Activity,
   AlertCircle,
   ArrowRight,
-  BookOpen,
   Brain,
   Heart,
   Layers,
@@ -90,26 +89,22 @@ export default function Verstehen() {
             transition={{ duration: 0.6, ease: "easeOut" }}
             className="max-w-3xl"
           >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center">
-                <BookOpen className="w-6 h-6 text-sage-mid-dark" />
-              </div>
-              <span className="text-sm font-medium text-sage-mid-dark">
-                Lesezeit: 15 Minuten
-              </span>
-            </div>
+            <span className="kicker text-sage-mid-dark">
+              Verstehen
+              <span aria-hidden="true"> · </span>
+              Lesezeit: 15 Minuten
+            </span>
 
-            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-6">
-              Borderline verstehen
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground mb-4">
+              Borderline <em>verstehen</em>
             </h1>
 
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
+            <hr className="rule rule-narrow mb-6" />
+
+            <p className="lede">
               Für Angehörige ist Borderline oft nicht nur schwer zu begreifen,
-              sondern schwer auszuhalten. Situationen können rasch kippen,
-              Reaktionen widersprüchlich wirken und die eigene Rolle unklar
-              werden. Diese Seite hilft Ihnen, typische innere und
-              zwischenmenschliche Dynamiken besser einzuordnen, ohne Verhalten
-              zu beschönigen oder zu verurteilen.
+              sondern schwer auszuhalten – Situationen kippen, Reaktionen wirken
+              widersprüchlich, die eigene Rolle bleibt unklar.
             </p>
           </motion.div>
         </div>

--- a/client/src/styles/tailwind-theme.css
+++ b/client/src/styles/tailwind-theme.css
@@ -71,7 +71,14 @@
   /* --- Teal Family (Hue 190, mapped from SA #1E656D) --- */
   --color-sage-darker: oklch(0.35 0.07 190);
   --color-sage-dark: oklch(0.44 0.07 190); /* ≈ SA --teal #1E656D */
+  --color-sage-mid-darker: oklch(
+    0.4 0.08 190
+  ); /* Between sage-darker and sage-mid */
+  --color-sage-mid-dark: oklch(
+    0.47 0.08 190
+  ); /* Between sage-dark and sage-mid */
   --color-sage-mid: oklch(0.52 0.09 190);
+  --color-sage-mid-mid: oklch(0.52 0.09 190); /* Alias for sage-mid */
   --color-sage: oklch(
     0.62 0.07 190
   ); /* 3.23:1 auf Cream – NUR für Icons/Dekor, NICHT als Textfarbe auf hellem BG */


### PR DESCRIPTION
## Editorial Design Phase 2

### Was wurde geändert?

**Hero-Redesign auf 5 redaktionellen Seiten** mit dem neuen Pattern aus dem Editorial Design Brief:
- `.kicker` (Eyebrow-Text, Caps, Inter, muted) als Kontext-Label
- `h1` mit `<em>`-Hervorhebung des Schlüsselbegriffs
- `.rule-narrow` als typografischer Trenner zwischen h1 und .lede
- `.lede` (italic, 1.32rem, max-width 44ch) als Untertitel

### Seiten-Details

| Seite | Kicker | h1-Hervorhebung |
|---|---|---|
| Verstehen | Verstehen · Lesezeit: 15 Min | `<em>verstehen</em>` |
| Genesung | Genesung · Langzeitverlauf | `<em>möglich</em>` |
| Kommunizieren | Kommunizieren · Lesezeit: 14 Min | `<em>belasteten Beziehungen</em>` |
| Selbstfürsorge | Selbstfürsorge · Lesezeit: 12 Min | `<em>Angehörige</em>` |
| Home | PUK-Meta-Zeile | `<em>Borderline-Persönlichkeitsstörung</em>` |

### Neue Sektionen auf Home

**Invitation-Sektion** (vor der Krise-Sektion):
- Kicker: «Sie dürfen anrufen»
- h2: «Sie müssen nicht wissen, was Sie sagen wollen.»
- .rule-narrow als Trenner
- Kontakt-Links (tel + mailto) aus `data/kontakte.ts` (INFO_FACHSTELLE, EMAIL_ANGEHOERIGEN)

### Bugfix

`sage-mid-dark`, `sage-mid-mid`, `sage-mid-darker` als fehlende Tailwind-Token in `tailwind-theme.css` ergänzt (waren in 52 Stellen im Code referenziert, aber nie definiert → wurden vom Browser ignoriert).

### CI
- ✅ typecheck (0 Fehler)
- ✅ lint (0 Fehler, 0 Warnings)
- ✅ 90/90 Tests