### PR TITLE
perf: Infografik-Karten auf Web-Thumbnails (600 px) umstellen

### DIFF
--- a/client/src/content/genesung.ts
+++ b/client/src/content/genesung.ts
@@ -5,6 +5,7 @@ export interface GenesungItem {
   title: string;
   desc: string;
   img: string;
+  thumbnailUrl?: string;
   pdf: string;
   category: Exclude<GenesungKategorie, "alle">;
 }
@@ -29,6 +30,8 @@ export const genesungItems: GenesungItem[] = [
     title: "Das Fortschritt-Paradox",
     desc: "Warum Rückfälle zum Weg gehören",
     img: "/infografiken/fortschritt-das-fortschritt-paradox-v4.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/fortschritt-das-fortschritt-paradox-v4.png",
     pdf: "/infografiken/fortschritt-das-fortschritt-paradox-v4.pdf",
     category: "verstehen",
   },

--- a/client/src/content/grenzen.ts
+++ b/client/src/content/grenzen.ts
@@ -5,6 +5,7 @@ export interface GrenzenItem {
   title: string;
   description: string;
   url: string;
+  thumbnailUrl?: string;
   pdfUrl: string;
   category: "erkennen" | "kommunizieren" | "handeln";
 }
@@ -40,6 +41,8 @@ export const grenzenItems: GrenzenItem[] = [
     title: "Die 4 Arten von Grenzen",
     description: "Physisch, emotional, zeitlich, materiell",
     url: "/infografiken/grenzen-die-4-arten-von-grenzen-v4.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/grenzen-die-4-arten-von-grenzen-v4.png",
     pdfUrl: "/infografiken/grenzen-die-4-arten-von-grenzen-v4.pdf",
     category: "erkennen",
   },

--- a/client/src/content/kommunizieren.ts
+++ b/client/src/content/kommunizieren.ts
@@ -9,6 +9,7 @@ export interface KommunikationsMaterial {
   title: string;
   description: string;
   url: string;
+  thumbnailUrl?: string;
   pdfUrl: string;
   category: Exclude<KommunikationsKategorie, "alle">;
 }
@@ -67,6 +68,8 @@ export const kommItems: KommunikationsMaterial[] = [
     title: "Zuhören ohne Zustimmen",
     description: "Validieren ohne nachzugeben",
     url: "/infografiken/validierung-die-validierungs-treppe-v5.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/validierung-die-validierungs-treppe-v5.png",
     pdfUrl: "/infografiken/validierung-die-validierungs-treppe-v5.pdf",
     category: "techniken",
   },
@@ -84,6 +87,8 @@ export const kommItems: KommunikationsMaterial[] = [
     title: "Spickzettel Krisenkommunikation (A4)",
     description: "A4-Spickzettel für akute Spannungszustände",
     url: "/infografiken/deeskalation-der-deeskalations-pfad-v9.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/deeskalation-der-deeskalations-pfad-v9.png",
     pdfUrl: "/infografiken/deeskalation-der-deeskalations-pfad-v9.pdf",
     category: "praxis",
   },

