### PR TITLE
docs(governance): operating model for health information

### DIFF
--- a/docs/governance/01-redaktionelle-grundsaetze.md
+++ b/docs/governance/01-redaktionelle-grundsaetze.md
@@ -1,0 +1,36 @@
+# Redaktionelle Grundsätze
+
+## Zweck
+
+Die Website bietet psychoedukative Orientierung für Angehörige von Menschen mit Borderline-Muster. Sie soll entlasten, sortieren und handlungsfähiger machen.
+
+## Zielgruppe
+
+Hauptzielgruppe sind Angehörige in der Schweiz: Partner:innen, Eltern, Geschwister, erwachsene Kinder und weitere nahestehende Personen.
+
+## Ton
+
+- ruhig, klar, warm
+- nicht moralisierend
+- nicht dramatisierend
+- nicht beschönigend
+- Schweizer Hochdeutsch
+
+## Grundhaltung
+
+- Angehörige dürfen belastet, wütend, erschöpft und ambivalent sein.
+- Betroffene werden nicht stigmatisiert.
+- Erklärungen entschuldigen kein verletzendes, gewalttätiges oder gefährdendes Verhalten.
+- Mitgefühl und Selbstschutz werden immer zusammen gedacht.
+
+## Grenzen des Angebots
+
+Die Website ersetzt keine medizinische, psychotherapeutische, juristische oder notfallpsychiatrische Abklärung. Bei akuter Gefahr verweist sie konsequent auf Soforthilfe und lokale Notfalldienste.
+
+## Sprachregeln
+
+- Keine Ferndiagnosen.
+- Keine Diagnosedruck-Sprache wie „Sie müssen ihn/sie zur Diagnose bringen“.
+- Keine Heilsversprechen.
+- Keine Garantieformulierungen wie „verhindert Krise“.
+- Stattdessen: „kann helfen“, „häufig“, „bei manchen“, „in akuter Gefahr“.

--- a/docs/governance/02-fachlicher-review-prozess.md
+++ b/docs/governance/02-fachlicher-review-prozess.md
@@ -1,0 +1,41 @@
+# Fachlicher Review-Prozess
+
+## Ziel
+
+Sicherstellen, dass medizinische und psychologische Inhalte korrekt, verantwortungsvoll und aktuell sind.
+
+## Risikostufen
+
+- hoch: Soforthilfe, Krise, Diagnostik, Begleiterkrankungen, Gewalt
+- mittel: Kommunikation, Grenzen, Selbstfürsorge
+- niedrig: Glossar, FAQ, allgemeine Orientierung
+
+## Review-Frequenz
+
+- hoch: alle 3–6 Monate
+- mittel: jährlich
+- niedrig: nach Bedarf
+
+## Review-Inhalte
+
+Bei jedem Review prüfen:
+
+- fachliche Korrektheit
+- Verständlichkeit für Angehörige
+- Krisenlogik (wird klar auf Soforthilfe verwiesen?)
+- Quellenlage
+- lokale Relevanz (Schweiz / Zürich)
+
+## Minimalregel
+
+Änderungen an Hochrisiko-Seiten dürfen nur erfolgen, wenn:
+
+- fachliche Aussage geprüft wurde
+- Soforthilfe-Logik intakt ist
+- keine missverständlichen Formulierungen entstehen
+
+## Dokumentation
+
+Jede Hochrisiko-Seite soll sichtbar enthalten:
+
+- fachlich geprüft am: Datum

