### PR TITLE
fix(notfallkarte): limit calming strategies to 4 (matches print slots)

### DIFF
--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -237,14 +237,19 @@ export default function Notfallkarte() {
     setAnnouncement("Kontakt entfernt");
   }, []);
 
+  const MAX_STRATEGIES = 4;
+
   const addStrategy = useCallback(() => {
-    setData(prev => ({
-      ...prev,
-      calmingStrategies: [
-        ...prev.calmingStrategies,
-        { id: createId(), text: "" },
-      ],
-    }));
+    setData(prev => {
+      if (prev.calmingStrategies.length >= MAX_STRATEGIES) return prev;
+      return {
+        ...prev,
+        calmingStrategies: [
+          ...prev.calmingStrategies,
+          { id: createId(), text: "" },
+        ],
+      };
+    });
     setAnnouncement("Strategie hinzugefügt");
   }, []);
 
@@ -472,6 +477,12 @@ export default function Notfallkarte() {
                 variant="outline"
                 size="sm"
                 onClick={addStrategy}
+                disabled={data.calmingStrategies.length >= MAX_STRATEGIES}
+                title={
+                  data.calmingStrategies.length >= MAX_STRATEGIES
+                    ? "Maximal 4 Strategien – passend zur Druckseite"
+                    : undefined
+                }
                 className="gap-1.5 print:hidden"
               >
                 <Plus className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Problem
Die Notfallkarte erlaubte unbegrenzt viele Beruhigungsstrategien. Die Druckseite `notfallkarte-print.html` hat jedoch nur 4 feste Slots (`strategy-0` bis `strategy-3`). Einträge ab Slot 5 wurden beim Drucken stillschweigend abgeschnitten.

## Lösung
- `MAX_STRATEGIES = 4` Konstante eingeführt
- `addStrategy()` Guard: verhindert Hinzufügen über das Limit hinaus
- «Hinzufügen»-Button wird bei Limit deaktiviert (`disabled`)
- Tooltip erklärt das Limit: «Maximal 4 Strategien – passend zur Druckseite»

## Verhalten
- Nutzerin mit < 4 Strategien: Button aktiv wie bisher
- Nutzerin mit = 4 Strategien: Button ausgegraut, Tooltip sichtbar
- Bestehende Daten mit > 4 Strategien (aus altem localStorage): werden angezeigt und können bearbeitet/gelöscht werden, aber keine neuen können hinzugefügt werden