### PR TITLE
fix: phase 1 governance hardening (privacy + seo)

### DIFF
--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -16,12 +16,10 @@ const SITE_URL = (import.meta.env.VITE_SITE_URL || DEFAULT_SITE_URL).replace(
   /\/+$/,
   ""
 );
-// Build-time date: set VITE_MEDICAL_LAST_REVIEWED in CI or .env to pin.
-// Fallback: the date of the build (Vite inlines import.meta.env at build).
+
+// Medical content must define review dates explicitly.
 const MEDICAL_LAST_REVIEWED =
-  import.meta.env.VITE_MEDICAL_LAST_REVIEWED ||
-  import.meta.env.VITE_BUILD_DATE ||
-  new Date().toISOString().slice(0, 10);
+  import.meta.env.VITE_MEDICAL_LAST_REVIEWED || null;
 
 const buildOgImageUrl = (siteUrl = SITE_URL) => `${siteUrl}/og-image.jpg`;
 
@@ -98,7 +96,7 @@ export function buildMedicalPageSchemaData({
       "@type": "PeopleAudience",
       audienceType: "Angehörige von Menschen mit Borderline-Muster",
     },
-    lastReviewed: MEDICAL_LAST_REVIEWED,
+    ...(MEDICAL_LAST_REVIEWED && { lastReviewed: MEDICAL_LAST_REVIEWED }),
     medicalAudience: {
       "@type": "MedicalAudience",
       audienceType: "Caregiver",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,7 +1,6 @@
 import "@fontsource-variable/source-serif-4";
 import { createRoot } from "react-dom/client";
 import App from "./App";
-import { initAnalytics } from "./bootstrap/analytics";
 import "./index.css";
 
 const root = document.getElementById("root");
@@ -11,7 +10,6 @@ if (!root) {
   throw new Error("#root element not found");
 }
 createRoot(root).render(<App />);
-initAnalytics();
 
 document.body.setAttribute("data-app-ready", "true");
 window.dispatchEvent(new Event("app-ready"));

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -45,6 +45,12 @@ const DEFAULT_STRATEGIES: CalmingStrategy[] = [
   { id: "s3", text: "Kaltes Wasser über die Handgelenke laufen lassen" },
 ];
 
+const EMPTY_DATA: NotfallkarteData = {
+  personalContacts: [],
+  calmingStrategies: DEFAULT_STRATEGIES,
+  notes: "",
+};
+
 function createId() {
   return Math.random().toString(36).slice(2, 9);
 }
@@ -60,11 +66,7 @@ function loadData(): NotfallkarteData {
   } catch {
     /* ignore corrupt data */
   }
-  return {
-    personalContacts: [],
-    calmingStrategies: DEFAULT_STRATEGIES,
-    notes: "",
-  };
+  return EMPTY_DATA;
 }
 
 function isStorageAvailable(): boolean {
@@ -81,6 +83,16 @@ function isStorageAvailable(): boolean {
 function saveData(data: NotfallkarteData): boolean {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function deleteStoredData(): boolean {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+    sessionStorage.removeItem("notfallkarte-print-data");
     return true;
   } catch {
     return false;
@@ -260,6 +272,24 @@ export default function Notfallkarte() {
     if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
     savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
   }, [data]);
+
+  const handleDeleteData = useCallback(() => {
+    const confirmed = window.confirm(
+      "Lokale Notfallkarten-Daten auf diesem Gerät löschen?"
+    );
+
+    if (!confirmed) return;
+
+    if (deleteStoredData()) {
+      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
+      setData(EMPTY_DATA);
+      setAnnouncement("Lokale Notfallkarten-Daten wurden gelöscht.");
+      setSaved(false);
+    } else {
+      setStorageError(true);
+      setAnnouncement("Daten konnten nicht gelöscht werden.");
+    }
+  }, []);
 
   const handlePrint = useCallback(() => {
     try {
@@ -640,14 +670,22 @@ export default function Notfallkarte() {
           >
             {saved ? "Gespeichert ✓" : "Im Browser speichern"}
           </SecondaryButton>
+          <SecondaryButton
+            onClick={handleDeleteData}
+            ariaLabel="Lokale Notfallkarten-Daten löschen"
+          >
+            Daten löschen
+          </SecondaryButton>
         </div>
         <EditorialSection rule>
           <EditorialProse>
             <p>
-              <strong>Ihre Daten bleiben bei Ihnen.</strong> Alle Angaben werden
-              nur lokal in Ihrem Browser gespeichert – sie verlassen nie Ihr
-              Gerät. Beim Drucken oder PDF-Export werden Ihre persönlichen
-              Einträge mit ausgegeben.
+              <strong>Ihre Daten bleiben auf diesem Gerät.</strong> Alle Angaben
+              werden nur lokal in Ihrem Browser gespeichert und verlassen Ihr
+              Gerät nicht. Auf gemeinsam genutzten Geräten können andere
+              Personen diese Einträge sehen. Nutzen Sie «Daten löschen», wenn
+              die Notfallkarte nicht auf diesem Gerät bleiben soll. Beim Drucken
+              oder PDF-Export werden Ihre persönlichen Einträge mit ausgegeben.
             </p>
           </EditorialProse>
         </EditorialSection>

--- a/docs/governance/notfallkarte-privacy-fix.md
+++ b/docs/governance/notfallkarte-privacy-fix.md
@@ -1,0 +1,60 @@
+# Notfallkarte: Privacy-Fix
+
+Status: als Umsetzungsanleitung für `client/src/pages/Notfallkarte.tsx` dokumentiert.
+
+## Ziel
+
+Die Notfallkarte speichert persönliche Einträge lokal im Browser. Für gemeinsam genutzte Geräte braucht es:
+
+- einen sichtbaren Button `Daten löschen`
+- Löschung von `localStorage` und `sessionStorage`
+- Rücksetzen auf leere Standarddaten
+- Screenreader-Statusmeldung
+- geschärften Hinweis auf gemeinsam genutzte Geräte
+
+## Code-Bausteine
+
+```ts
+const EMPTY_DATA: NotfallkarteData = {
+  personalContacts: [],
+  calmingStrategies: DEFAULT_STRATEGIES,
+  notes: "",
+};
+```
+
+```ts
+function deleteStoredData(): boolean {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+    sessionStorage.removeItem("notfallkarte-print-data");
+    return true;
+  } catch {
+    return false;
+  }
+}
+```
+
+```ts
+const handleDeleteData = useCallback(() => {
+  const confirmed = window.confirm(
+    "Lokale Notfallkarten-Daten auf diesem Gerät löschen?"
+  );
+
+  if (!confirmed) return;
+
+  if (deleteStoredData()) {
+    setData(EMPTY_DATA);
+    setAnnouncement("Lokale Notfallkarten-Daten wurden gelöscht.");
+    setSaved(false);
+  } else {
+    setStorageError(true);
+    setAnnouncement("Daten konnten nicht gelöscht werden.");
+  }
+}, []);
+```
+
+## Hinweistext
+
+```txt
+Ihre Daten bleiben auf diesem Gerät. Alle Angaben werden nur lokal in Ihrem Browser gespeichert und verlassen Ihr Gerät nicht. Auf gemeinsam genutzten Geräten können andere Personen diese Einträge sehen. Nutzen Sie «Daten löschen», wenn die Notfallkarte nicht auf diesem Gerät bleiben soll.
+```


### PR DESCRIPTION
Phase 1 Umsetzung gemäss Governance-Plan:

- Analytics vollständig entfernt (Privacy-Konsistenz)
- SEO lastReviewed nicht mehr automatisch gesetzt

Nächster Schritt:
- Notfallkarte: Daten löschen Funktion ergänzen

Ziel:
Vertrauen, Datenschutz und medizinische Transparenz stärken.