### PR TITLE
refactor(editorial): harmonise section spacing for rule-separated sections

### DIFF
--- a/client/src/components/editorial/EditorialSection.tsx
+++ b/client/src/components/editorial/EditorialSection.tsx
@@ -6,7 +6,10 @@ interface EditorialSectionProps {
   /** Optional: H2-Titel der Sektion */
   title?: string;
   children: ReactNode;
-  /** Trennt Sektion durch obere Hairline statt nur Whitespace */
+  /** Trennt Sektion durch obere Hairline statt nur Whitespace.
+   *  Wenn true: Margin + Padding symmetrisch verteilt (je --space-6),
+   *  sodass die Hairline optisch mittig zwischen den Sektionen sitzt.
+   *  Wenn false: nur Margin (--space-8 Desktop, 4rem Mobile). */
   rule?: boolean;
 }
 
@@ -16,8 +19,12 @@ export function EditorialSection({
   children,
   rule = false,
 }: EditorialSectionProps) {
+  const sectionClass = rule
+    ? "mt-[var(--space-6)] pt-[var(--space-6)] space-y-[var(--space-4)] first:mt-0 first:pt-0 md:mt-[var(--space-7)] md:pt-[var(--space-7)]"
+    : "mt-16 space-y-[var(--space-4)] first:mt-0 md:mt-[var(--space-8)]";
+
   return (
-    <section className="mt-16 space-y-[var(--space-4)] first:mt-0 md:mt-[var(--space-8)]">
+    <section className={sectionClass}>
       {rule && (
         <div
           aria-hidden="true"


### PR DESCRIPTION
## Problem

Sektionen mit `rule={true}` hatten `marginTop=96px` und `paddingTop=0px`. Das bedeutete: Die Hairline sass direkt am oberen Rand der Sektion, während der gesamte Whitespace *vor* der Hairline lag. Das wirkte optisch unausgewogen – die Linie «klebt» am vorherigen Inhalt.

## Lösung

Symmetrisches Margin + Padding für `rule`-Sektionen:

| | Vorher | Nachher |
|---|---|---|
| Mobile `mt` | 64px (`mt-16`) | 48px (`--space-6`) |
| Mobile `pt` | 0px | 48px (`--space-6`) |
| Desktop `mt` | 96px (`--space-8`) | 72px (`--space-7`) |
| Desktop `pt` | 0px | 72px (`--space-7`) |

Die Hairline sitzt jetzt optisch mittig zwischen den Sektionen. Sektionen ohne `rule` bleiben unverändert.

## Umfang

Eine Datei (`EditorialSection.tsx`), **24 Verwendungen** erben automatisch.

## Gates

build ✓ lint ✓ 88/88 tests ✓ prettier ✓