### PR TITLE
feat(governance): extend review badge display

### DIFF
--- a/client/public/soforthilfe/index.html
+++ b/client/public/soforthilfe/index.html
@@ -44,9 +44,11 @@
               App-JavaScript aus. Bei unmittelbarer Gefahr zählt der schnellste
               funktionierende Weg.
             </p>
-            <p class="fallback-small" style="margin: 1rem 0 0">
-              Noch kein Reviewdatum gesetzt
-            </p>
+            <div class="fallback-small" style="margin: 1rem 0 0">
+              <div>Fachlich geprüft am: 30.04.2026</div>
+              <div>Nächste Prüfung: 31.07.2026</div>
+              <div>Verantwortlich: Fachstelle Angehörigenarbeit</div>
+            </div>
           </div>
         </header>
 

--- a/client/src/__tests__/review-badge.test.tsx
+++ b/client/src/__tests__/review-badge.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import ReviewBadge from "@/components/ReviewBadge";
+import { pageGovernance } from "@/data/pageGovernance";
+
+const originalDiagnostik = { ...pageGovernance["/diagnostik"] };
+const originalNotfallkarte = { ...pageGovernance["/notfallkarte"] };
+
+describe("ReviewBadge", () => {
+  afterEach(() => {
+    pageGovernance["/diagnostik"] = { ...originalDiagnostik };
+    pageGovernance["/notfallkarte"] = { ...originalNotfallkarte };
+  });
+
+  it("renders the review date, next review date, and owner", () => {
+    pageGovernance["/diagnostik"] = {
+      riskLevel: "high",
+      lastReviewed: "2026-04-30",
+      nextReviewDue: "2026-10-31",
+      owner: "Fachstelle Angehörigenarbeit",
+    };
+
+    render(<ReviewBadge path="/diagnostik" />);
+
+    expect(screen.getByText("Review & Governance")).toBeInTheDocument();
+    expect(screen.getByText("Fachlicher Review:")).toBeInTheDocument();
+    expect(screen.getByText("geprüft am 30.04.2026")).toBeInTheDocument();
+    expect(screen.getByText("Nächste Prüfung:")).toBeInTheDocument();
+    expect(screen.getByText("31.10.2026")).toBeInTheDocument();
+    expect(screen.getByText("Verantwortlich:")).toBeInTheDocument();
+    expect(
+      screen.getByText("Fachstelle Angehörigenarbeit")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a fallback when no review date is present", () => {
+    pageGovernance["/notfallkarte"] = {
+      riskLevel: "high",
+    };
+
+    render(<ReviewBadge path="/notfallkarte" />);
+
+    expect(
+      screen.getByText("Noch kein Reviewdatum gesetzt")
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ReviewBadge.tsx
+++ b/client/src/components/ReviewBadge.tsx
@@ -1,17 +1,55 @@
 import { pageGovernance } from "@/data/pageGovernance";
 
+function formatDate(date: string) {
+  const [year, month, day] = date.split("-");
+
+  if (!year || !month || !day) return date;
+
+  return `${day}.${month}.${year}`;
+}
+
 export default function ReviewBadge({ path }: { path: string }) {
   const meta = pageGovernance[path];
 
   if (!meta) return null;
 
+  const lastReviewed = meta.lastReviewed
+    ? `geprüft am ${formatDate(meta.lastReviewed)}`
+    : "Noch kein Reviewdatum gesetzt";
+
+  const nextReviewDue = meta.nextReviewDue
+    ? formatDate(meta.nextReviewDue)
+    : null;
+
   return (
-    <div className="mt-4 text-sm" style={{ color: "var(--fg-tertiary)" }}>
-      {meta.lastReviewed ? (
-        <>Fachlich geprüft am: {meta.lastReviewed}</>
-      ) : (
-        <>Noch kein Reviewdatum gesetzt</>
-      )}
-    </div>
+    <aside
+      className="mt-4 rounded-xl border border-border/60 bg-white/70 px-4 py-3 text-sm text-muted-foreground shadow-sm"
+      aria-label="Review-Informationen"
+    >
+      <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+        Review & Governance
+      </p>
+
+      <dl className="space-y-1.5">
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+          <dt className="font-medium text-foreground">Fachlicher Review:</dt>
+          <dd>{lastReviewed}</dd>
+        </div>
+
+        {nextReviewDue && (
+          <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+            <dt className="font-medium text-foreground">Nächste Prüfung:</dt>
+            <dd>{nextReviewDue}</dd>
+          </div>
+        )}
+
+        {meta.owner && (
+          <div className="flex flex-wrap gap-x-2 gap-y-0.5">
+            <dt className="font-medium text-foreground">Verantwortlich:</dt>
+            <dd>{meta.owner}</dd>
+          </div>
+        )}
+      </dl>
+    </aside>
   );
 }


### PR DESCRIPTION
## Summary
- extend `ReviewBadge` to show formatted review dates, next review due, and optional owner
- align the static `/soforthilfe` fallback page with the same review metadata
- add a component test for metadata rendering and fallback behavior

## Validation
- `pnpm test`
- `pnpm run check`
- `pnpm lint`
- `pnpm run build`