--- a/client/src/content/materialien.ts
+++ b/client/src/content/materialien.ts
@@ -20,6 +20,7 @@ export interface MaterialItem {
     | "Notfallkarte"
     | "Notfallplan";
   url: string;
+  thumbnailUrl?: string;
   downloadUrl?: string;
   pdfUrl?: string;
   previewUrl?: string;
@@ -80,6 +81,7 @@ export const materials: MaterialItem[] = [
     category: "verstehen",
     kind: "Infografik",
     url: "/infografiken/eisberg-der-eisberg-v6.png",
+    thumbnailUrl: "/infografiken/extras/thumbnails/eisberg-der-eisberg-v6.png",
     downloadUrl: "/infografiken/eisberg-der-eisberg-v6.pdf",
     priority: "core",
   },
@@ -91,6 +93,8 @@ export const materials: MaterialItem[] = [
     category: "unterstuetzen",
     kind: "Infografik",
     url: "/infografiken/sphären-die-einfluss-sphären-v3.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/sphären-die-einfluss-sphären-v3.png",
     downloadUrl: "/infografiken/sphären-die-einfluss-sphären-v3.pdf",
     priority: "core",
   },
@@ -102,6 +106,8 @@ export const materials: MaterialItem[] = [
     category: "kommunizieren",
     kind: "Spickzettel",
     url: "/infografiken/deeskalation-der-deeskalations-pfad-v9.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/deeskalation-der-deeskalations-pfad-v9.png",
     downloadUrl: "/infografiken/deeskalation-der-deeskalations-pfad-v9.pdf",
     priority: "core",
   },
@@ -149,6 +155,8 @@ export const materials: MaterialItem[] = [
     category: "verstehen",
     kind: "Infografik",
     url: "/infografiken/pendel-das-bewertungs-pendel-v14.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/pendel-das-bewertungs-pendel-v14.png",
     downloadUrl: "/infografiken/pendel-das-bewertungs-pendel-v14.pdf",
     priority: "secondary",
   },
@@ -160,6 +168,8 @@ export const materials: MaterialItem[] = [
     category: "verstehen",
     kind: "Infografik",
     url: "/infografiken/alarm-der-alarm-modus-v3.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/alarm-der-alarm-modus-v3.png",
     downloadUrl: "/infografiken/alarm-der-alarm-modus-v3.pdf",
     priority: "secondary",
   },

--- a/client/src/content/selbstfuersorge.ts
+++ b/client/src/content/selbstfuersorge.ts
@@ -10,6 +10,7 @@ export type SelbstfuersorgeInfografik = {
   desc: string;
   category: Exclude<SelbstfuersorgeKategorie, "alle">;
   webp: string;
+  thumbnailUrl?: string;
   pdf: string;
   featured?: boolean;
 };
@@ -30,6 +31,8 @@ export const selbstfuersorgeInfografiken: SelbstfuersorgeInfografik[] = [
     desc: "Kreislauf-Diagramm: Teufelskreis vs. positiver Kreislauf – warum Selbstfürsorge keine Selbstsucht ist.",
     category: "erkennen",
     webp: "/infografiken/sauerstoff-die-sauerstoffmaske-v4.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/sauerstoff-die-sauerstoffmaske-v4.png",
     pdf: "/infografiken/sauerstoff-die-sauerstoffmaske-v4.pdf",
   },
   {

--- a/client/src/content/unterstuetzen.ts
+++ b/client/src/content/unterstuetzen.ts
@@ -12,6 +12,8 @@ export const unterstuetzenItems = [
     id: "im-krisenmodus",
     title: "Im Krisenmodus – Orientierung geben",
     url: "/infografiken/ampel-das-ampel-system-v3.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/ampel-das-ampel-system-v3.png",
     pdfUrl: "/infografiken/ampel-das-ampel-system-v3.pdf",
     category: "grundlagen",
   },
@@ -19,6 +21,8 @@ export const unterstuetzenItems = [
     id: "rolle-klaeren",
     title: "Ihre Rolle klären",
     url: "/infografiken/sphären-die-einfluss-sphären-v3.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/sphären-die-einfluss-sphären-v3.png",
     pdfUrl: "/infografiken/sphären-die-einfluss-sphären-v3.pdf",
     category: "grundlagen",
   },

--- a/client/src/content/verstehen.ts
+++ b/client/src/content/verstehen.ts
@@ -6,6 +6,7 @@ export interface VerstehenInfografik {
   description: string;
   category: Exclude<VerstehenMaterialCategory, "alle">;
   webpUrl: string;
+  thumbnailUrl?: string;
   pdfUrl: string;
   alt: string;
   featured?: boolean;
@@ -36,6 +37,7 @@ export const verstehenInfografiken: VerstehenInfografik[] = [
       "Wut ist oft nur die Spitze – darunter liegen Schmerz und Angst.",
     category: "grundlagen",
     webpUrl: "/infografiken/eisberg-der-eisberg-v6.png",
+    thumbnailUrl: "/infografiken/extras/thumbnails/eisberg-der-eisberg-v6.png",
     pdfUrl: "/infografiken/eisberg-der-eisberg-v6.pdf",
     alt: "Der Eisberg – Wut ist oft die Spitze",
   },
@@ -45,6 +47,8 @@ export const verstehenInfografiken: VerstehenInfografik[] = [
     description: "Das Pendel zwischen Extremen – die Grauzone stärken.",
     category: "grundlagen",
     webpUrl: "/infografiken/pendel-das-bewertungs-pendel-v14.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/pendel-das-bewertungs-pendel-v14.png",
     pdfUrl: "/infografiken/pendel-das-bewertungs-pendel-v14.pdf",
     alt: "Spaltung – das Pendel zwischen Extremen",
   },
@@ -55,6 +59,8 @@ export const verstehenInfografiken: VerstehenInfografik[] = [
       "Erst beruhigen, dann klären – warum Logik manchmal nicht ankommt.",
     category: "neurobiologie",
     webpUrl: "/infografiken/alarm-der-alarm-modus-v3.png",
+    thumbnailUrl:
+      "/infografiken/extras/thumbnails/alarm-der-alarm-modus-v3.png",
     pdfUrl: "/infografiken/alarm-der-alarm-modus-v3.pdf",
     alt: "Alarm-Modus vs. Denk-Modus",
   },

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -102,12 +102,12 @@ function GenesungInfografiken() {
             >
               <div className="aspect-[3/4] overflow-hidden bg-muted">
                 <img
-                  src={item.img}
+                  src={item.thumbnailUrl ?? item.img}
                   alt={item.title}
                   className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-700"
                   loading="lazy"
-                  width={400}
-                  height={223}
+                  width={600}
+                  height={848}
                   decoding="async"
                 />
               </div>

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -686,12 +686,12 @@ export default function Grenzen() {
                     >
                       <div className="relative aspect-[3/4] bg-muted overflow-hidden">
                         <img
-                          src={item.url}
+                          src={item.thumbnailUrl ?? item.url}
                           alt={item.title}
                           className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-500"
                           loading="lazy"
-                          width={400}
-                          height={223}
+                          width={600}
+                          height={848}
                           decoding="async"
                         />
                       </div>

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -426,12 +426,12 @@ export default function UnterstuetzenUebersicht() {
                     >
                       <div className="aspect-[4/3] bg-muted overflow-hidden">
                         <img
-                          src={item.url}
+                          src={item.thumbnailUrl ?? item.url}
                           alt={item.title}
                           className="w-full h-full object-cover object-top"
                           loading="lazy"
-                          width={400}
-                          height={223}
+                          width={600}
+                          height={848}
                           decoding="async"
                         />
                       </div>

--- a/client/src/sections/GenesungInfografikenSection.tsx
+++ b/client/src/sections/GenesungInfografikenSection.tsx
@@ -86,12 +86,12 @@ export default function GenesungInfografikenSection() {
           >
             <div className="aspect-[3/4] overflow-hidden bg-muted">
               <img
-                src={item.img}
+                src={item.thumbnailUrl ?? item.img}
                 alt={item.title}
                 className="w-full h-full object-cover object-top group-hover:scale-105 transition-transform duration-700"
                 loading="lazy"
-                width={400}
-                height={223}
+                width={600}
+                height={848}
                 decoding="async"
               />
             </div>

--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -115,12 +115,12 @@ export default function KommunizierenMaterialsSection() {
               >
                 <div className="aspect-[4/3] bg-muted">
                   <img
-                    src={item.url}
+                    src={item.thumbnailUrl ?? item.url}
                     alt={item.title}
                     className="w-full h-full object-cover object-top"
                     loading="lazy"
-                    width={400}
-                    height={223}
+                    width={600}
+                    height={848}
                     decoding="async"
                   />
                 </div>

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -109,12 +109,12 @@ export default function SelbstfuersorgeInfografikenSection() {
             >
               <div className="aspect-[3/4] overflow-hidden bg-muted">
                 <img
-                  src={item.webp}
+                  src={item.thumbnailUrl ?? item.webp}
                   alt={item.title}
                   className="w-full h-full object-cover object-top"
                   loading="lazy"
-                  width={400}
-                  height={223}
+                  width={600}
+                  height={848}
                   decoding="async"
                 />
               </div>

--- a/client/src/sections/VerstehenInfografikenSection.tsx
+++ b/client/src/sections/VerstehenInfografikenSection.tsx
@@ -114,12 +114,12 @@ export default function VerstehenInfografikenSection() {
                   aria-label={`${item.alt} – Vorschau öffnen`}
                 >
                   <img
-                    src={item.webpUrl}
+                    src={item.thumbnailUrl ?? item.webpUrl}
                     alt={item.alt}
                     className="w-full h-full object-cover object-top"
                     loading="lazy"
-                    width={400}
-                    height={223}
+                    width={600}
+                    height={848}
                     decoding="async"
                   />
                 </button>

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -117,12 +117,12 @@ export default function VerstehenMaterialsSection() {
                 aria-label={`${item.alt} – Vorschau öffnen`}
               >
                 <img
-                  src={item.webpUrl}
+                  src={item.thumbnailUrl ?? item.webpUrl}
                   alt={item.alt}
                   className="w-full h-full object-cover object-top"
                   loading="lazy"
-                  width={400}
-                  height={223}
+                  width={600}
+                  height={848}
                   decoding="async"
                 />
               </button>


### PR DESCRIPTION
## Was wurde geändert?

Infografik-Karten laden jetzt die leichten Web-Thumbnails (600 px, 112–515 KB) statt der High-Res-Originale (2480 px, 1–4 MB) als Vorschau-Bild. Die Originale bleiben weiterhin für Download/Vollbild verfügbar.

## Änderungen

### Content-Dateien (7 Dateien)
- `thumbnailUrl`-Feld als optionales Feld in allen Interfaces/Types ergänzt
- 10 lokale Infografiken mit `thumbnailUrl` auf `/infografiken/extras/thumbnails/` verknüpft
- CDN-Infografiken ohne Thumbnail bleiben unverändert (Fallback greift automatisch)

### Render-Stellen (8 Stellen in 7 Dateien)
- `src={item.url}` → `src={item.thumbnailUrl ?? item.url}` (Fallback-Pattern)
- `width`/`height`-Attribute auf 600×848 korrigiert (entspricht tatsächlicher Thumbnail-Grösse)
- Betrifft: Grenzen.tsx, UnterstuetzenUebersicht.tsx, Genesung.tsx, GenesungInfografikenSection.tsx, KommunizierenMaterialsSection.tsx, SelbstfuersorgeInfografikenSection.tsx, VerstehenInfografikenSection.tsx, VerstehenMaterialsSection.tsx

## Performance-Gewinn
| Infografik | Original | Thumbnail | Ersparnis |
|---|---|---|---|
| Sauerstoffmaske | ~3.8 MB | 515 KB | -86% |
| Grenzen | ~3.5 MB | 506 KB | -86% |
| Ampel | ~3.2 MB | 456 KB | -86% |
| Eisberg | ~3.1 MB | 469 KB | -85% |
| Alarm-Modus | ~2.8 MB | 162 KB | -94% |
| Pendel | ~2.5 MB | 122 KB | -95% |
| Deeskalation | ~2.4 MB | 121 KB | -95% |
| Fortschritt | ~2.2 MB | 112 KB | -95% |

## Backward-Compatibility
Das `thumbnailUrl`-Feld ist überall optional. Neue Infografiken ohne Thumbnail-Datei fallen automatisch auf das Original zurück.