### PR TITLE
test(governance): enforce review metadata for high-risk pages

### DIFF
--- a/client/src/__tests__/page-governance.test.ts
+++ b/client/src/__tests__/page-governance.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { pageGovernance } from "@/data/pageGovernance";
+
+const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+describe("pageGovernance", () => {
+  it("sets review metadata for every high-risk page", () => {
+    const highRiskEntries = Object.entries(pageGovernance).filter(
+      ([, meta]) => meta.riskLevel === "high"
+    );
+
+    expect(highRiskEntries.length).toBeGreaterThan(0);
+
+    for (const [path, meta] of highRiskEntries) {
+      expect(meta.lastReviewed, `${path} needs lastReviewed`).toMatch(
+        isoDatePattern
+      );
+      expect(meta.nextReviewDue, `${path} needs nextReviewDue`).toMatch(
+        isoDatePattern
+      );
+      expect(meta.owner, `${path} needs owner`).toBeTruthy();
+    }
+  });
+
+  it("uses future review due dates after the last review date", () => {
+    for (const [path, meta] of Object.entries(pageGovernance)) {
+      if (!meta.lastReviewed || !meta.nextReviewDue) continue;
+
+      expect(
+        meta.nextReviewDue > meta.lastReviewed,
+        `${path} nextReviewDue must be after lastReviewed`
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Adds automated enforcement for review metadata on high-risk pages.

## What this does
- ensures every high-risk page has:
  - lastReviewed
  - nextReviewDue
  - owner
- ensures nextReviewDue is after lastReviewed

## Why
Prevents accidental merges of high-risk content without review metadata.

## Impact
- future PRs will fail if governance rules are violated
- keeps review system reliable over time