### PR TITLE
fix: TOC-Sidebar content-relativ positionieren (Phase 9.3b)

### DIFF
--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -419,7 +419,8 @@ export function TableOfContents() {
       </AnimatePresence>
 
       {/* ─── Desktop: Sticky Sidebar in der linken Gutter-Zone ─── */}
-      <div className="hidden min-[1800px]:block fixed left-[max(0.75rem,calc((100vw-1280px)/2-15rem-1.5rem))] top-[calc(8rem+env(safe-area-inset-top,0px))] z-30 max-h-[calc(100vh-9.5rem)] w-60">
+      {/* left = 50vw - halbe Content-Breite (304px) - Abstand (2rem) - Sidebar-Breite (15rem) */}
+      <div className="hidden min-[1800px]:block fixed left-[calc(50vw-304px-17rem)] top-[calc(8rem+env(safe-area-inset-top,0px))] z-30 max-h-[calc(100vh-9.5rem)] w-60">
         <div className="flex max-h-full flex-col overflow-hidden rounded-[1.4rem] border border-border/60 bg-background/92 shadow-[0_28px_52px_-36px_rgba(15,23,42,0.45)] backdrop-blur-md">
           <div className="px-4 pt-4 pb-2">
             <div className="flex items-center gap-2.5 rounded-full border border-sage-light/60 bg-sage-wash/80 px-3 py-2">


### PR DESCRIPTION
## Was wurde geändert

Die Positionierungsformel der Desktop-TOC-Sidebar (sichtbar ab 1800px) wurde von einer viewport-absoluten zu einer content-relativen Formel geändert.

**Datei:** `client/src/components/UXEnhancements.tsx`, Zeile 423

| | Vorher | Nachher |
|---|---|---|
| Formel | `left-[max(0.75rem,calc((100vw-1280px)/2-15rem-1.5rem))]` | `left-[calc(50vw-304px-17rem)]` |
| Sidebar auf 1800px | X=12–252px | X=324–564px |
| Sidebar auf 2000px | X=96–336px | X=424–664px |
| Abstand zum Content | 344–360px (variabel) | 32px (konstant) |

## Warum

Phase-9.3-Diagnose hat gezeigt: der Content ist auf allen Viewports mathematisch exakt zentriert. Die optische Asymmetrie entstand, weil die Sidebar am linken Viewport-Rand klebte, während rechts 360px Leerraum blieben.

Die neue Formel positioniert die Sidebar immer 2rem links vom Content-Linksrand:
`left = 50vw - 304px (halbe Content-Breite) - 2rem (Abstand) - 15rem (Sidebar-Breite)`

## Auswirkungen

- Kein Einfluss auf den Document-Flow (Sidebar bleibt `fixed`)
- Kein Einfluss auf Viewports < 1800px (Sidebar bleibt `hidden`)
- Keine Änderung an Breakpoints oder Sidebar-Inhalt

## Reviewer-Checkliste

- [ ] Deploy-Preview auf ≥1800px-Display prüfen: Sidebar sitzt jetzt 32px links vom Content