### PR TITLE
feat(editorial): Phase 4 – .pull-quote Utility, Erfahrungsberichte .kicker, Pull-Quotes auf 4 Seiten

### DIFF
--- a/client/src/components/Erfahrungsberichte.tsx
+++ b/client/src/components/Erfahrungsberichte.tsx
@@ -144,9 +144,11 @@ export default function Erfahrungsberichte({
       viewport={{ once: true }}
       className="text-center mb-10"
     >
+      <span className="kicker">Erfahrungen von Angehörigen</span>
       <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-4">
-        Typische Erfahrungen von Angehörigen
+        Was viele kennen – <em>und selten benennen können</em>
       </h2>
+      <hr className="rule rule-narrow rule-center mb-5" />
       <p className="text-muted-foreground max-w-2xl mx-auto">
         Diese kurzen Verdichtungen fassen Erfahrungen zusammen, die in der
         Angehörigenarbeit häufig geschildert werden. Sie sollen Wiedererkennung

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -245,6 +245,30 @@
     max-width: 44ch;
   }
 
+  /* ── Pull-Quote (Phase 4) ── */
+  /* Zitat-Hervorhebung in Prosa-Abschnitten: linker Akzentbalken, italic, etwas grösser */
+  .pull-quote {
+    border-left: 3px solid var(--color-sage, oklch(0.72 0.08 150));
+    padding-left: 1.25rem;
+    margin: 1.75rem 0;
+  }
+
+  .pull-quote p {
+    font-size: 1.05rem;
+    line-height: 1.6;
+    font-style: italic;
+    color: var(--foreground);
+  }
+
+  .pull-quote cite {
+    display: block;
+    margin-top: 0.5rem;
+    font-size: 0.8rem;
+    font-style: normal;
+    color: var(--muted-foreground);
+    letter-spacing: 0.02em;
+  }
+
   .home-hero-surface {
     background: linear-gradient(
       to bottom right,

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -481,16 +481,14 @@ export default function Genesung() {
                   schnell an, als wäre alles umsonst gewesen. Meist ist das
                   nicht die treffendste Deutung.
                 </p>
-                <Card className="border-l-4 border-l-sage-mid bg-sage-wash/30">
-                  <CardContent className="p-5">
-                    <p className="text-foreground leading-relaxed">
-                      Entwicklung bedeutet bei Borderline häufig nicht: Schritt
-                      für Schritt nur vorwärts. Eher: Es gibt Bewegungen,
-                      Unterbrüche, Wiederaufnahmen und Phasen, in denen neue
-                      Stabilität erst gelernt werden muss.
-                    </p>
-                  </CardContent>
-                </Card>
+                <blockquote className="pull-quote">
+                  <p>
+                    Entwicklung bedeutet bei Borderline häufig nicht: Schritt
+                    für Schritt nur vorwärts. Eher: Es gibt Bewegungen,
+                    Unterbrüche, Wiederaufnahmen und Phasen, in denen neue
+                    Stabilität erst gelernt werden muss.
+                  </p>
+                </blockquote>
 
                 {/* Genesungsverlauf – Wellenlinie */}
                 <div className="rounded-lg border border-border/40 bg-slate-wash/10 p-4">

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -226,15 +226,13 @@ export default function Kommunizieren() {
                   ist die Frage nicht nur, welcher Satz "richtig" wäre, sondern
                   ob überhaupt schon ein Moment für Gespräch da ist.
                 </p>
-                <Card className="bg-slate-wash border-slate-mid/20">
-                  <CardContent className="p-5">
-                    <p className="text-foreground leading-relaxed">
-                      Hilfreiche Kommunikation ist meist kürzer, langsamer und
-                      klarer. Sie versucht nicht sofort zu überzeugen, sondern
-                      zuerst Beziehungsspannung etwas zu senken.
-                    </p>
-                  </CardContent>
-                </Card>
+                <blockquote className="pull-quote">
+                  <p>
+                    Hilfreiche Kommunikation ist meist kürzer, langsamer und
+                    klarer. Sie versucht nicht sofort zu überzeugen, sondern
+                    zuerst Beziehungsspannung etwas zu senken.
+                  </p>
+                </blockquote>
               </div>
             </ContentSection>
 

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -305,16 +305,10 @@ export default function Selbstfuersorge() {
               id="radikale-akzeptanz"
               preview="«Es ist, wie es ist.» – Dieses DBT-Konzept kann auch für Angehörige befreiend sein."
             >
-              <Card className="bg-sage-wash/50 border-sage-mid/30 mb-6">
-                <CardContent className="p-6">
-                  <p className="text-foreground leading-relaxed text-lg italic text-center">
-                    «Es ist, wie es ist.»
-                  </p>
-                  <p className="text-muted-foreground text-sm text-center mt-2">
-                    – Dieser Satz kann befreiend sein.
-                  </p>
-                </CardContent>
-              </Card>
+              <blockquote className="pull-quote mb-6">
+                <p>«Es ist, wie es ist.»</p>
+                <cite>– Dieser Satz kann befreiend sein.</cite>
+              </blockquote>
 
               <p className="text-muted-foreground leading-relaxed mb-6">
                 Radikale Akzeptanz bedeutet nicht, dass Sie die Situation

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -213,19 +213,15 @@ export default function Verstehen() {
               viewport={{ once: true }}
               className="mb-8"
             >
-              <Card className="border-l-4 border-l-sage bg-sage-light/20">
-                <CardContent className="p-6">
-                  <p className="text-foreground leading-relaxed italic">
-                    "Verstehen hat mir nicht alles leichter gemacht. Aber ich
-                    habe aufgehört, jede Eskalation nur als Bosheit, jede
-                    Distanz nur als Ablehnung und jede Krise nur als mein
-                    persönliches Versagen zu lesen."
-                  </p>
-                  <p className="text-muted-foreground text-sm mt-3">
-                    — Eine Angehörige
-                  </p>
-                </CardContent>
-              </Card>
+              <blockquote className="pull-quote">
+                <p>
+                  «Verstehen hat mir nicht alles leichter gemacht. Aber ich habe
+                  aufgehört, jede Eskalation nur als Bosheit, jede Distanz nur
+                  als Ablehnung und jede Krise nur als mein persönliches
+                  Versagen zu lesen.»
+                </p>
+                <cite>— Eine Angehörige (Kompositum, keine reale Person)</cite>
+              </blockquote>
             </motion.div>
 
             <ContentSection


### PR DESCRIPTION
## Editorial Design Phase 4

### Neue CSS-Utility: `.pull-quote`

In `index.css` unter `@layer components` ergänzt:

```css
.pull-quote {
  border-left: 3px solid var(--color-sage);
  padding-left: 1.25rem;
  margin: 1.75rem 0;
}
.pull-quote p { font-size: 1.05rem; line-height: 1.6; font-style: italic; }
.pull-quote cite { display: block; margin-top: 0.5rem; font-size: 0.8rem; font-style: normal; }
```

Semantisch korrekt: `<blockquote>` + `<cite>` statt Card-Wrapper.

### Erfahrungsberichte-Komponente

Heading-Block auf das neue Editorial-Pattern umgestellt:
- Kicker: «Erfahrungen von Angehörigen»
- h2 mit `<em>`-Hervorhebung: «Was viele kennen – *und selten benennen können*»
- `.rule-narrow .rule-center` als Trenner vor dem Lede-Text

### Pull-Quotes auf 4 Seiten

Alle bestehenden Card-basierten Hervorhebungen auf semantisches `<blockquote class="pull-quote">` umgestellt:

| Seite | Zitat |
|---|---|
| Verstehen.tsx | «Verstehen hat mir nicht alles leichter gemacht…» |
| Genesung.tsx | «Entwicklung bedeutet bei Borderline häufig nicht: Schritt für Schritt nur vorwärts…» |
| Kommunizieren.tsx | «Hilfreiche Kommunikation ist meist kürzer, langsamer und klarer…» |
| Selbstfuersorge.tsx | «Es ist, wie es ist.» |

### CI
- ✅ typecheck (0 Fehler)
- ✅ lint (0 Fehler, 0 Warnings)