### PR TITLE
fix(editorial): reduce outer layout top-padding

### DIFF
--- a/client/src/components/editorial/EditorialLayout.tsx
+++ b/client/src/components/editorial/EditorialLayout.tsx
@@ -13,7 +13,7 @@ export function EditorialLayout({
   const maxWidth =
     width === "narrow" ? "var(--measure)" : "var(--measure-wide)";
   return (
-    <div className="bg-[var(--bg-primary)] px-[var(--container-pad)] py-[var(--space-7)] md:px-[var(--container-pad-md)] md:py-[var(--space-8)]">
+    <div className="bg-[var(--bg-primary)] px-[var(--container-pad)] pt-[var(--space-4)] pb-[var(--space-7)] md:px-[var(--container-pad-md)] md:pt-[var(--space-5)] md:pb-[var(--space-8)]">
       <div className="mx-auto" style={{ maxWidth }}>
         {children}
       </div>


### PR DESCRIPTION
## Problem

`EditorialLayout` hatte ein symmetrisches `py`-Padding (oben = unten). Zusammen mit Navbar, Notfall-Banner, Breadcrumb und Hero-inner-Padding ergab das auf Desktop **288px leeren Cream-Raum** bis zum ersten Inhalt – 36% des Viewports (800px). Auf Mobile waren es 240px.

## Lösung

Asymmetrisches Padding: oben stark reduziert, unten unverändert.

| | Vorher | Nachher | Ersparnis |
|---|---|---|---|
| Mobile `pt` | 72px (`space-7`) | 24px (`space-4`) | −48px |
| Mobile `pb` | 72px (`space-7`) | 72px (`space-7`) | 0px |
| Desktop `pt` | 96px (`space-8`) | 32px (`space-5`) | −64px |
| Desktop `pb` | 96px (`space-8`) | 96px (`space-8`) | 0px |

**Kicker-Position nach Fix (Desktop):** ~208px (statt 288px) – 26% vom Viewport.  
**Kicker-Position nach Fix (Mobile):** ~156px (statt 240px) – 21% vom Viewport.

## Scope

Eine Zeile in `EditorialLayout.tsx`. Alle 11 Tier-1-Pages, Tier-2-Pages und Home erben die Änderung automatisch.

## Gates

- typecheck ✓ lint ✓ 88/88 tests ✓ build ✓ prettier ✓

Folgt auf PR #316 (Hero-inner-Padding-Reduktion).