### PR TITLE
fix(content): EvidenceNote für Radikale Akzeptanz + Übergangs-Satz Grenzen→Selbstfürsorge

### DIFF
--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -835,6 +835,14 @@ export default function Grenzen() {
               </div>
             </ContentSection>
 
+            <div className="mt-8 mb-6 rounded-2xl border border-sage-light/60 bg-sage-wash/40 px-6 py-5">
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Grenzen sind der Schutzraum – Selbstfürsorge ist das, was Sie
+                darin aufbauen. Wer weiss, wo er aufhört und der andere anfängt,
+                kann sich erholen, ohne sich schuldig zu fühlen.
+              </p>
+            </div>
+
             <motion.div
               initial={{ opacity: 0, y: 20 }}
               whileInView={{ opacity: 1, y: 0 }}

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -21,6 +21,7 @@ import { permissionList } from "@/content/selbstfuersorge-page";
 import { SelbstfuersorgeExercisesSection } from "@/sections/SelbstfuersorgeExercisesSection";
 import { SelbstfuersorgeSignalsSection } from "@/sections/SelbstfuersorgeSignalsSection";
 import { SelbstfuersorgeRoleNotesSection } from "@/sections/SelbstfuersorgeRoleNotesSection";
+import EvidenceNote from "@/components/EvidenceNote";
 
 const selbstfuersorgeIntroCards = [
   {
@@ -377,9 +378,19 @@ export default function Selbstfuersorge() {
                 </CardContent>
               </Card>
 
-              <p className="text-xs text-muted-foreground mt-4">
-                Quelle: Marsha M. Linehan, DBT Skills Training Manual (2015)
-              </p>
+              <EvidenceNote
+                title="Quelle zur Radikalen Akzeptanz"
+                definition="Das Konzept der Radikalen Akzeptanz ist ein zentrales Element der Dialektisch-Behavioralen Therapie (DBT). Es beschreibt eine Haltung, keine Kapitulation."
+                reviewDate="26.04.2026"
+                sources={[
+                  {
+                    label:
+                      "Linehan, DBT Skills Training Manual, 2. Aufl. (2015)",
+                    type: "wissenschaft",
+                  },
+                ]}
+                className="mt-4"
+              />
             </ContentSection>
 
             {/* ═══ 7. Erlaubnis geben ═══ */}


### PR DESCRIPTION
## Stringenz-Audit Follow-ups

### Änderungen

**Selbstfuersorge.tsx**
- Einfachen `<p>`-Quellenverweis auf `<EvidenceNote>`-Komponente umgestellt
- Quelle: Linehan, DBT Skills Training Manual, 2. Aufl. (2015)
- reviewDate: 26.04.2026
- Konsistent mit allen anderen Seiten die EvidenceNote verwenden

**Grenzen.tsx**
- Übergangs-Satz vor dem Navigation-Block eingefügt
- Inhalt: «Grenzen sind der Schutzraum – Selbstfürsorge ist das, was Sie darin aufbauen.»
- Erklärt den inhaltlichen Übergang zur nächsten Seite

### Hintergrund
Beide Punkte wurden im Stringenz-Audit identifiziert (kein Bug, sondern inhaltliche Verbesserungen).