### PR TITLE
fix(fachstelle): correct hero lede width from 60ch to 44ch

### DIFF
--- a/client/src/pages/Fachstelle.tsx
+++ b/client/src/pages/Fachstelle.tsx
@@ -51,7 +51,7 @@ export default function Fachstelle() {
 
             <hr className="rule-narrow mb-6" />
 
-            <p className="lede prose-editorial">
+            <p className="lede">
               Ein Angebot der Psychiatrischen Universitätsklinik Zürich für
               Angehörige von Menschen mit psychischen Erkrankungen. Die
               Fachstelle bietet Orientierung, Entlastung und Beratung für


### PR DESCRIPTION
## Bug

`Fachstelle.tsx` Zeile 54 hatte `className="lede prose-editorial"`. Die Klasse `.prose-editorial` (max-width: 60ch) überschrieb das eingebaute `max-width: 44ch` von `.lede`, sodass der Hero-Lede-Text auf Desktop bis zu 60 Zeichen breit wurde – 36 % breiter als typografisch korrekt.

## Fix

`prose-editorial` aus dem Lede-Paragraphen entfernt. `.lede` hat bereits `max-width: 44ch` eingebaut.

## Vorher / Nachher

| | Vorher | Nachher |
|---|---|---|
| Klassen | `lede prose-editorial` | `lede` |
| max-width | 60ch (überschrieben) | 44ch (korrekt) |