--- a/docs/governance/03-quellenstandard.md
+++ b/docs/governance/03-quellenstandard.md
@@ -1,0 +1,43 @@
+# Quellenstandard
+
+## Ziel
+
+Medizinische, psychologische und krisenbezogene Aussagen sollen nachvollziehbar, fachlich belastbar und für Angehörige verständlich abgesichert sein.
+
+## Quellenhierarchie
+
+Für fachliche Aussagen gilt folgende Reihenfolge:
+
+1. Leitlinien, offizielle Empfehlungen, anerkannte Standards
+2. systematische Reviews und hochwertige Übersichtsarbeiten
+3. zentrale Primärstudien
+4. lokale Versorgungsquellen und offizielle Angebotsseiten
+
+## Minimalregel
+
+Je höher das Risiko einer Seite, desto klarer muss die fachliche Quelle benennbar sein.
+
+- Hochrisiko-Seiten: Quelle muss vor Veröffentlichung geprüft sein
+- Mittlere Risikostufe: Quelle oder fachliche Herleitung muss dokumentiert sein
+- Niedrige Risikostufe: redaktionelle Pflege genügt oft, solange keine neue medizinische Aussage eingeführt wird
+
+## EvidenceNotes
+
+EvidenceNotes dienen dazu, Quellen nah am Text sichtbar zu machen, ohne die Lesbarkeit für Angehörige zu zerstören.
+
+Sie sollen vor allem eingesetzt werden bei:
+
+- diagnostischen Aussagen
+- Therapie- und Prognoseaussagen
+- Krisenlogik
+- medizinischen Einordnungen mit Missverständnisrisiko
+
+## Klinische Erfahrung
+
+Praxisnahe Orientierung kann zusätzlich auf klinischer Erfahrung aus der Angehörigenarbeit beruhen. Diese Erfahrung ersetzt jedoch keine Quellenprüfung bei medizinischen oder sicherheitsrelevanten Aussagen.
+
+## Nicht erlaubt
+
+- Quellenfreie neue medizinische Behauptungen
+- veraltete Notfall- oder Versorgungsangaben ohne Re-Check
+- Vermischung von persönlicher Einschätzung und fachlicher Aussage ohne Kennzeichnung

--- a/docs/governance/04-krisen-und-sicherheitsinhalte.md
+++ b/docs/governance/04-krisen-und-sicherheitsinhalte.md
@@ -1,0 +1,27 @@
+# Krisen- und Sicherheitsinhalte
+
+## Grundsatz
+
+Sicherheit hat Vorrang vor Erklärung.
+
+## Pflicht
+
+Seiten mit Krisenbezug müssen enthalten:
+
+- klare Einordnung
+- konkrete Schritte
+- Verweis auf Soforthilfe
+
+## Sprache
+
+Keine Bagatellisierung.
+Keine Verzögerung.
+
+## Gewalt
+
+Gewalt ist immer eine Sicherheitsfrage.
+
+## Notfallnummern
+
+- müssen korrekt sein
+- regelmässig prüfen

--- a/docs/governance/05-datenschutz-und-lokale-speicherung.md
+++ b/docs/governance/05-datenschutz-und-lokale-speicherung.md
@@ -1,0 +1,43 @@
+# Datenschutz und lokale Speicherung
+
+## Grundsatz
+
+Datenschutz ist Teil der Vertrauensbasis des Angebots. Besonders bei Hochrisiko-Seiten müssen Datennutzung, lokale Speicherung und externe Dienste klar, sparsam und verständlich geregelt sein.
+
+## Analytics
+
+- Keine stillschweigende Aktivierung von Tracking oder Analytics
+- Externe Mess- oder Marketingdienste nur nach bewusster Entscheidung und mit konsistenter Datenschutzerklärung
+- Wenn Analytics deaktiviert oder entfernt wurde, muss dies in Technik und Kommunikation übereinstimmen
+
+## Lokale Speicherung
+
+Lokale Speicherung im Browser ist nur dort zulässig, wo sie einen klaren Nutzwert hat und keine Serververarbeitung nötig ist.
+
+Besonders relevant:
+
+- Notfallkarte
+- Theme- oder Komforteinstellungen
+
+## Anforderungen an lokale Speicherung
+
+- klarer Hinweis, wenn Daten auf dem Gerät bleiben
+- keine irreführende Formulierung wie «bleibt bei Ihnen», wenn gemeinsam genutzte Geräte ein Risiko darstellen
+- Möglichkeit, lokale Daten wieder zu löschen
+- vorsichtiger Umgang mit gemeinsam genutzten Geräten
+
+## Hochrisiko-Fall Notfallkarte
+
+Für die Notfallkarte gilt zusätzlich:
+
+- persönliche Einträge verlassen das Gerät nicht
+- ein Löschpfad für lokale Daten muss vorhanden sein
+- Druck- und PDF-Export dürfen nur die bewusst eingegebenen Inhalte ausgeben
+
+## Release-Regel
+
+Änderungen mit Datenschutzfolgen dürfen erst freigegeben werden, wenn:
+
+- die Datenschutzerklärung weiterhin stimmt
+- technische Speicherung zur sichtbaren Kommunikation passt
+- bei Hochrisiko-Seiten ein Shared-Device-Risiko mitgedacht wurde

--- a/docs/governance/06-release-checkliste.md
+++ b/docs/governance/06-release-checkliste.md
@@ -3,24 +3,29 @@
 Diese Checkliste ist vor jedem Release zwingend zu prüfen.
 
 ## Technisch
