### PR TITLE
feat(editorial): Phase 3 – Story-Sektion Home + Kicker-Vereinheitlichung (20 Stellen)

### DIFF
--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -242,10 +242,7 @@ export default function Genesung() {
                     <Heart className="h-6 w-6 text-sage-dark" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-dark/85">
-                      <span className="h-px w-6 bg-sage-dark/30" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-sage-dark">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Was auf dieser Seite besonders wichtig ist
                     </h2>
@@ -283,8 +280,7 @@ export default function Genesung() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.28)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -134,10 +134,7 @@ export default function Grenzen() {
                     <Shield className="h-6 w-6 text-sage-dark" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sand-warm/90">
-                      <span className="h-px w-6 bg-sand-warm/35" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-sand-warm">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Was auf dieser Seite besonders wichtig ist
                     </h2>
@@ -175,8 +172,7 @@ export default function Grenzen() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.28)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -236,10 +236,7 @@ export default function Home() {
         <div className="container">
           <div className="max-w-5xl mx-auto">
             <div className="mb-8">
-              <span className="inline-flex items-center gap-2.5 text-[11px] font-semibold tracking-[0.1em] uppercase text-sage-dark/85 mb-3">
-                <span className="w-6 h-px bg-sage-dark/30" />
-                Orientierung
-              </span>
+              <span className="kicker text-sage-dark">Orientierung</span>
               <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-3">
                 Was ist gerade Ihre Lage?
               </h2>
@@ -315,8 +312,7 @@ export default function Home() {
 
               <div className="relative grid lg:grid-cols-[0.95fr_1.05fr]">
                 <div className="p-8 md:p-10 lg:p-12">
-                  <span className="inline-flex items-center gap-2.5 text-[11px] font-semibold tracking-[0.1em] uppercase text-sage-light/90 mb-4">
-                    <span className="w-6 h-px bg-sage-light/50" />
+                  <span className="kicker text-sage-light/90">
                     Unser Ansatz
                   </span>
 
@@ -333,18 +329,14 @@ export default function Home() {
 
                   <div className="grid sm:grid-cols-2 gap-3 mb-8 max-w-xl">
                     <div className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4 backdrop-blur-sm">
-                      <p className="text-xs font-semibold uppercase tracking-[0.08em] text-sage-light/80 mb-2">
-                        Fokus
-                      </p>
+                      <p className="kicker text-sage-light/80">Fokus</p>
                       <p className="text-sm text-white/88">
                         Verstehen, kommunizieren, Grenzen, Selbstfürsorge und
                         Soforthilfe in einer Linie gedacht.
                       </p>
                     </div>
                     <div className="rounded-2xl border border-white/10 bg-white/6 px-4 py-4 backdrop-blur-sm">
-                      <p className="text-xs font-semibold uppercase tracking-[0.08em] text-sage-light/80 mb-2">
-                        Einstieg
-                      </p>
+                      <p className="kicker text-sage-light/80">Einstieg</p>
                       <p className="text-sm text-white/88">
                         Sie starten dort, wo der Druck gerade am grössten ist,
                         statt sich durch ein Archiv zu arbeiten.
@@ -410,11 +402,7 @@ export default function Home() {
           <div className="max-w-5xl mx-auto">
             <div>
               <div className="text-center mb-8">
-                <span className="inline-flex items-center gap-2.5 text-[11px] font-semibold tracking-[0.1em] uppercase text-sage-dark/85 mb-3">
-                  <span className="w-6 h-px bg-sage-dark/30" />
-                  Werkzeuge
-                  <span className="w-6 h-px bg-sage-dark/30" />
-                </span>
+                <span className="kicker text-sage-dark">Werkzeuge</span>
                 <h2 className="text-2xl md:text-3xl font-normal text-foreground">
                   Praktische Hilfen für Ihren Alltag
                 </h2>
@@ -469,11 +457,7 @@ export default function Home() {
         <div className="container">
           <div className="max-w-5xl mx-auto">
             <div className="text-center mb-10">
-              <span className="inline-flex items-center gap-2.5 text-[11px] font-semibold tracking-[0.1em] uppercase text-sage-dark/85 mb-3">
-                <span className="w-6 h-px bg-sage-dark/30" />
-                Forschung & Praxis
-                <span className="w-6 h-px bg-sage-dark/30" />
-              </span>
+              <span className="kicker text-sage-dark">Forschung & Praxis</span>
               <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-3">
                 Was Forschung und Praxis zeigen
               </h2>
@@ -511,6 +495,44 @@ export default function Home() {
                 Alle Quellen ansehen
               </Link>
             </p>
+          </div>
+        </div>
+      </section>
+
+      <div className="home-section-divider h-6" />
+
+      {/* Story-Sektion: anonymisierte Erfahrungsgeschichte als Fliesstext */}
+      <section className="py-14 md:py-20 bg-sage-pale/40">
+        <div className="container">
+          <div className="max-w-2xl mx-auto">
+            <span className="kicker">Eine Geschichte von vielen</span>
+            <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-4">
+              «Ich habe alles versucht –{" "}
+              <em>und trotzdem nicht gewusst, was ich falsch mache.</em>»
+            </h2>
+            <hr className="rule rule-narrow mb-6" />
+            <div className="prose-editorial text-muted-foreground leading-relaxed space-y-4">
+              <p>
+                Martina, Mutter eines erwachsenen Sohnes, beschreibt es so: Sie
+                habe jahrelang das Gefühl gehabt, auf Eierschalen zu laufen.
+                Jedes Gespräch konnte kippen. Jeder gut gemeinte Satz wurde
+                falsch verstanden. Sie habe sich zurückgezogen, dann wieder
+                angenähert – und immer das Gefühl gehabt, dass sie das Problem
+                sei.
+              </p>
+              <p>
+                Was ihr schliesslich geholfen hat: zu verstehen, dass die
+                Dynamik nicht an ihr lag. Dass Borderline bestimmte
+                Beziehungsmuster erzeugt, die für Angehörige fast unmöglich zu
+                durchschauen sind – solange man sie nicht kennt. Und dass
+                Grenzen setzen keine Kälte ist, sondern Schutz für beide Seiten.
+              </p>
+              <p className="text-sm italic text-muted-foreground/70">
+                Martina ist ein Kompositum aus Erfahrungen, die in der
+                Angehörigenarbeit häufig geschildert werden. Keine echte
+                Einzelperson.
+              </p>
+            </div>
           </div>
         </div>
       </section>

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -122,10 +122,7 @@ export default function Kommunizieren() {
                     <MessageCircle className="h-6 w-6 text-slate-blue" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                      <span className="h-px w-6 bg-slate-dark/30" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-slate-dark">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Was auf dieser Seite besonders wichtig ist
                     </h2>
@@ -164,8 +161,7 @@ export default function Kommunizieren() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.28)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -129,10 +129,7 @@ export default function Selbstfuersorge() {
                     <Heart className="h-6 w-6 text-terracotta-mid" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-dark/85">
-                      <span className="h-px w-6 bg-sage-dark/30" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-sage-dark">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Was auf dieser Seite besonders trägt
                     </h2>
@@ -171,8 +168,7 @@ export default function Selbstfuersorge() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.26)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -136,10 +136,7 @@ export default function UnterstuetzenAlltag() {
                     <Calendar className="h-6 w-6 text-sage-mid-dark" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-mid-dark/80">
-                      <span className="h-px w-6 bg-sage-dark/25" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-sage-mid-dark">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Was diese Seite im Alltag ordnet
                     </h2>
@@ -178,8 +175,7 @@ export default function UnterstuetzenAlltag() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.28)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -173,10 +173,7 @@ export default function UnterstuetzenKrise() {
                     <AlertTriangle className="h-6 w-6 text-sage-mid-mid" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sand-warm/90">
-                      <span className="h-px w-6 bg-sand-warm/35" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-sand-warm">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Was diese Seite in Krisen ordnet
                     </h2>
@@ -215,8 +212,7 @@ export default function UnterstuetzenKrise() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.28)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -159,10 +159,7 @@ export default function UnterstuetzenTherapie() {
                     <Stethoscope className="h-6 w-6 text-slate-blue" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                      <span className="h-px w-6 bg-slate-dark/30" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-slate-dark">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Was diese Seite bei Therapie ordnet
                     </h2>
@@ -201,8 +198,7 @@ export default function UnterstuetzenTherapie() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.28)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -120,10 +120,7 @@ export default function Verstehen() {
                     <Brain className="h-6 w-6 text-sage-mid-dark" />
                   </div>
                   <div>
-                    <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-sage-mid-dark/85">
-                      <span className="h-px w-6 bg-sage-dark/30" />
-                      Überblick
-                    </span>
+                    <span className="kicker text-sage-mid-dark">Überblick</span>
                     <h2 className="mt-2 text-2xl font-normal text-foreground md:text-3xl">
                       Worum es hier vor allem geht
                     </h2>
@@ -161,8 +158,7 @@ export default function Verstehen() {
 
             <Card className="border-border/60 bg-cream/95 shadow-[0_28px_56px_-40px_rgba(15,23,42,0.3)]">
               <CardContent className="p-6 md:p-7">
-                <span className="inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em] text-slate-dark/85">
-                  <span className="h-px w-6 bg-slate-dark/30" />
+                <span className="kicker text-slate-dark">
                   Direkt einsteigen
                 </span>
                 <p className="mt-3 text-sm leading-relaxed text-muted-foreground">


### PR DESCRIPTION
## Editorial Design Phase 3

### Was wurde geändert?

#### 1. Story-Sektion auf Home (neu)

Neue Sektion zwischen den Themen-Karten und dem Erfahrungsberichte-Karussell:
- Kicker: «Eine Geschichte von vielen»
- h2 mit `<em>`-Hervorhebung: «Ich habe alles versucht – *und trotzdem nicht gewusst, was ich falsch mache.*»
- `.rule-narrow` als Trenner
- 2 Absätze Fliesstext (Martina-Kompositum) + Disclaimer-Zeile
- Hintergrund: `bg-sage-pale/40` (weicher Kontrast zur Umgebung)

#### 2. Kicker-Vereinheitlichung: 20 Stellen in 9 Dateien

Alle verbleibenden Inline-Kicker-Muster (`inline-flex items-center gap-2 text-[11px] font-semibold uppercase tracking-[0.08em]` + Dekorations-`<span>`) wurden auf die semantische `.kicker`-Klasse umgestellt:

| Datei | Stellen |
|---|---|
| Home.tsx | 6 (Orientierung, Unser Ansatz, Werkzeuge, Forschung & Praxis, Fokus, Einstieg) |
| Verstehen.tsx | 2 (Überblick, Direkt einsteigen) |
| Genesung.tsx | 2 (Überblick, Direkt einsteigen) |
| Kommunizieren.tsx | 2 (Überblick, Direkt einsteigen) |
| Selbstfuersorge.tsx | 2 (Überblick, Direkt einsteigen) |
| Grenzen.tsx | 2 (Überblick, Direkt einsteigen) |
| UnterstuetzenAlltag.tsx | 2 (Überblick, Direkt einsteigen) |
| UnterstuetzenKrise.tsx | 2 (Überblick, Direkt einsteigen) |
| UnterstuetzenTherapie.tsx | 2 (Überblick, Direkt einsteigen) |

**Ergebnis:** 0 verbleibende Inline-Kicker-Muster im gesamten `/pages/`-Verzeichnis.

### CI
- ✅ typecheck (0 Fehler)
- ✅ lint (0 Fehler, 0 Warnings)