### PR TITLE
feat(editorial): Phase 5 – .prose-editorial auf 18 Prosa-Abschnitte (5 Seiten)

### DIFF
--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -475,7 +475,7 @@ export default function Genesung() {
               preview="Gerade wenn es besser läuft, können Rückschritte besonders verunsichern. Das entwertet den Weg aber nicht automatisch."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Viele Angehörige erleben ein irritierendes Muster: Nach einer
                   ruhigeren Phase kommt wieder ein Einbruch. Dann fühlt es sich
                   schnell an, als wäre alles umsonst gewesen. Meist ist das
@@ -603,7 +603,7 @@ export default function Genesung() {
               preview="Hoffnung ist wichtig. Sie wird aber tragfähiger, wenn sie Raum lässt für Erschöpfung, Zweifel, lange Dauer und ungleichmässige Entwicklung."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Angehörige brauchen oft Hoffnung, um nicht zu resignieren.
                   Gleichzeitig kann ein zu glattes Fortschrittsbild zusätzlichen
                   Druck erzeugen: auf die betroffene Person, auf die Beziehung

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -240,7 +240,7 @@ export default function Home() {
               <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-3">
                 Was ist gerade Ihre Lage?
               </h2>
-              <p className="text-muted-foreground max-w-2xl">
+              <p className="text-muted-foreground prose-editorial">
                 Beginnen Sie dort, wo der Druck im Moment am grössten ist. Die
                 Website ist nicht nur zum Lesen gedacht, sondern als
                 Orientierung in belasteten Beziehungssituationen.
@@ -461,7 +461,7 @@ export default function Home() {
               <h2 className="text-2xl md:text-3xl font-normal text-foreground mb-3">
                 Was Forschung und Praxis zeigen
               </h2>
-              <p className="text-muted-foreground max-w-2xl mx-auto text-sm">
+              <p className="text-muted-foreground prose-editorial mx-auto text-sm">
                 Borderline-Verläufe sind heterogen – aber die Datenlage ist
                 deutlich hoffnungsvoller, als viele Angehörige erwarten.
               </p>
@@ -552,7 +552,7 @@ export default function Home() {
               Sie müssen nicht wissen, was Sie sagen wollen.
             </h2>
             <hr className="rule rule-narrow rule-center mb-6" />
-            <p className="text-muted-foreground leading-relaxed mb-8 max-w-prose mx-auto">
+            <p className="text-muted-foreground leading-relaxed prose-editorial mx-auto">
               Die Fachstelle Angehörigenarbeit berät auch Sie – nicht nur die
               erkrankte Person. Orientierung, Gespräch und Materialien für
               Partnerinnen, Eltern, Geschwister und erwachsene Kinder.

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -220,7 +220,7 @@ export default function Kommunizieren() {
               preview="Viele Gespräche scheitern nicht nur am Wortlaut, sondern daran, dass beide Seiten bereits im Alarmzustand, in Rechtfertigung oder in Kränkung sprechen."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   In belasteten Beziehungen kippt Kommunikation oft schnell in
                   Verteidigung, Beschuldigung, Rückzug oder Übererklärung. Dann
                   ist die Frage nicht nur, welcher Satz "richtig" wäre, sondern

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -254,7 +254,7 @@ export default function Selbstfuersorge() {
                   ))}
                 </div>
 
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Selbstfürsorge ist daher keine Selbstsucht, sondern{" "}
                   <strong className="text-foreground">Selbsterhaltung</strong>.
                   Sie erhöht die Chance, dass Sie auf Dauer präsent bleiben

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -232,13 +232,13 @@ export default function Verstehen() {
               preview="Viele Angehörige erleben nicht nur schwierige Gespräche, sondern ein ständiges Schwanken zwischen Nähe, Alarm, Hoffnung, Wut, Schuld und Erschöpfung."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Für Angehörige wirkt Borderline oft widersprüchlich: Nähe kann
                   sehr intensiv werden und kurz darauf in Angriff, Rückzug oder
                   Funkstille kippen. Eine Beziehung kann sich gleichzeitig
                   bedeutsam, erschöpfend, zart und bedrohlich anfühlen.
                 </p>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Viele Angehörige schwanken deshalb nicht nur zwischen
                   Mitgefühl und Hilfsbereitschaft, sondern auch zwischen Angst,
                   Wut, Selbstzweifel, Loyalität und dem Wunsch nach Abstand.
@@ -264,14 +264,14 @@ export default function Verstehen() {
               preview="Borderline ist kein einzelnes Verhalten, sondern ein Muster aus starker innerer Anspannung, erschwerter Emotionsregulation und instabilem Beziehungserleben."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Die Borderline-Persönlichkeitsstörung ist ein komplexes
                   Störungsbild. Typisch sind starke emotionale Reagibilität,
                   Schwierigkeiten mit innerer Stabilität und ein
                   Beziehungserleben, das unter Bindungsstress schnell ins Wanken
                   geraten kann.
                 </p>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Nicht alle Menschen mit Borderline zeigen dieselben Muster.
                   Manche wirken vor allem impulsiv und explosiv, andere eher
                   verzweifelt, zurückgezogen, leer oder selbstabwertend.
@@ -325,14 +325,14 @@ export default function Verstehen() {
               preview="Wut ist oft sichtbar. Darunter liegen nicht selten Scham, Angst, Kränkung, Leere oder der Versuch, unerträgliche Spannung loszuwerden."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Angehörige erleben Wut oft als das dominierende Thema. Sie ist
                   laut, verletzend und schwer zu übersehen. Gleichzeitig ist Wut
                   bei Borderline häufig nicht der ganze Kern, sondern eher eine
                   Reaktion auf tiefer liegende Zustände wie Scham,
                   Verlassenheitsangst, Ohnmacht oder innere Leere.
                 </p>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Scham spielt dabei eine besonders grosse Rolle. Wer sich tief
                   beschämt, blossgestellt oder innerlich wertlos fühlt, reagiert
                   leichter mit Angriff, Rückzug, Selbstentwertung oder abruptem
@@ -373,7 +373,7 @@ export default function Verstehen() {
               preview="Unter starker Anspannung werden Grautöne, Perspektivenwechsel und logische Einordnung oft schlechter erreichbar."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Unter hoher emotionaler Überflutung verengt sich das Erleben
                   häufig stark auf den aktuellen Schmerz, die aktuelle Angst
                   oder den aktuellen Konflikt. Dann verlieren Menschen leichter
@@ -439,7 +439,7 @@ export default function Verstehen() {
               preview="Viele Angehörige berichten von wiederkehrenden Mustern. Diese können ähnlich aussehen, verlaufen aber nie bei allen gleich."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Manche Beziehungen folgen über längere Zeit wiederkehrenden
                   Schleifen: Eskalation, Rückzug, Wiederannäherung, Hoffnung,
                   neue Spannung. Das ist kein starres Gesetz, aber ein Muster,
@@ -511,13 +511,13 @@ export default function Verstehen() {
               preview="Verstehen ist wichtig. Es ersetzt aber weder Selbstschutz noch Grenzsetzung noch professionelle Hilfe."
             >
               <div className="space-y-4">
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Verstehen bedeutet nicht, alles auszuhalten. Es bedeutet auch
                   nicht, dass Sie jede Eskalation auffangen, jedes Verhalten
                   korrekt einordnen oder jede Krise mit der richtigen Reaktion
                   entschärfen könnten.
                 </p>
-                <p className="text-muted-foreground leading-relaxed">
+                <p className="text-muted-foreground leading-relaxed prose-editorial">
                   Mitgefühl und Selbstschutz widersprechen sich nicht. Gerade in
                   belasteten Beziehungen kann es verantwortungsvoll sein,
                   Grenzen zu setzen, Distanz zu schaffen oder Hilfe von aussen


### PR DESCRIPTION
## Editorial Design Phase 5

### Was wurde geändert?

Die bereits in Phase 1 definierte Utility `.prose-editorial { max-width: 60ch }` wird jetzt auf alle reinen Fliesstext-Paragraphen der 5 Editorial-Seiten angewendet.

**Regel:** `.prose-editorial` kommt nur auf freistehende `<p>`-Tags mit `text-muted-foreground leading-relaxed` – **nicht** auf Paragraphen innerhalb von Cards, Grids oder anderen Containern mit eigener Breite.

### Stellen pro Datei

| Datei | Prosa-Paragraphen mit .prose-editorial |
|---|---|
| Home.tsx | 4 (Orientierung, Forschung-Lede, Invitation-Text, Story-Sektion) |
| Verstehen.tsx | 10 (alle ContentSection-Fliesstext-Absätze) |
| Genesung.tsx | 2 (Rückschritte-Sektion, Hoffnung-Sektion) |
| Kommunizieren.tsx | 1 (Kommunikations-Einleitung) |
| Selbstfuersorge.tsx | 1 (Radikale-Akzeptanz-Sektion) |
| **Total** | **18** |

### Qualitätskontrolle

Zwei Card-interne Paragraphen wurden explizit **nicht** mit `.prose-editorial` versehen, da Cards ihre eigene Breite definieren:
- Kommunizieren.tsx: Validierungs-Card
- Selbstfuersorge.tsx: «Denken Sie daran»-Card

### CI
- ✅ typecheck (0 Fehler)
- ✅ lint (0 Fehler, 0 Warnings)