### PR TITLE
refactor(design): refine drop-cap initial for elegance

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -397,10 +397,11 @@
   .editorial-prose-dropcap > p:first-child::first-letter {
     font-family: var(--font-display);
     float: left;
-    font-size: 4.5rem;
-    line-height: 0.9;
-    padding-right: 0.5rem;
-    padding-top: 0.5rem;
+    font-size: 4.2rem; /* Minimal kleiner – wirkt weniger wuchtig */
+    line-height: 0.85;
+    padding-right: 0.6rem; /* Mehr Luft zum Fliesstext */
+    padding-top: 0.4rem;
+    margin-bottom: -0.15rem; /* Verhindert, dass Initiale Zeilenhöhe der Folgezeilen stört */
     color: var(--accent-primary);
     font-weight: var(--weight-display);
   }
@@ -408,7 +409,7 @@
   /* Brief Anhang C: Mobile-Sicherung gegen Layout-Bruch bei sehr schmalen Viewports */
   @media (max-width: 380px) {
     .editorial-prose-dropcap > p:first-child::first-letter {
-      font-size: 3.5rem;
+      font-size: 3.2rem; /* Proportional reduziert */
     }
   }
 


### PR DESCRIPTION
## Problem

Die Drop-Cap-Initiale (4.5rem) wirkte zu wuchtig und der Absatz-Zeilenumbruch klebte unschön links aussen. Zu wenig Abstand zum Fliesstext (0.5rem).

## Änderungen (eine Datei: `index.css`)

| Eigenschaft | Vorher | Nachher |
|---|---|---|
| `font-size` | 4.5rem | **4.2rem** |
| `line-height` | 0.9 | **0.85** |
| `padding-right` | 0.5rem | **0.6rem** |
| `padding-top` | 0.5rem | **0.4rem** |
| `margin-bottom` | – | **-0.15rem** (neu) |
| Mobile-Fallback | 3.5rem | **3.2rem** |

Das `margin-bottom: -0.15rem` verhindert, dass die Initiale die Zeilenhöhe der Folgezeilen stört (der Absatz-Umbruch klebt nicht mehr links aussen).

## Umfang

Betrifft ausschliesslich `Home.tsx` (einzige Seite mit `dropCap={true}`).

## Gates

build ✓ lint ✓ 88/88 tests ✓ prettier ✓