### PR TITLE
fix(home): reduce hero top-padding to match tier-1 visual rhythm

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -41,7 +41,7 @@ export default function Home() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── eigener <header>, KEIN EditorialSection (sonst <h2>) */}
-        <header className="pb-20 pt-16 md:pb-28 md:pt-24">
+        <header className="pb-12 pt-10 md:pb-16 md:pt-12">
           <p
             className="text-xs uppercase"
             style={{


### PR DESCRIPTION
## Problem

Nach PR #317 (EditorialLayout outer-pt 96→32px) wirkte der Home-Hero immer noch zu luftig. Home hat **keinen Breadcrumb** (anders als alle Tier-1-Pages), daher beginnt der Kicker-Text bei 192px – 24% des Viewports sind leer.

## Lösung

Hero-Padding in `Home.tsx` asymmetrisch reduziert (oben stärker als unten):

| | Vorher | Nachher | Ersparnis |
|---|---|---|---|
| Mobile `pt` | 64px (`pt-16`) | 40px (`pt-10`) | −24px |
| Mobile `pb` | 80px (`pb-20`) | 48px (`pb-12`) | −32px |
| Desktop `pt` | 96px (`pt-24`) | 48px (`pt-12`) | −48px |
| Desktop `pb` | 112px (`pb-28`) | 64px (`pb-16`) | −48px |

**Kicker-Position nach Fix:**
- Desktop: ~168px (statt 192px)
- Mobile: ~136px (statt 160px)

**Tier-1-Referenz** (mit Breadcrumb, nach PR #316+317): ~224px Desktop.

## Scope

Eine Zeile in `Home.tsx`. Kein Einfluss auf andere Pages.

## Gates

build ✓ lint ✓ 88/88 tests ✓ prettier ✓