### PR TITLE
refactor(design): responsive prose typography – 16px/1.6 mobile, 17px/1.7 desktop

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -360,9 +360,18 @@
      eine eigenständige Inline-Anchor-Utility. */
 
   .editorial-prose {
-    font-size: var(--text-md);
-    line-height: var(--lh-relaxed);
+    font-size: var(
+      --text-base
+    ); /* 16px auf Mobile – kompakter, weniger "löchrig" */
+    line-height: 1.6; /* Etwas enger auf Mobile */
     color: var(--fg-primary);
+  }
+
+  @media (min-width: 768px) {
+    .editorial-prose {
+      font-size: var(--text-md); /* 17px auf Desktop – mehr Luft */
+      line-height: var(--lh-relaxed); /* 1.7 */
+    }
   }
 
   .editorial-prose > * + * {


### PR DESCRIPTION
## Problem

`.editorial-prose` verwendete auf Mobile und Desktop identisch 17px / 1.7 line-height. Auf Mobile wirkte das 'löchrig' und verschwendete wertvollen Viewport-Platz.

## Änderungen (eine Datei: `index.css`)

| | Mobile (< 768px) | Desktop (≥ 768px) |
|---|---|---|
| `font-size` | **16px** (`--text-base`) | 17px (`--text-md`) — unverändert |
| `line-height` | **1.6** | 1.7 (`--lh-relaxed`) — unverändert |

## Umsetzung

Basis-Klasse bekommt Mobile-Werte, ein `@media (min-width: 768px)`-Override setzt Desktop-Werte. Verwendet bestehende Tokens (`--text-base`, `--text-md`, `--lh-relaxed`).

## Umfang

Alle Seiten mit `EditorialProse`-Komponente (Verstehen, Kommunizieren, Grenzen, Wegweiser, Home).

## Gates

build ✓ lint ✓ 88/88 tests ✓ prettier ✓