### PR TITLE
fix(ux-prio3): Notfallkarte CTA-Hierarchie + Soforthilfe Triage-Buttons

### DIFF
--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -321,13 +321,22 @@ export default function Notfallkarte() {
 
           {/* Action buttons – hidden when printing */}
           <div className="flex flex-wrap justify-center gap-3 mt-6 print:hidden">
-            <Button onClick={handlePrint} className="gap-2">
+            {/* Primärer CTA: Drucken / Als PDF – häufigster Use-Case */}
+            <Button
+              onClick={handlePrint}
+              className="gap-2 bg-[var(--color-sos-rot)] hover:bg-[var(--color-sos-rot-body)] text-white shadow-sm"
+            >
               <Printer className="w-4 h-4" />
               Drucken / Als PDF
             </Button>
-            <Button variant="outline" onClick={handleSave} className="gap-2">
+            {/* Sekundärer CTA: Im Browser speichern */}
+            <Button
+              variant="outline"
+              onClick={handleSave}
+              className="gap-2 text-muted-foreground border-muted-foreground/30"
+            >
               <Save className="w-4 h-4" />
-              {saved ? "Gespeichert!" : "Speichern"}
+              {saved ? "Gespeichert ✓" : "Im Browser speichern"}
             </Button>
           </div>
 

--- a/client/src/pages/Soforthilfe.tsx
+++ b/client/src/pages/Soforthilfe.tsx
@@ -378,6 +378,7 @@ export default function Notfall() {
               Was ist gerade los?
             </p>
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">
+              {/* ROT: Lebensgefahr – roter Wash-Hintergrund, farbige Typografie */}
               <button
                 type="button"
                 onClick={() =>
@@ -385,13 +386,14 @@ export default function Notfall() {
                     .getElementById("block-rot")
                     ?.scrollIntoView({ behavior: "smooth", block: "start" })
                 }
-                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-background border border-[var(--color-sos-rot)]/40 hover:border-[var(--color-sos-rot)] hover:bg-[var(--color-sos-rot-wash)] transition-all text-left group"
+                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-[var(--color-sos-rot-wash)] border-2 border-[var(--color-sos-rot)]/50 hover:border-[var(--color-sos-rot)] hover:bg-[var(--color-sos-rot)]/10 transition-all text-left group"
               >
-                <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sos-rot)] shrink-0" />
-                <span className="text-sm font-medium text-foreground">
+                <span className="w-3 h-3 rounded-full bg-[var(--color-sos-rot)] shrink-0" />
+                <span className="text-sm font-semibold text-[var(--color-sos-rot)]">
                   Akute Lebensgefahr
                 </span>
               </button>
+              {/* ORANGE: Psychiatrische Krise – oranger Wash */}
               <button
                 type="button"
                 onClick={() =>
@@ -399,13 +401,14 @@ export default function Notfall() {
                     .getElementById("block-orange")
                     ?.scrollIntoView({ behavior: "smooth", block: "start" })
                 }
-                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-background border border-[var(--color-sos-orange-text)]/30 hover:border-[var(--color-sos-orange-text)] hover:bg-[var(--color-sos-orange-wash)] transition-all text-left group"
+                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-[var(--color-sos-orange-wash)] border-2 border-[var(--color-sos-orange-text)]/40 hover:border-[var(--color-sos-orange-text)] hover:bg-[var(--color-sos-orange-light)] transition-all text-left group"
               >
-                <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sos-orange-text)] shrink-0" />
-                <span className="text-sm font-medium text-foreground">
+                <span className="w-3 h-3 rounded-full bg-[var(--color-sos-orange-text)] shrink-0" />
+                <span className="text-sm font-semibold text-[var(--color-sos-orange-dark)]">
                   Psychiatrische Krise
                 </span>
               </button>
+              {/* GRÜN: Jemand zum Reden – grüner Wash */}
               <button
                 type="button"
                 onClick={() =>
@@ -413,10 +416,10 @@ export default function Notfall() {
                     .getElementById("block-gruen")
                     ?.scrollIntoView({ behavior: "smooth", block: "start" })
                 }
-                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-background border border-[var(--color-sos-gruen-text)]/30 hover:border-[var(--color-sos-gruen-text)] hover:bg-[var(--color-sos-gruen-wash)] transition-all text-left group"
+                className="flex items-center gap-2.5 px-4 py-3 rounded-xl bg-[var(--color-sos-gruen-wash)] border-2 border-[var(--color-sos-gruen-text)]/40 hover:border-[var(--color-sos-gruen-text)] hover:bg-[var(--color-sos-gruen-light)] transition-all text-left group"
               >
-                <span className="w-2.5 h-2.5 rounded-full bg-[var(--color-sos-gruen-text)] shrink-0" />
-                <span className="text-sm font-medium text-foreground">
+                <span className="w-3 h-3 rounded-full bg-[var(--color-sos-gruen-text)] shrink-0" />
+                <span className="text-sm font-semibold text-[var(--color-sos-gruen-dark)]">
                   Jemand zum Reden
                 </span>
               </button>


### PR DESCRIPTION
## Audit-Follow-ups: UX Prio-3 + Technische Schulden

### Ergebnis der Prüfung

**Technische Schulden (Audit 20.04.2026):** Alle 4 Punkte waren bereits behoben:
- `useCountUp` → `cancelAnimationFrame` im Cleanup bereits vorhanden (Zeile 96–99)
- `Search` → Fokus-Timeout-Cleanup bereits korrekt (Zeilen 64–69)
- TOC-Scroll-Logik → bereits mit `requestAnimationFrame` gedrosselt (Zeilen 276–288)
- Suchindex-Vorverarbeitung + Debounce → `useMemo` + 150ms Debounce bereits implementiert

**Test-Warnung (whileInView):** Nicht mehr reproduzierbar – 90/90 Tests grün, keine Warnungen.

**baseline-browser-mapping:** Transitive Abhängigkeit, bereits auf 2.8.13 (aktuell).

---

### Umgesetzte UX Prio-3-Änderungen

#### Notfallkarte (/notfallkarte)
- **Drucken / Als PDF** als primärer CTA: `sos-rot` Hintergrund, weisse Schrift, Shadow
- **Im Browser speichern** als sekundärer CTA: outline, gedämpfte Textfarbe
- Label von «Speichern» zu «Im Browser speichern» für mehr Klarheit

#### Soforthilfe (/soforthilfe)
- Triage-Buttons mit **farbigen Wash-Hintergründen** (rot-wash / orange-wash / grün-wash)
- **border-2** statt border für stärkere visuelle Abgrenzung
- **Farbige Typografie** pro Stufe: sos-rot / sos-orange-dark / sos-gruen-dark
- Indikator-Punkt von 2.5 auf 3 vergrössert

#### Accordion-Prüfung
- FAQ: Accordions bereits korrekt eingesetzt ✅
- Glossar: Card-Layout + Filter optimal für Browse-Verhalten ✅
- Buchempfehlungen: Card-Layout + Filter optimal ✅
- **Kein Handlungsbedarf**

### CI
- TypeScript: ✅
- ESLint: ✅ (lint-staged sauber)
- Tests: 90/90 ✅