### PR TITLE
fix(editorial): home layout zentrierung — tailwind @source ergänzt

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -538,3 +538,4 @@
 @source "./components/ui/card.tsx";
 @source "./components/ui/sonner.tsx";
 @source "./pages/Home.tsx";
+@source "./components/editorial";


### PR DESCRIPTION
## Bug

Home-Layout fiel auf Browser-Default zurück (linksbündig, kein Padding, kein `max-width`). EditorialLayout-Utility-Klassen fehlten im Critical-CSS-Bundle.

## Root Cause

Tailwind v4 generiert nur Klassen, die es via `@source` scannt. `client/src/components/editorial/` war im Critical-Bundle (`index.css`) **nirgends** als `@source` referenziert — nur `deferred-routes.css` scannte `components/` rekursiv. Home ist explizit aus dem Deferred-Bundle ausgeschlossen (`@source not "../pages/Home.tsx"` in `deferred-routes.css` Z. 13), bekam also die Editorial-Utility-Klassen nicht.

Fehlende Klassen: `mx-auto`, `px-[var(--container-pad)]`, `py-[var(--space-7)]`, `md:px-[var(--container-pad-md)]`, `md:py-[var(--space-8)]`, `bg-[var(--bg-primary)]`.

## Fix

Eine Zeile in `client/src/index.css` nach Z. 540:

```css
@source "./components/editorial";
```

## Verifikation Build-Output

`dist/public/assets/index-*.css` enthält jetzt:

| Klasse | Definition |
|---|---|
| `.mx-auto` | `margin-inline:auto` |
| `.px-\[var\(--container-pad\)\]` | `padding-inline:var(--container-pad)` |
| `.py-\[var\(--space-7\)\]` | `padding-block:var(--space-7)` |
| `.bg-\[var\(--bg-primary\)\]` | `background-color:var(--bg-primary)` |
| `md\:px-\[var\(--container-pad-md\)\]` | `padding-inline:var(--container-pad-md)` |
| `md\:py-\[var\(--space-8\)\]` | `padding-block:var(--space-8)` |

## Gates

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` 90/90 ✓
- `pnpm build` ✓

## Diff-Stat

`+1 LOC`

## Manuelle Verifikation nach Deploy-Preview

DevTools → Element-Picker auf EditorialLayout-Outer-`<div>` (Parent von Home-Hero `<header>`) → Computed-Tab. Erwartete Werte:
- `padding-left/right: 24px` (mobile <768px) bzw. `40px` (md ≥768px)
- `margin-left/right: auto`
- `max-width: 608px` (für `width="narrow"`)

## Out of Scope

- Header-Padding-Reduktion auf Tier-1-Pages (Manus Befund 2) — separater PR
- TOC-Sidebar-Breakpoint (Befund 3) — Christas Entscheidung
- Soforthilfe-Architektur (Befund 4: PR #308) — eigene Phase
- EditorialPillButton-Konsolidierung — Backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgim39G74HH8r2tEn7phbv)_