### PR TITLE
fix(editorial): reduce tier-1 hero padding

### DIFF
--- a/client/src/pages/Fachstelle.tsx
+++ b/client/src/pages/Fachstelle.tsx
@@ -88,7 +88,7 @@ export default function Fachstelle() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -127,7 +127,7 @@ export default function Genesung() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -160,7 +160,7 @@ export default function Grenzen() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -83,7 +83,7 @@ export default function Kommunizieren() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -76,7 +76,7 @@ export default function Selbstfuersorge() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/UeberUns.tsx
+++ b/client/src/pages/UeberUns.tsx
@@ -114,7 +114,7 @@ export default function UeberUns() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -278,7 +278,7 @@ export default function UnterstuetzenAlltag() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -355,7 +355,7 @@ export default function UnterstuetzenKrise() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -185,7 +185,7 @@ export default function UnterstuetzenTherapie() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -74,7 +74,7 @@ export default function UnterstuetzenUebersicht() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -102,7 +102,7 @@ export default function Verstehen() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{


### PR DESCRIPTION
## Bug

Tier-1-Hero-Padding war `pt-16 pb-20 md:pt-24 md:pb-28` (96/160/192/224 px), ergab zusammen mit Layout-Outer-Padding ~826 px Whitespace zwischen Viewport-Top und erstem Inhalt. Auf Standard-Viewports (800 px) optisch verlierend.

Found via Manus Phase-8 Re-Diagnose, Befund 2.

## Fix

In allen 11 Tier-1-Pages den Hero-Padding-Pattern ersetzen:

```diff
- <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+ <header className="pb-12 pt-12 md:pb-16 md:pt-16">
```

| Achse | Vorher | Nachher | Reduktion |
|---|---|---|---|
| Mobile pt | 96 px | 48 px | −48 |
| Mobile pb | 160 px | 48 px | −112 |
| Desktop pt | 192 px | 64 px | −128 |
| Desktop pb | 224 px | 64 px | −160 |

Total ~270 px weniger Hero-Whitespace auf Desktop, ~160 px auf Mobile.

## Migrierte Pages (11)

- Verstehen
- Kommunizieren
- Grenzen
- Selbstfuersorge
- Genesung
- Fachstelle
- UeberUns
- UnterstuetzenUebersicht
- UnterstuetzenAlltag
- UnterstuetzenTherapie
- UnterstuetzenKrise

## Was NICHT angefasst

| Page | Grund |
|---|---|
| `Home.tsx` Z. 44 | Narrativer Hero, grosszügige Werte richtig |
| `Soforthilfe.tsx` Z. 350 | Schon Phase-6-reduziert (`pt-12 pb-8 md:pt-16 md:pb-10`) |
| Tier-2 (Glossar, FAQ, Materialien, etc.) | Befund 2 betrifft nur Tier-1 |

## Gates

- `pnpm typecheck` ✓
- `pnpm lint` ✓
- `pnpm test` 90/90 ✓
- `pnpm build` ✓

## Diff-Stat

`11 files changed, 11 insertions(+), 11 deletions(-)` — exakt eine Zeile pro Page, kein Drift.

## Out of Scope

- Befund 3 (TOC-Sidebar-Breakpoint) — separater PR, braucht Designentscheidung
- Befund 4 (Soforthilfe-Architektur) — eigene Phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kgim39G74HH8r2tEn7phbv)_