### PR TITLE
refactor(design): consolidate hairline colors from rgba to oklch

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -76,13 +76,12 @@
   --accent-primary: #5b3a4e; /* Aubergine — Inline-Links, Drop-Cap (~8.6:1 auf bg-primary, AAA) */
   --accent-primary-h: #4a2f40; /* Aubergine hover */
   --accent-label: #4f6b5e; /* gedämpftes Sage für Sektionslabels in Caps */
-  --rule-color: rgba(31, 42, 55, 0.08); /* Hairline */
-  --rule-color-strong: rgba(
-    31,
-    42,
-    55,
-    0.2
-  ); /* Hairline für Pull-Quote-Border */
+  --rule-color: oklch(
+    0.91 0.008 85
+  ); /* Hairline – warm, sehr hell (≈ rgba(31,42,55,0.08) auf Cream) */
+  --rule-color-strong: oklch(
+    0.8 0.012 85
+  ); /* Hairline stark – für Pull-Quote-Border (≈ rgba(31,42,55,0.20) auf Cream) */
 
   /* — Spacing-Skala (Vertikal-Rhythmus) — */
   --space-1: 0.5rem; /* 8px */


### PR DESCRIPTION
## Motivation

Die `--rule-color` und `--rule-color-strong` Tokens verwendeten `rgba()` mit harten RGB-Werten, was aus dem konsistenten `oklch`-Farbsystem ausbrach. Das betrifft **30+ Verwendungen** im gesamten Codebase.

## Änderung

Nur **2 Zeilen** in `client/src/index.css` – alle Konsumenten erben automatisch.

| Token | Vorher | Nachher |
|---|---|---|
| `--rule-color` | `rgba(31, 42, 55, 0.08)` | `oklch(0.91 0.008 85)` |
| `--rule-color-strong` | `rgba(31, 42, 55, 0.2)` | `oklch(0.80 0.012 85)` |

## Perceptuelle Äquivalenz

Die neuen Werte entsprechen der tatsächlichen Mischfarbe auf dem Cream-Hintergrund (`#faf7f2`):
- `rgba(31,42,55,0.08)` auf Cream → `#e8e6e3` → `oklch(0.91 0.008 85)`
- `rgba(31,42,55,0.20)` auf Cream → `#cececc` → `oklch(0.80 0.012 85)`

Kein visueller Unterschied auf Cream-Hintergrund. Der Vorteil: Die Hairlines sind jetzt **opak** und funktionieren korrekt auf jedem Hintergrund (z.B. `bg-elevated` = `#ffffff`), wo `rgba` leicht abweichen würde.

## Gates

build ✓ lint ✓ 88/88 tests ✓ prettier ✓