### PR TITLE
fix(useCountUp): prevent self-cancelling RAF via stale effect cleanup

### DIFF
--- a/client/src/hooks/useCountUp.ts
+++ b/client/src/hooks/useCountUp.ts
@@ -17,6 +17,11 @@ interface UseCountUpOptions {
  * Die Animation läuft nur als visuelles Enhancement, wenn der Block
  * im Viewport sichtbar wird.
  *
+ * hasAnimatedRef ist ein Ref, kein State: das Tracking braucht keinen
+ * Re-Render, und useState in der Effect-Dep-Liste hatte eine Self-
+ * Cancelling-RAF-Race ausgelöst (Cleanup der alten Effect-Instanz
+ * canceled die soeben geschedulete RAF, displayValue blieb auf "0").
+ *
  * WICHTIG: Hook-Reihenfolge ist fix (useState → useCallback → useRef → useEffect).
  */
 export function useCountUp({
@@ -37,10 +42,7 @@ export function useCountUp({
     return `${prefix}${withSeparator}${suffix}`;
   });
 
-  // 2. useState
-  const [hasAnimated, setHasAnimated] = useState(false);
-
-  // 3. useCallback
+  // 2. useCallback
   const formatValue = useCallback(
     (value: number) => {
       const formatted =
@@ -53,20 +55,21 @@ export function useCountUp({
     [prefix, suffix, separator, decimals]
   );
 
-  // 4. useRef
+  // 3. useRef
+  const hasAnimatedRef = useRef(false);
   const ref = useRef<HTMLDivElement>(null);
   const rafIdRef = useRef<number | null>(null);
 
-  // 5. useEffect – IntersectionObserver
+  // 4. useEffect – IntersectionObserver
   useEffect(() => {
     const element = ref.current;
-    if (!element || hasAnimated) return;
+    if (!element || hasAnimatedRef.current) return;
 
     const observer = new IntersectionObserver(
       entries => {
         entries.forEach(entry => {
-          if (entry.isIntersecting && !hasAnimated) {
-            setHasAnimated(true);
+          if (entry.isIntersecting && !hasAnimatedRef.current) {
+            hasAnimatedRef.current = true;
             // Kurz den Startwert setzen, dann hochzählen
             setDisplayValue(formatValue(0));
 
@@ -98,7 +101,7 @@ export function useCountUp({
         rafIdRef.current = null;
       }
     };
-  }, [hasAnimated, formatValue, duration, end]);
+  }, [formatValue, duration, end]);
 
   return { ref, displayValue };
 }


### PR DESCRIPTION
Latenter Race-Condition-Bug im `useCountUp`-Hook, entdeckt während der parallelen Phase-1-Editorial-Variante in PR #281 (jetzt geschlossen als obsolet zu #259-#270). Der Fix selbst ist unabhängig vom Editorial-Token-Layer und trägt isoliert.

## Problem

`hasAnimated` war als `useState` in der Effect-Dep-Liste:
```ts
}, [hasAnimated, formatValue, duration, end]);
```

Wenn der `IntersectionObserver` triggerte, rief die Callback `setHasAnimated(true)` auf. Das schedulete einen Effect-Re-Run. Bei React's Batch-Commit lief der **Cleanup der alten Effect-Instanz** (`cancelAnimationFrame(rafIdRef.current)`) nach den State-Updates — und canceled damit die soeben in derselben Callback geschedulete RAF. Der Display-Wert blieb auf "0".

Der Bug ist timing-empfindlich: in den meisten Browser/React-Commit-Reihenfolgen feuerte der erste RAF-Step glücklich vor dem Cleanup, sodass die Animation lief. Aber Layout-Verschiebungen (z.B. durch zusätzliche `text-wrap: balance`-Layout-Passes in einer parallelen Phase-1-Variante) konnten das Timing kippen lassen.

## Fix

`hasAnimated` von `useState<boolean>` auf `useRef<boolean>` umstellen und aus der Effect-Dep-Liste rausnehmen. Der Effect runt jetzt einmal beim Mount; der Observer-Trigger setzt den Ref synchron, ohne Re-Render auszulösen, ohne Effect-Cleanup zu triggern. Zwei `useState` werden eingespart, Hook-Reihenfolge bleibt konsistent.

Diff: 13 Zeilen in einer Datei (`client/src/hooks/useCountUp.ts`).

## Test-Status

- `pnpm typecheck` ✓
- `pnpm test` ✓ (90/90)
- `pnpm build` ✓
- `pnpm lint` ✓

## Verifikations-Scope

`AnimatedStat` ist der einzige `useCountUp`-Konsumer und wird ausschliesslich in `Home.tsx` (3 Stellen, "Was Forschung und Praxis zeigen"-Sektion) verwendet. Erwartete Werte nach Animation: **93%**, **50%**, **10 J.**

Im Netlify-Deploy-Preview von PR #281 (vor dem Hook-Fix Commit) waren die Stats auf "0%/0%/0 J." eingefroren. Nach dem Fix animierten sie korrekt — verifiziert durch User-Visual-Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)