### PR TITLE
feat: phase 2.2 set review dates

### DIFF
--- a/client/src/data/pageGovernance.ts
+++ b/client/src/data/pageGovernance.ts
@@ -3,36 +3,65 @@ export type RiskLevel = "high" | "medium" | "low";
 export interface PageGovernance {
   riskLevel: RiskLevel;
   lastReviewed?: string; // YYYY-MM-DD
-  nextReviewDue?: string;
+  nextReviewDue?: string; // YYYY-MM-DD
   owner?: string;
 }
+
+const DEFAULT_OWNER = "Fachstelle Angehörigenarbeit";
 
 export const pageGovernance: Record<string, PageGovernance> = {
   "/soforthilfe": {
     riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-07-31",
+    owner: DEFAULT_OWNER,
   },
   "/notfallkarte": {
     riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-07-31",
+    owner: DEFAULT_OWNER,
   },
   "/unterstuetzen/krise": {
     riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-10-31",
+    owner: DEFAULT_OWNER,
   },
   "/diagnostik": {
     riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-10-31",
+    owner: DEFAULT_OWNER,
   },
   "/begleiterkrankungen": {
     riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-10-31",
+    owner: DEFAULT_OWNER,
   },
   "/grenzen": {
     riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-10-31",
+    owner: DEFAULT_OWNER,
   },
   "/verstehen": {
     riskLevel: "medium",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2027-04-30",
+    owner: DEFAULT_OWNER,
   },
   "/kommunizieren": {
     riskLevel: "medium",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2027-04-30",
+    owner: DEFAULT_OWNER,
   },
   "/selbstfuersorge": {
     riskLevel: "medium",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2027-04-30",
+    owner: DEFAULT_OWNER,
   },
 };


### PR DESCRIPTION
Phase 2.2: Echte Reviewdaten setzen

Enthält:
- lastReviewed für alle Kernseiten
- nextReviewDue nach Risikostufe gestaffelt
- owner definiert

Logik:
- high risk: 3–6 Monate
- medium risk: 12 Monate

Ziel:
- Sichtbare Aktualität
- Grundlage für Review-Zyklen
- echtes Gesundheitsinformationsniveau