### PR TITLE
feat: Visualisierungen für Unterstützen-Seiten und GrenzenCheck

### DIFF
--- a/client/src/components/interactive/GrenzenCheck.tsx
+++ b/client/src/components/interactive/GrenzenCheck.tsx
@@ -1,0 +1,314 @@
+import { useState } from "react";
+import {
+  Shield,
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+type Antwort = "ja" | "manchmal" | "nein" | null;
+
+interface CheckPunkt {
+  id: string;
+  bereich: string;
+  frage: string;
+  einordnung: Record<Exclude<Antwort, null>, string>;
+  hinweis: string;
+}
+
+const checkPunkte: CheckPunkt[] = [
+  {
+    id: "warnsignale",
+    bereich: "Warnsignale erkennen",
+    frage:
+      "Merke ich meistens erst im Nachhinein, dass eine Grenze nötig gewesen wäre?",
+    einordnung: {
+      ja: "Das ist häufig. Grenzen werden oft erst sichtbar, wenn sie überschritten wurden. Es lohnt sich, im Ruhigen zu überlegen: Welche Situationen kosten mich regelmässig Energie?",
+      manchmal:
+        "Sie haben schon ein gewisses Gespür für Warnsignale. Üben Sie, diese früher zu benennen – auch innerlich, ohne sofort handeln zu müssen.",
+      nein: "Sie erkennen Warnsignale gut. Die Herausforderung liegt oft weniger im Erkennen als im Handeln.",
+    },
+    hinweis: "Warnsignale: Erschöpfung, Groll, das Gefühl «schon wieder».",
+  },
+  {
+    id: "formulierung",
+    bereich: "Grenzen formulieren",
+    frage:
+      "Fällt es mir schwer, eine Grenze klar und ruhig auszusprechen – ohne Vorwurf, aber auch ohne Entschuldigung?",
+    einordnung: {
+      ja: "Das ist eine der häufigsten Schwierigkeiten. Grenzen klingen oft entweder zu hart oder zu weich. Kurze, ich-bezogene Sätze helfen: «Ich brauche jetzt eine Pause.» statt «Du bist immer so…»",
+      manchmal:
+        "Manchmal gelingt es, manchmal nicht – das ist normal. Oft hängt es von der eigenen Erschöpfung ab. Je früher Sie eine Grenze setzen, desto ruhiger klingt sie.",
+      nein: "Sie können Grenzen klar formulieren. Achten Sie darauf, dass Klarheit nicht in Kälte kippt – Ton und Timing bleiben wichtig.",
+    },
+    hinweis:
+      "Kurze Ich-Sätze: «Ich mache das nicht mit.» «Ich melde mich morgen.»",
+  },
+  {
+    id: "konsequenz",
+    bereich: "Konsequenz halten",
+    frage:
+      "Weiche ich Grenzen, die ich gesetzt habe, oft wieder auf – aus Schuldgefühl, Mitleid oder Angst vor Eskalation?",
+    einordnung: {
+      ja: "Das ist sehr verständlich und sehr häufig. Konsequenz ist nicht Härte – es ist Verlässlichkeit. Wenn Grenzen immer wieder aufgeweicht werden, verlieren sie ihre Wirkung für beide Seiten.",
+      manchmal:
+        "Sie halten Grenzen manchmal, aber nicht immer. Überlegen Sie: In welchen Situationen weichen Sie eher nach? Was löst das aus?",
+      nein: "Sie können Konsequenz halten. Achten Sie darauf, dass Sie dabei nicht in Starrheit kippen – Grenzen dürfen auch bewusst angepasst werden.",
+    },
+    hinweis:
+      "Konsequenz heisst: Ihr Handeln passt zu dem, was Sie angekündigt haben.",
+  },
+  {
+    id: "schuld",
+    bereich: "Schuldgefühle",
+    frage:
+      "Fühle ich mich nach dem Setzen einer Grenze häufig schuldig oder wie eine schlechte Person?",
+    einordnung: {
+      ja: "Schuldgefühle nach Grenzen sind fast universell bei Angehörigen. Sie bedeuten nicht, dass Sie falsch gehandelt haben. Schuldgefühl und Schuld sind nicht dasselbe.",
+      manchmal:
+        "Manchmal taucht Schuld auf, manchmal nicht. Beobachten Sie, wann sie stärker ist – oft hängt es mit der Reaktion der anderen Person zusammen.",
+      nein: "Sie können Grenzen setzen, ohne sich dauerhaft schuldig zu fühlen. Das ist eine wichtige Ressource.",
+    },
+    hinweis: "Grenzen schützen die Beziehung – sie zerstören sie nicht.",
+  },
+  {
+    id: "eskalation",
+    bereich: "Eskalationsangst",
+    frage:
+      "Vermeide ich Grenzen, weil ich Angst habe, dass die andere Person eskaliert, sich verletzt oder die Beziehung abbricht?",
+    einordnung: {
+      ja: "Diese Angst ist real und nachvollziehbar. Sie führt aber oft dazu, dass Grenzen nie gesetzt werden – und die Belastung steigt. Grenzen können mit Ankündigung, Ruhe und Vorbereitung gesetzt werden.",
+      manchmal:
+        "Manchmal hält Eskalationsangst Sie zurück, manchmal nicht. Überlegen Sie: Welche Grenzen trauen Sie sich zu setzen, welche nicht?",
+      nein: "Eskalationsangst hält Sie nicht zurück. Achten Sie trotzdem auf Timing und Ton – auch wenn Sie keine Angst haben, kann die Reaktion der anderen Person schwierig sein.",
+    },
+    hinweis:
+      "Grenzen setzen und Eskalation verhindern schliessen sich nicht aus.",
+  },
+];
+
+const antwortLabels: Record<Exclude<Antwort, null>, string> = {
+  ja: "Ja, oft",
+  manchmal: "Manchmal",
+  nein: "Eher nicht",
+};
+
+const antwortFarben: Record<Exclude<Antwort, null>, string> = {
+  ja: "border-sand-border bg-sand-muted/60 text-sand-warm",
+  manchmal: "border-sage-light bg-sage-wash/60 text-sage-mid-dark",
+  nein: "border-slate-light bg-slate-wash/60 text-slate-blue",
+};
+
+const antwortAktivFarben: Record<Exclude<Antwort, null>, string> = {
+  ja: "border-sand-warm bg-sand-muted ring-2 ring-sand-warm/30 text-sand-warm font-semibold",
+  manchmal:
+    "border-sage-mid bg-sage-wash ring-2 ring-sage-mid/30 text-sage-mid-dark font-semibold",
+  nein: "border-slate-blue bg-slate-wash ring-2 ring-slate-blue/30 text-slate-blue font-semibold",
+};
+
+export default function GrenzenCheck() {
+  const [antworten, setAntworten] = useState<Record<string, Antwort>>({});
+  const [offenePunkte, setOffenePunkte] = useState<Record<string, boolean>>({});
+  const [abgeschlossen, setAbgeschlossen] = useState(false);
+
+  const setzeAntwort = (id: string, antwort: Antwort) => {
+    setAntworten(prev => ({ ...prev, [id]: antwort }));
+    // Einordnung automatisch öffnen
+    setOffenePunkte(prev => ({ ...prev, [id]: true }));
+  };
+
+  const togglePunkt = (id: string) => {
+    setOffenePunkte(prev => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const anzahlBeantwortet = Object.values(antworten).filter(Boolean).length;
+  const alleBeantwortet = anzahlBeantwortet === checkPunkte.length;
+  const anzahlJa = Object.values(antworten).filter(a => a === "ja").length;
+  const anzahlManchmal = Object.values(antworten).filter(
+    a => a === "manchmal"
+  ).length;
+
+  const getGesamtEinordnung = () => {
+    if (anzahlJa >= 4) {
+      return {
+        ton: "alert",
+        text: "Sie tragen gerade viel. In mehreren Bereichen zeigen sich deutliche Schwierigkeiten mit Grenzen. Das ist kein Versagen – es ist ein Hinweis, dass Unterstützung sinnvoll wäre. Professionelle Begleitung kann helfen, Grenzen einzuüben.",
+      };
+    }
+    if (anzahlJa >= 2 || anzahlManchmal >= 3) {
+      return {
+        ton: "sand",
+        text: "Sie kennen die Herausforderungen beim Grenzen setzen gut. In einigen Bereichen haben Sie bereits Ressourcen, in anderen lohnt sich gezieltes Üben oder Unterstützung.",
+      };
+    }
+    return {
+      ton: "sage",
+      text: "Sie haben in vielen Bereichen bereits ein gutes Fundament. Grenzen setzen ist trotzdem ein fortlaufender Prozess – kein einmaliger Entscheid.",
+    };
+  };
+
+  return (
+    <div className="mt-6 space-y-5">
+      <Card className="border-border/50 bg-muted/20">
+        <CardContent className="p-5">
+          <div className="flex items-start gap-3">
+            <Shield className="w-5 h-5 text-sage-mid-dark flex-shrink-0 mt-0.5" />
+            <div>
+              <h3 className="font-semibold text-foreground mb-1">
+                Orientierung zu Grenzen im Alltag
+              </h3>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                Dieser Check hilft Ihnen, fünf häufige Schwierigkeiten beim
+                Grenzen setzen ruhig zu reflektieren. Es gibt keine richtigen
+                oder falschen Antworten – nur ehrliche.
+              </p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-4">
+        {checkPunkte.map((punkt, index) => {
+          const antwort = antworten[punkt.id] ?? null;
+          const istOffen = offenePunkte[punkt.id] ?? false;
+
+          return (
+            <Card
+              key={punkt.id}
+              className={`border-border/50 transition-all ${antwort ? "border-border/70" : ""}`}
+            >
+              <CardContent className="p-5">
+                <div className="flex items-start gap-3 mb-3">
+                  <span className="flex-shrink-0 w-6 h-6 rounded-full bg-sage-wash text-sage-mid-dark text-xs font-bold flex items-center justify-center mt-0.5">
+                    {index + 1}
+                  </span>
+                  <div className="flex-1">
+                    <p className="text-xs font-medium text-sage-mid-dark mb-1">
+                      {punkt.bereich}
+                    </p>
+                    <p className="text-sm font-medium text-foreground leading-relaxed">
+                      {punkt.frage}
+                    </p>
+                  </div>
+                </div>
+
+                <div className="flex gap-2 ml-9 flex-wrap">
+                  {(["ja", "manchmal", "nein"] as const).map(option => (
+                    <button
+                      key={option}
+                      type="button"
+                      onClick={() => setzeAntwort(punkt.id, option)}
+                      className={`px-3 py-1.5 rounded-xl border text-sm transition-all ${
+                        antwort === option
+                          ? antwortAktivFarben[option]
+                          : antwortFarben[option] + " hover:opacity-80"
+                      }`}
+                    >
+                      {antwortLabels[option]}
+                    </button>
+                  ))}
+                </div>
+
+                {antwort && (
+                  <div className="ml-9 mt-3">
+                    <button
+                      type="button"
+                      onClick={() => togglePunkt(punkt.id)}
+                      className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                    >
+                      {istOffen ? (
+                        <>
+                          <ChevronUp className="w-3 h-3" />
+                          Einordnung ausblenden
+                        </>
+                      ) : (
+                        <>
+                          <ChevronDown className="w-3 h-3" />
+                          Einordnung anzeigen
+                        </>
+                      )}
+                    </button>
+
+                    {istOffen && (
+                      <div className="mt-2 space-y-2">
+                        <p className="text-sm text-muted-foreground leading-relaxed">
+                          {punkt.einordnung[antwort]}
+                        </p>
+                        <p className="text-xs text-muted-foreground/70 italic">
+                          {punkt.hinweis}
+                        </p>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {alleBeantwortet && !abgeschlossen && (
+        <div className="flex justify-center">
+          <Button
+            variant="outline"
+            className="border-sage-mid text-sage-mid-dark hover:bg-sage-wash"
+            onClick={() => setAbgeschlossen(true)}
+          >
+            <CheckCircle2 className="w-4 h-4 mr-2" />
+            Gesamteinordnung anzeigen
+          </Button>
+        </div>
+      )}
+
+      {abgeschlossen &&
+        (() => {
+          const einordnung = getGesamtEinordnung();
+          const istAlert = einordnung.ton === "alert";
+          const istSand = einordnung.ton === "sand";
+          return (
+            <Card
+              className={`${
+                istAlert
+                  ? "border-alert/20 bg-alert/5"
+                  : istSand
+                    ? "border-sand-border/60 bg-sand-muted/40"
+                    : "border-sage-mid/20 bg-sage-wash/30"
+              }`}
+            >
+              <CardContent className="p-5">
+                <div className="space-y-3">
+                  <div className="flex items-start gap-3">
+                    {istAlert ? (
+                      <AlertTriangle className="w-5 h-5 text-alert flex-shrink-0 mt-0.5" />
+                    ) : (
+                      <Shield
+                        className={`w-5 h-5 flex-shrink-0 mt-0.5 ${istSand ? "text-sand-warm" : "text-sage-dark"}`}
+                      />
+                    )}
+                    <p className="text-sm text-foreground leading-relaxed">
+                      {einordnung.text}
+                    </p>
+                  </div>
+                  <p className="text-xs text-muted-foreground leading-relaxed ml-8">
+                    Die Fachstelle Angehörigenarbeit (PUK Zürich) bietet
+                    Beratung: 058 384 38 00. Grenzen setzen lässt sich üben –
+                    manchmal hilft ein Gespräch mehr als jeder Ratgeber.
+                  </p>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })()}
+
+      {!alleBeantwortet && anzahlBeantwortet > 0 && (
+        <p className="text-xs text-center text-muted-foreground">
+          {checkPunkte.length - anzahlBeantwortet} von {checkPunkte.length}{" "}
+          Fragen noch offen
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/visualizations/EnergieHaushaltVisualisierung.tsx
+++ b/client/src/components/visualizations/EnergieHaushaltVisualisierung.tsx
@@ -1,0 +1,206 @@
+/**
+ * EnergieHaushaltVisualisierung
+ *
+ * Visuelles Balkenmodell für die Alltag-Seite.
+ * Zeigt was Energie kostet vs. was sie zurückgibt –
+ * als interaktive Waage/Balance-Metapher.
+ */
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { Minus, Plus } from "lucide-react";
+
+interface EnergieItem {
+  label: string;
+  wert: number; // 1–5
+  hinweis?: string;
+}
+
+const KOSTET: EnergieItem[] = [
+  {
+    label: "Ständige Wachsamkeit",
+    wert: 5,
+    hinweis: "Immer auf das nächste Kippen gefasst sein",
+  },
+  {
+    label: "Gespräche, die eskalieren",
+    wert: 4,
+    hinweis: "Auch wenn sie gut gemeint beginnen",
+  },
+  {
+    label: "Schuldgefühle & Grübeln",
+    wert: 4,
+    hinweis: "Nächte, in denen Sie Gespräche wiederholen",
+  },
+  {
+    label: "Unvorhersehbarkeit",
+    wert: 3,
+    hinweis: "Nicht wissen, wie der Abend wird",
+  },
+  {
+    label: "Eigene Bedürfnisse zurückstellen",
+    wert: 3,
+    hinweis: "Weil gerade wieder kein guter Moment ist",
+  },
+];
+
+const GIBT_ZURUECK: EnergieItem[] = [
+  {
+    label: "Klare Grenzen & Routinen",
+    wert: 4,
+    hinweis: "Vorhersehbarkeit schützt beide Seiten",
+  },
+  {
+    label: "Eigene Auszeiten",
+    wert: 5,
+    hinweis: "Nicht als Luxus, sondern als Schutzfaktor",
+  },
+  {
+    label: "Gespräche mit Vertrauenspersonen",
+    wert: 4,
+    hinweis: "Jemand, der zuhört ohne zu urteilen",
+  },
+  {
+    label: "Körperliche Bewegung",
+    wert: 3,
+    hinweis: "Auch kurze Spaziergänge helfen",
+  },
+  {
+    label: "Momente ohne Rolle",
+    wert: 3,
+    hinweis: "Zeiten, in denen Sie nicht Angehöriger sind",
+  },
+];
+
+function EnergieBalken({
+  item,
+  richtung,
+}: {
+  item: EnergieItem;
+  richtung: "kostet" | "gibt";
+}) {
+  const [hover, setHover] = useState(false);
+  const isKostet = richtung === "kostet";
+  const farbe = isKostet
+    ? "bg-[var(--color-sos-orange-text)]"
+    : "bg-[var(--color-sage-mid)]";
+  const farbeBg = isKostet
+    ? "bg-[var(--color-sos-orange-wash)]"
+    : "bg-sage-wash";
+  const borderFarbe = isKostet
+    ? "border-[var(--color-sos-orange-border)]"
+    : "border-sage-light/70";
+
+  return (
+    <div
+      className={`relative rounded-xl border p-3 transition-all duration-200 cursor-default ${farbeBg} ${borderFarbe} ${hover ? "shadow-sm" : ""}`}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+    >
+      <div className="flex items-center gap-3">
+        {/* Icon */}
+        <div
+          className={`shrink-0 w-7 h-7 rounded-full flex items-center justify-center ${isKostet ? "bg-[var(--color-sos-orange-light)]" : "bg-sage-lighter"}`}
+        >
+          {isKostet ? (
+            <Minus className="w-3.5 h-3.5 text-[var(--color-sos-orange-text)]" />
+          ) : (
+            <Plus className="w-3.5 h-3.5 text-sage-mid" />
+          )}
+        </div>
+
+        {/* Label + Balken */}
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-medium text-foreground leading-tight mb-1.5">
+            {item.label}
+          </p>
+          <div className="h-1.5 rounded-full bg-border/30 overflow-hidden">
+            <motion.div
+              className={`h-full rounded-full ${farbe}`}
+              initial={{ width: 0 }}
+              whileInView={{ width: `${(item.wert / 5) * 100}%` }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.6, ease: "easeOut", delay: 0.1 }}
+            />
+          </div>
+        </div>
+
+        {/* Stärke-Dots */}
+        <div className="shrink-0 flex gap-0.5">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <span
+              key={i}
+              className={`w-1.5 h-1.5 rounded-full ${i < item.wert ? farbe : "bg-border/40"}`}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Hinweis-Tooltip */}
+      {hover && item.hinweis && (
+        <motion.p
+          initial={{ opacity: 0, y: 4 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="mt-2 text-xs text-muted-foreground leading-relaxed pl-10"
+        >
+          {item.hinweis}
+        </motion.p>
+      )}
+    </div>
+  );
+}
+
+export default function EnergieHaushaltVisualisierung() {
+  return (
+    <div className="my-6 rounded-2xl border border-border/50 bg-background/60 p-5 md:p-6 shadow-[0_4px_24px_-8px_rgba(15,23,42,0.1)]">
+      {/* Header */}
+      <div className="mb-5">
+        <p className="text-sm font-semibold text-foreground mb-1">
+          Energie-Haushalt im Angehörigenalltag
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Was typischerweise Energie kostet – und was sie zurückgibt. Fahren Sie
+          über einen Punkt für mehr Details.
+        </p>
+      </div>
+
+      {/* Zwei Spalten */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {/* Kostet */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sos-orange-text)]" />
+            <p className="text-xs font-bold uppercase tracking-wide text-[var(--color-sos-orange-dark)]">
+              Kostet Energie
+            </p>
+          </div>
+          <div className="space-y-2">
+            {KOSTET.map(item => (
+              <EnergieBalken key={item.label} item={item} richtung="kostet" />
+            ))}
+          </div>
+        </div>
+
+        {/* Gibt zurück */}
+        <div>
+          <div className="flex items-center gap-2 mb-3">
+            <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sage-mid)]" />
+            <p className="text-xs font-bold uppercase tracking-wide text-sage-dark">
+              Gibt Energie zurück
+            </p>
+          </div>
+          <div className="space-y-2">
+            {GIBT_ZURUECK.map(item => (
+              <EnergieBalken key={item.label} item={item} richtung="gibt" />
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <p className="mt-4 text-xs text-muted-foreground text-center border-t border-border/30 pt-3">
+        Selbstfürsorge beginnt mit ehrlicher Wahrnehmung der eigenen
+        Energiebilanz.
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/visualizations/KrisenampelVisualisierung.tsx
+++ b/client/src/components/visualizations/KrisenampelVisualisierung.tsx
@@ -1,0 +1,267 @@
+/**
+ * KrisenampelVisualisierung
+ *
+ * Interaktive Drei-Stufen-Ampel für die Krisenbegleitung.
+ * Zeigt Gelb / Orange / Rot mit Hover-Details und Scroll-Anker.
+ * Kein Bild – reine React/Tailwind-Komponente.
+ */
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { AlertTriangle, ChevronDown } from "lucide-react";
+
+interface AmpelStufe {
+  id: string;
+  farbe: "gelb" | "orange" | "rot";
+  label: string;
+  beschreibung: string;
+  signale: string[];
+  reaktion: string;
+  anker?: string; // Scroll-Anker auf der Seite
+}
+
+const stufen: AmpelStufe[] = [
+  {
+    id: "gelb",
+    farbe: "gelb",
+    label: "Gelb – Anspannung steigt",
+    beschreibung: "Die Situation ist noch handhabbar, aber die Energie kippt.",
+    signale: [
+      "Erhöhte Reizbarkeit oder Rückzug",
+      "Erkennbare Trigger werden aktiv",
+      "Kommunikation wird einsilbiger",
+      "Körperliche Anspannung sichtbar",
+    ],
+    reaktion: "Validieren, Raum geben, Skills gemeinsam erinnern",
+    anker: "ampel-system",
+  },
+  {
+    id: "orange",
+    farbe: "orange",
+    label: "Orange – Eskalation",
+    beschreibung: "Starke Emotionen dominieren, Kontrolle nimmt ab.",
+    signale: [
+      "Verbale Aggression oder Vorwürfe",
+      "Starke Emotionen, Kontrollverlust",
+      "Logisches Gespräch nicht mehr möglich",
+      "Körperliche Unruhe oder Erstarrung",
+    ],
+    reaktion: "Deeskalieren, Sicherheit prüfen, eigene Grenzen setzen",
+    anker: "deeskalation",
+  },
+  {
+    id: "rot",
+    farbe: "rot",
+    label: "Rot – Akute Krise",
+    beschreibung: "Akute Gefahr für sich oder andere. Soforthandeln nötig.",
+    signale: [
+      "Suizidgedanken oder -drohungen",
+      "Selbstverletzung oder Fremdgefährdung",
+      "Totale Dissoziation oder Kontaktverlust",
+      "Akute psychiatrische Dekompensation",
+    ],
+    reaktion: "Professionelle Hilfe holen – 144 / 117 / 112",
+    anker: "krise-formulierungen",
+  },
+];
+
+const FARB_TOKENS = {
+  gelb: {
+    dot: "bg-[oklch(0.75_0.12_85)]",
+    dotActive: "bg-[oklch(0.65_0.15_85)] ring-4 ring-[oklch(0.65_0.15_85)]/25",
+    border: "border-[oklch(0.75_0.12_85)]",
+    borderActive: "border-[oklch(0.65_0.15_85)]",
+    bg: "bg-[oklch(0.97_0.02_85)]",
+    bgActive: "bg-[oklch(0.94_0.03_85)]",
+    text: "text-[oklch(0.45_0.1_85)]",
+    badge: "bg-[oklch(0.92_0.04_85)] text-[oklch(0.45_0.1_85)]",
+    line: "bg-[oklch(0.75_0.12_85)]",
+  },
+  orange: {
+    dot: "bg-[var(--color-sos-orange-text)]",
+    dotActive:
+      "bg-[var(--color-sos-orange-text)] ring-4 ring-[var(--color-sos-orange-text)]/25",
+    border: "border-[var(--color-sos-orange-border)]",
+    borderActive: "border-[var(--color-sos-orange-text)]",
+    bg: "bg-[var(--color-sos-orange-wash)]",
+    bgActive: "bg-[var(--color-sos-orange-light)]",
+    text: "text-[var(--color-sos-orange-dark)]",
+    badge:
+      "bg-[var(--color-sos-orange-light)] text-[var(--color-sos-orange-dark)]",
+    line: "bg-[var(--color-sos-orange-text)]",
+  },
+  rot: {
+    dot: "bg-[var(--color-sos-rot)]",
+    dotActive:
+      "bg-[var(--color-sos-rot)] ring-4 ring-[var(--color-sos-rot)]/25",
+    border: "border-[var(--color-sos-rot)]/40",
+    borderActive: "border-[var(--color-sos-rot)]",
+    bg: "bg-[var(--color-sos-rot-wash)]",
+    bgActive: "bg-[oklch(0.96_0.03_25)]",
+    text: "text-[var(--color-sos-rot)]",
+    badge: "bg-[var(--color-sos-rot-wash)] text-[var(--color-sos-rot)]",
+    line: "bg-[var(--color-sos-rot)]",
+  },
+};
+
+export default function KrisenampelVisualisierung() {
+  const [aktiv, setAktiv] = useState<string | null>(null);
+
+  const scrollToAnker = (anker?: string) => {
+    if (!anker) return;
+    const el = document.getElementById(anker);
+    if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
+  };
+
+  return (
+    <div className="my-6 rounded-2xl border border-border/50 bg-background/60 p-5 md:p-6 shadow-[0_4px_24px_-8px_rgba(15,23,42,0.1)]">
+      {/* Header */}
+      <div className="flex items-center gap-2.5 mb-5">
+        <AlertTriangle className="w-5 h-5 text-sand-warm shrink-0" />
+        <p className="text-sm font-semibold text-foreground">
+          Krisenampel – auf einen Blick
+        </p>
+        <span className="ml-auto text-xs text-muted-foreground hidden sm:block">
+          Stufe auswählen für Details
+        </span>
+      </div>
+
+      {/* Ampel-Leiste */}
+      <div className="relative flex flex-col sm:flex-row gap-3 sm:gap-0 sm:items-stretch">
+        {/* Verbindungslinie (nur Desktop) */}
+        <div className="hidden sm:block absolute top-[22px] left-[calc(16.66%)] right-[calc(16.66%)] h-0.5 bg-border/50 z-0" />
+
+        {stufen.map((stufe, idx) => {
+          const t = FARB_TOKENS[stufe.farbe];
+          const isAktiv = aktiv === stufe.id;
+
+          return (
+            <div
+              key={stufe.id}
+              className="flex-1 flex flex-col items-center relative z-10"
+            >
+              {/* Dot + Linie (Mobile: links, Desktop: oben) */}
+              <div className="flex sm:flex-col items-center gap-3 sm:gap-2 w-full sm:w-auto">
+                {/* Verbindungslinie Mobile */}
+                {idx < stufen.length - 1 && (
+                  <div
+                    className={`sm:hidden w-0.5 h-6 ${t.line} absolute left-[22px] top-[44px]`}
+                  />
+                )}
+
+                <button
+                  type="button"
+                  onClick={() => setAktiv(isAktiv ? null : stufe.id)}
+                  className={`
+                    w-full sm:w-auto flex sm:flex-col items-center gap-3 sm:gap-2
+                    rounded-xl border p-3 sm:p-4 transition-all duration-200
+                    hover:-translate-y-0.5 hover:shadow-md
+                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
+                    ${isAktiv ? `${t.bgActive} ${t.borderActive}` : `${t.bg} ${t.border}`}
+                  `}
+                  aria-expanded={isAktiv}
+                >
+                  {/* Ampel-Punkt */}
+                  <span
+                    className={`
+                      shrink-0 w-11 h-11 rounded-full flex items-center justify-center
+                      transition-all duration-200
+                      ${isAktiv ? t.dotActive : t.dot}
+                    `}
+                  >
+                    <span className="w-4 h-4 rounded-full bg-white/40" />
+                  </span>
+
+                  {/* Label */}
+                  <div className="text-left sm:text-center flex-1 sm:flex-none">
+                    <p
+                      className={`text-xs font-bold uppercase tracking-wide ${t.text}`}
+                    >
+                      {stufe.farbe.charAt(0).toUpperCase() +
+                        stufe.farbe.slice(1)}
+                    </p>
+                    <p className="text-sm font-semibold text-foreground leading-tight mt-0.5">
+                      {stufe.label.split(" – ")[1]}
+                    </p>
+                  </div>
+
+                  {/* Chevron */}
+                  <ChevronDown
+                    className={`shrink-0 w-4 h-4 text-muted-foreground transition-transform duration-200 ml-auto sm:ml-0 ${isAktiv ? "rotate-180" : ""}`}
+                  />
+                </button>
+              </div>
+
+              {/* Detail-Panel */}
+              <AnimatePresence>
+                {isAktiv && (
+                  <motion.div
+                    key="detail"
+                    initial={{ opacity: 0, height: 0, marginTop: 0 }}
+                    animate={{ opacity: 1, height: "auto", marginTop: 8 }}
+                    exit={{ opacity: 0, height: 0, marginTop: 0 }}
+                    transition={{ duration: 0.22, ease: "easeOut" }}
+                    className="w-full overflow-hidden"
+                  >
+                    <div
+                      className={`rounded-xl border p-4 ${t.bg} ${t.borderActive}`}
+                    >
+                      <p className="text-sm text-muted-foreground mb-3 leading-relaxed">
+                        {stufe.beschreibung}
+                      </p>
+
+                      <p className="text-xs font-semibold text-foreground uppercase tracking-wide mb-2">
+                        Typische Signale
+                      </p>
+                      <ul className="space-y-1 mb-3">
+                        {stufe.signale.map(s => (
+                          <li
+                            key={s}
+                            className="flex items-start gap-2 text-sm text-muted-foreground"
+                          >
+                            <span
+                              className={`mt-1.5 w-1.5 h-1.5 rounded-full shrink-0 ${t.dot}`}
+                            />
+                            {s}
+                          </li>
+                        ))}
+                      </ul>
+
+                      <div className={`rounded-lg px-3 py-2.5 ${t.badge}`}>
+                        <p className="text-xs font-semibold uppercase tracking-wide mb-0.5">
+                          Ihre Reaktion
+                        </p>
+                        <p className="text-sm font-medium">{stufe.reaktion}</p>
+                      </div>
+
+                      {stufe.anker && (
+                        <button
+                          type="button"
+                          onClick={() => scrollToAnker(stufe.anker)}
+                          className={`mt-3 text-xs font-medium underline underline-offset-2 ${t.text} hover:opacity-80 transition-opacity`}
+                        >
+                          Mehr dazu ↓
+                        </button>
+                      )}
+                    </div>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Footer-Hinweis */}
+      <p className="mt-4 text-xs text-muted-foreground text-center">
+        Bei akuter Lebensgefahr sofort{" "}
+        <a
+          href="tel:144"
+          className="font-semibold text-[var(--color-sos-rot)] underline underline-offset-2"
+        >
+          144
+        </a>{" "}
+        anrufen. Diese Ampel ersetzt keine professionelle Krisenberatung.
+      </p>
+    </div>
+  );
+}

--- a/client/src/components/visualizations/RollenOrbitVisualisierung.tsx
+++ b/client/src/components/visualizations/RollenOrbitVisualisierung.tsx
@@ -1,0 +1,272 @@
+/**
+ * RollenOrbitVisualisierung
+ *
+ * Orbit-Diagramm für die Therapie-Seite.
+ * Zeigt die Rollen im Therapiesystem: Was ist Aufgabe der Angehörigen,
+ * was gehört zur Therapie, was liegt beim Betroffenen.
+ * Interaktiv: Klick auf eine Rolle zeigt Details.
+ */
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Heart, Stethoscope, User, X } from "lucide-react";
+
+interface OrbitRolle {
+  id: string;
+  label: string;
+  kurz: string;
+  icon: React.ReactNode;
+  farbe: string;
+  farbeBg: string;
+  farbeBorder: string;
+  aufgaben: string[];
+  nichtAufgaben: string[];
+  position: { top: string; left: string };
+}
+
+const rollen: OrbitRolle[] = [
+  {
+    id: "angehoerige",
+    label: "Sie als Angehörige/r",
+    kurz: "Ihre Rolle",
+    icon: <Heart className="w-5 h-5" />,
+    farbe: "text-terracotta-mid",
+    farbeBg: "bg-terracotta-wash",
+    farbeBorder: "border-terracotta-light",
+    aufgaben: [
+      "Stabile Präsenz zeigen",
+      "Eigene Grenzen kommunizieren",
+      "Therapie emotional mittragen",
+      "Eigene Entlastung suchen",
+      "Verlässlich und berechenbar bleiben",
+    ],
+    nichtAufgaben: [
+      "Therapieziele vorgeben",
+      "Fortschritt kontrollieren",
+      "Therapeut ersetzen",
+      "Motivation übernehmen",
+    ],
+    position: { top: "10%", left: "10%" },
+  },
+  {
+    id: "therapeut",
+    label: "Therapeut/in",
+    kurz: "Therapie",
+    icon: <Stethoscope className="w-5 h-5" />,
+    farbe: "text-slate-blue",
+    farbeBg: "bg-slate-wash",
+    farbeBorder: "border-slate-light",
+    aufgaben: [
+      "Behandlung planen und leiten",
+      "Skills vermitteln (z.B. DBT)",
+      "Krisen professionell begleiten",
+      "Therapieziele mit Betroffenen setzen",
+      "Angehörige ggf. einbeziehen",
+    ],
+    nichtAufgaben: [
+      "Angehörige therapieren",
+      "Familienprobleme lösen",
+      "Rund-um-die-Uhr erreichbar sein",
+    ],
+    position: { top: "10%", left: "60%" },
+  },
+  {
+    id: "betroffene",
+    label: "Betroffene Person",
+    kurz: "Betroffene/r",
+    icon: <User className="w-5 h-5" />,
+    farbe: "text-sage-mid",
+    farbeBg: "bg-sage-wash",
+    farbeBorder: "border-sage-light",
+    aufgaben: [
+      "Eigene Therapiemotivation entwickeln",
+      "Skills im Alltag üben",
+      "Verantwortung für eigenes Handeln",
+      "Krisen-Signale früh kommunizieren",
+    ],
+    nichtAufgaben: [
+      "Angehörige therapieren",
+      "Allein für Beziehungsqualität sorgen",
+    ],
+    position: { top: "55%", left: "35%" },
+  },
+];
+
+export default function RollenOrbitVisualisierung() {
+  const [aktiv, setAktiv] = useState<string | null>(null);
+  const aktivRolle = rollen.find(r => r.id === aktiv);
+
+  return (
+    <div className="my-6 rounded-2xl border border-border/50 bg-background/60 p-5 md:p-6 shadow-[0_4px_24px_-8px_rgba(15,23,42,0.1)]">
+      {/* Header */}
+      <div className="mb-5">
+        <p className="text-sm font-semibold text-foreground mb-1">
+          Rollen im Therapiesystem
+        </p>
+        <p className="text-xs text-muted-foreground">
+          Wer trägt was? Klicken Sie auf eine Rolle, um Aufgaben und
+          Abgrenzungen zu sehen.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-[1fr_1.4fr] gap-4 items-start">
+        {/* Orbit-Diagramm (vereinfacht als 3 Karten mit Verbindungslinien-Illusion) */}
+        <div className="relative">
+          {/* Zentraler Kreis */}
+          <div className="relative mx-auto w-full max-w-[280px] aspect-square">
+            {/* Orbit-Ring */}
+            <div className="absolute inset-4 rounded-full border-2 border-dashed border-border/40" />
+            <div className="absolute inset-12 rounded-full border border-border/25" />
+
+            {/* Zentrum */}
+            <div className="absolute inset-0 flex items-center justify-center">
+              <div className="w-16 h-16 rounded-full bg-cream border border-border/50 flex items-center justify-center shadow-sm">
+                <p className="text-[10px] font-semibold text-muted-foreground text-center leading-tight px-1">
+                  Therapie-
+                  <br />
+                  system
+                </p>
+              </div>
+            </div>
+
+            {/* Rollen-Buttons auf dem Orbit */}
+            {rollen.map((rolle, idx) => {
+              // Gleichmässig auf dem Kreis verteilen
+              const winkel = (idx / rollen.length) * 2 * Math.PI - Math.PI / 2;
+              const radius = 42; // % vom Container
+              const x = 50 + radius * Math.cos(winkel);
+              const y = 50 + radius * Math.sin(winkel);
+              const isAktiv = aktiv === rolle.id;
+
+              return (
+                <button
+                  key={rolle.id}
+                  type="button"
+                  onClick={() => setAktiv(isAktiv ? null : rolle.id)}
+                  style={{
+                    left: `${x}%`,
+                    top: `${y}%`,
+                    transform: "translate(-50%, -50%)",
+                  }}
+                  className={`
+                    absolute w-16 h-16 rounded-full border-2 flex flex-col items-center justify-center gap-0.5
+                    transition-all duration-200 hover:scale-105 hover:shadow-md
+                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
+                    ${isAktiv ? `${rolle.farbeBg} ${rolle.farbeBorder} shadow-md scale-105` : `bg-background ${rolle.farbeBorder}`}
+                  `}
+                  aria-label={rolle.label}
+                  aria-pressed={isAktiv}
+                >
+                  <span className={rolle.farbe}>{rolle.icon}</span>
+                  <span className="text-[9px] font-semibold text-foreground leading-tight text-center px-0.5">
+                    {rolle.kurz}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Legende */}
+          <div className="mt-3 flex flex-wrap justify-center gap-3">
+            {rollen.map(rolle => (
+              <button
+                key={rolle.id}
+                type="button"
+                onClick={() => setAktiv(aktiv === rolle.id ? null : rolle.id)}
+                className={`flex items-center gap-1.5 text-xs font-medium transition-opacity ${aktiv && aktiv !== rolle.id ? "opacity-40" : "opacity-100"}`}
+              >
+                <span
+                  className={`w-2 h-2 rounded-full ${rolle.farbeBg} border ${rolle.farbeBorder}`}
+                />
+                <span className="text-muted-foreground">{rolle.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Detail-Panel */}
+        <div className="min-h-[200px]">
+          <AnimatePresence mode="wait">
+            {aktivRolle ? (
+              <motion.div
+                key={aktivRolle.id}
+                initial={{ opacity: 0, x: 12 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: -12 }}
+                transition={{ duration: 0.2 }}
+                className={`rounded-xl border p-4 ${aktivRolle.farbeBg} ${aktivRolle.farbeBorder}`}
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <div className="flex items-center gap-2">
+                    <span className={aktivRolle.farbe}>{aktivRolle.icon}</span>
+                    <p className="text-sm font-semibold text-foreground">
+                      {aktivRolle.label}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setAktiv(null)}
+                    className="w-6 h-6 rounded-full bg-background/70 flex items-center justify-center hover:bg-background transition-colors"
+                    aria-label="Schliessen"
+                  >
+                    <X className="w-3.5 h-3.5 text-muted-foreground" />
+                  </button>
+                </div>
+
+                <div className="space-y-3">
+                  <div>
+                    <p className="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-1.5">
+                      Aufgaben
+                    </p>
+                    <ul className="space-y-1">
+                      {aktivRolle.aufgaben.map(a => (
+                        <li
+                          key={a}
+                          className="flex items-start gap-2 text-sm text-foreground"
+                        >
+                          <span
+                            className={`mt-1.5 w-1.5 h-1.5 rounded-full shrink-0 ${aktivRolle.farbeBg} border ${aktivRolle.farbeBorder}`}
+                            style={{ backgroundColor: "currentColor" }}
+                          />
+                          {a}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+
+                  <div className="border-t border-border/30 pt-3">
+                    <p className="text-[10px] font-bold uppercase tracking-wide text-muted-foreground mb-1.5">
+                      Nicht Ihre Aufgabe
+                    </p>
+                    <ul className="space-y-1">
+                      {aktivRolle.nichtAufgaben.map(a => (
+                        <li
+                          key={a}
+                          className="flex items-start gap-2 text-sm text-muted-foreground"
+                        >
+                          <span className="mt-1.5 w-1.5 h-1.5 rounded-full bg-border/60 shrink-0" />
+                          {a}
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                </div>
+              </motion.div>
+            ) : (
+              <motion.div
+                key="leer"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                className="h-full flex items-center justify-center rounded-xl border border-dashed border-border/40 p-6"
+              >
+                <p className="text-sm text-muted-foreground text-center">
+                  Klicken Sie auf eine Rolle im Diagramm, um Aufgaben und
+                  Abgrenzungen zu sehen.
+                </p>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { Link } from "wouter";
 import ContentSection from "@/components/ContentSection";
+import GrenzenCheck from "@/components/interactive/GrenzenCheck";
 import { TableOfContents } from "@/components/UXEnhancements";
 
 import { grenzenItems } from "@/content/grenzen";
@@ -60,6 +61,11 @@ const grenzenQuickLinks = [
     id: "warnsignale",
     title: "Woran Sie merken, dass eine Grenze nötig ist",
     text: "Wenn Sie zuerst Ihre eigenen Warnsignale und Überlastung klarer lesen möchten.",
+  },
+  {
+    id: "grenzen-check",
+    title: "Wo stehe ich beim Grenzen setzen?",
+    text: "Fünf Reflexionsfragen zu den häufigsten Schwierigkeiten – mit persönlicher Einordnung.",
   },
   {
     id: "priorisierung",
@@ -330,6 +336,15 @@ export default function Grenzen() {
               </div>
             </ContentSection>
 
+            {/* Grenzen-Check: Interaktive Reflexion */}
+            <ContentSection
+              title="Wo stehe ich beim Grenzen setzen?"
+              icon={<Shield className="w-7 h-7 text-sage-mid-dark" />}
+              id="grenzen-check"
+              preview="Fünf kurze Reflexionsfragen zu den häufigsten Schwierigkeiten beim Grenzen setzen – mit persönlicher Einordnung."
+            >
+              <GrenzenCheck />
+            </ContentSection>
             {/* Grenzen-Priorisierungsmatrix */}
             <ContentSection
               title="Welche Grenzen zuerst?"

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -19,6 +19,7 @@ import {
   Zap,
 } from "lucide-react";
 import { Link } from "wouter";
+import EnergieHaushaltVisualisierung from "@/components/visualizations/EnergieHaushaltVisualisierung";
 
 const alltagIntroCards = [
   {
@@ -232,6 +233,8 @@ export default function UnterstuetzenAlltag() {
       <section className="pt-4 pb-12 md:pt-6 md:pb-16">
         <div className="container">
           <div className="max-w-3xl mx-auto">
+            {/* Energie-Haushalt-Visualisierung – visueller Überblick */}
+            <EnergieHaushaltVisualisierung />
             <ContentSection
               title="Der Alltag ist oft nicht ruhig, sondern vorspannt"
               icon={<Clock className="w-7 h-7 text-sage-mid" />}

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { Link } from "wouter";
 import { kontaktByIdStrict } from "@/data/kontakte";
+import KrisenampelVisualisierung from "@/components/visualizations/KrisenampelVisualisierung";
 
 const rot144 = kontaktByIdStrict("ROT_144");
 const gruen143 = kontaktByIdStrict("GRUEN_143");
@@ -277,6 +278,8 @@ export default function UnterstuetzenKrise() {
               akuter Gefahr direkt{" "}
               <strong className="text-foreground">144 / 117</strong> anrufen.
             </p>
+            {/* Krisenampel-Visualisierung – visueller Überblick */}
+            <KrisenampelVisualisierung />
             {/* Ampel-System */}
             <ContentSection
               title="Das Ampel-System: Krisen erkennen"

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -29,6 +29,7 @@ import {
   Users,
 } from "lucide-react";
 import { Link } from "wouter";
+import RollenOrbitVisualisierung from "@/components/visualizations/RollenOrbitVisualisierung";
 import {
   GELB,
   kontaktByIdStrict,
@@ -255,6 +256,8 @@ export default function UnterstuetzenTherapie() {
       <section className="pt-4 pb-12 md:pt-6 md:pb-16">
         <div className="container">
           <div className="max-w-3xl mx-auto">
+            {/* Rollen-Orbit-Visualisierung – visueller Überblick */}
+            <RollenOrbitVisualisierung />
             <ContentSection
               title="Was Angehörige in der Therapie wirklich tun können"
               icon={<Users className="w-7 h-7 text-slate-blue" />}


### PR DESCRIPTION
## Neue Visualisierungen und interaktive Elemente

### Unterstützen-Unterseiten
Alle drei Unterseiten hatten bisher nur Text und Accordions – keine einzige Visualisierung. Das wurde behoben:

| Seite | Neue Komponente | Typ |
|---|---|---|
| `/unterstuetzen/krise` | `KrisenampelVisualisierung` | Interaktiv: 3 Stufen (Gelb/Orange/Rot), Klick öffnet Detail-Panel |
| `/unterstuetzen/alltag` | `EnergieHaushaltVisualisierung` | Statisch: Balkenmodell Energie-Kosten vs. Energie-Quellen |
| `/unterstuetzen/therapie` | `RollenOrbitVisualisierung` | Interaktiv: Orbit-Diagramm mit 3 klickbaren Rollen + Detail-Panel |

### Grenzen-Seite
- Neue Komponente `GrenzenCheck` (interaktiv): 5 Reflexionsfragen zu häufigen Grenzschwierigkeiten
- Antwortoptionen: «Ja, oft» / «Manchmal» / «Eher nicht»
- Klick öffnet sofort personalisierte Einordnung
- Nach allen 5 Antworten: Gesamteinordnung mit Handlungsempfehlung
- In `grenzenQuickLinks` eingetragen (erscheint im Hero-Direkteinstieg)

### Technisch
- TypeScript: ✅ keine Fehler
- ESLint: ✅ (lint-staged sauber)