-- [ ] npm run test erfolgreich
-- [ ] npm run check erfolgreich
-- [ ] npm run build erfolgreich
-- [ ] npm run lint erfolgreich
+
+- [ ] pnpm run test erfolgreich
+- [ ] pnpm run check erfolgreich
+- [ ] pnpm run build erfolgreich
+- [ ] pnpm run lint erfolgreich
 
 ## Inhaltlich
+
 - [ ] Keine neue medizinische Aussage ohne Quellenprüfung
 - [ ] EvidenceNotes konsistent
 
 ## Hochrisiko-Seiten
+
 - [ ] Soforthilfe geprüft
 - [ ] Diagnostik geprüft
 - [ ] Grenzen geprüft
 
 ## Datenschutz
+
 - [ ] Datenschutzerklärung konsistent
 - [ ] Analytics geklärt
 
 ## Freigabe
+
 - [ ] Fachlich geprüft
 - [ ] Release freigegeben

--- a/docs/governance/06-release-checkliste.md
+++ b/docs/governance/06-release-checkliste.md
@@ -1,0 +1,26 @@
+# Release-Checkliste
+
+Diese Checkliste ist vor jedem Release zwingend zu prüfen.
+
+## Technisch
+- [ ] npm run test erfolgreich
+- [ ] npm run check erfolgreich
+- [ ] npm run build erfolgreich
+- [ ] npm run lint erfolgreich
+
+## Inhaltlich
+- [ ] Keine neue medizinische Aussage ohne Quellenprüfung
+- [ ] EvidenceNotes konsistent
+
+## Hochrisiko-Seiten
+- [ ] Soforthilfe geprüft
+- [ ] Diagnostik geprüft
+- [ ] Grenzen geprüft
+
+## Datenschutz
+- [ ] Datenschutzerklärung konsistent
+- [ ] Analytics geklärt
+
+## Freigabe
+- [ ] Fachlich geprüft
+- [ ] Release freigegeben

--- a/docs/governance/07-rollen-und-verantwortlichkeiten.md
+++ b/docs/governance/07-rollen-und-verantwortlichkeiten.md
@@ -1,0 +1,16 @@
+# Rollen und Verantwortlichkeiten
+
+## Rollen
+
+Fachverantwortung
+- prüft medizinische Inhalte
+
+Redaktion
+- sorgt für Verständlichkeit
+
+Technik
+- Deployment und Sicherheit
+
+## Minimalregel
+
+Hochrisiko-Seiten brauchen fachliche Freigabe.

--- a/docs/governance/07-rollen-und-verantwortlichkeiten.md
+++ b/docs/governance/07-rollen-und-verantwortlichkeiten.md
@@ -3,12 +3,15 @@
 ## Rollen
 
 Fachverantwortung
+
 - prüft medizinische Inhalte
 
 Redaktion
+
 - sorgt für Verständlichkeit
 
 Technik
+
 - Deployment und Sicherheit
 
 ## Minimalregel

--- a/docs/governance/08-seiten-risikoklassifikation.md
+++ b/docs/governance/08-seiten-risikoklassifikation.md
@@ -1,0 +1,67 @@
+# Seiten-Risikoklassifikation
+
+Diese Klassifikation steuert Reviewtiefe und Release-Freigabe.
+
+## Hoch
+
+Diese Seiten brauchen fachliche Prüfung und regelmässige Aktualisierung:
+
+- `/soforthilfe`
+- `/notfallkarte`
+- `/unterstuetzen/krise`
+- `/diagnostik`
+- `/begleiterkrankungen`
+- `/grenzen`
+- `/beratung`
+- `/datenschutz`
+- `/quellen`
+
+Typische Risiken:
+
+- falsche oder veraltete Notfallnummern
+- missverständliche Krisenempfehlungen
+- unklare medizinische Aussagen
+- Datenschutz- oder Vertrauensprobleme
+
+## Mittel
+
+Diese Seiten brauchen redaktionelle und periodische fachliche Prüfung:
+
+- `/verstehen`
+- `/kommunizieren`
+- `/selbstfuersorge`
+- `/unterstuetzen/uebersicht`
+- `/unterstuetzen/alltag`
+- `/unterstuetzen/therapie`
+- `/genesung`
+- `/selbsttest`
+- `/materialien`
+
+Typische Risiken:
+
+- zu starke Vereinfachung
+- zu dichte Sprache
+- fehlende Quellenanbindung
+- unklare Grenzen zwischen Orientierung und Beratung
+
+## Niedrig
+
+Diese Seiten brauchen vor allem redaktionelle Pflege:
+
+- `/glossar`
+- `/faq`
+- `/buchempfehlungen`
+- `/impressum`
+- `/barrierefreiheit`
+- `/feedback`
+- `/ueber-uns`
+
+## Review-Frequenz
+
+- hoch: alle 3 bis 6 Monate
+- mittel: jährlich
+- niedrig: nach Bedarf oder bei grösseren Änderungen
+
+## Release-Regel
+
+Änderungen an Hochrisiko-Seiten dürfen nicht ohne bewusste fachliche Freigabe gemergt werden.

--- a/docs/governance/09-umsetzungsplan-90-tage.md
+++ b/docs/governance/09-umsetzungsplan-90-tage.md
@@ -1,0 +1,35 @@
+# Umsetzungsplan – 90 Tage
+
+Ziel: Übergang von Website zu stabilem Gesundheitsinformationsangebot.
+
+## Phase 1 (0–2 Wochen)
+
+- Datenschutz und Analytics klären
+- Soforthilfe-Seite produktiv testen
+- Branch Protection aktivieren
+- Notfallkarte: Hinweis zur lokalen Speicherung ergänzen
+
+## Phase 2 (2–6 Wochen)
+
+- Review-Daten pro Seite einführen
+- Hochrisiko-Seiten fachlich prüfen
+- Quellen-Anbindung verbessern
+- Release-Checkliste in Workflow integrieren
+
+## Phase 3 (6–12 Wochen)
+
+- Content-Struktur langfristig wartbar machen
+- Glossar erweitern
+- Performance der Startseite verbessern
+- Monitoring für zentrale Seiten einrichten
+
+## Erfolgskriterien
+
+- klare Verantwortlichkeiten
+- keine unklaren Krisenempfehlungen
+- konsistente Datenschutzkommunikation
+- regelmässige fachliche Reviews
+
+## Minimalziel
+
+Alle Hochrisiko-Seiten sind überprüft und haben ein sichtbares Reviewdatum.

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -1,0 +1,25 @@
+# Governance für das Gesundheitsinformationsangebot
+
+Dieses Verzeichnis beschreibt, wie `borderline-angehoerige` als dauerhaft gepflegtes Gesundheitsinformationsangebot betrieben wird.
+
+Die Dokumente sind bewusst nicht als juristische Formalität geschrieben, sondern als Arbeitsgrundlage für Redaktion, Fachprüfung, Technik und Release-Entscheide.
+
+## Dokumente
+
+1. `01-redaktionelle-grundsaetze.md` — Ton, Zielgruppe, Grenzen des Angebots.
+2. `02-fachlicher-review-prozess.md` — fachliche Prüfung, Reviewfristen und Risikostufen.
+3. `03-quellenstandard.md` — Quellenhierarchie, EvidenceNotes und Umgang mit klinischer Erfahrung.
+4. `04-krisen-und-sicherheitsinhalte.md` — Regeln für Suizidalität, Selbstverletzung, Gewalt und Soforthilfe.
+5. `05-datenschutz-und-lokale-speicherung.md` — Datenschutz, Analytics, lokale Speicherung und Notfallkarte.
+6. `06-release-checkliste.md` — Mindestprüfung vor jedem Release.
+7. `07-rollen-und-verantwortlichkeiten.md` — Rollenmodell für dauerhafte Pflege.
+8. `08-seiten-risikoklassifikation.md` — Risikoeinstufung der zentralen Seiten.
+9. `09-umsetzungsplan-90-tage.md` — erste Umsetzungsetappen.
+
+## Grundsatz
+
+Die Website bietet psychoedukative Orientierung für Angehörige. Sie ersetzt keine medizinische, psychotherapeutische, juristische oder notfallpsychiatrische Abklärung. Medizinische und therapeutische Aussagen werden fachlich geprüft und mit Quellen hinterlegt; praxisnahe Orientierungstexte beruhen zusätzlich auf klinischer Erfahrung aus der Angehörigenarbeit.
+
+## Arbeitsregel
+
+Änderungen an Hochrisiko-Seiten dürfen nur erfolgen, wenn mindestens die fachliche Aussage, die Krisenlogik, die Quellenlage und die Datenschutzfolgen geprüft wurden.


### PR DESCRIPTION
Initiales Governance-Paket für den Übergang zu einem dauerhaft gepflegten Gesundheitsinformationsangebot.

Enthält:
- README Governance
- Release-Checkliste

Weitere Dokumente folgen im nächsten Commit-Block.

Ziel: klare Verantwortlichkeiten, Review-Prozess, Datenschutz-Konsistenz und Release-Sicherheit etablieren.