### PR TITLE
[codex] Fix soforthilfe direct-page navigation

### DIFF
--- a/client/src/__tests__/app-link.test.tsx
+++ b/client/src/__tests__/app-link.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Router } from "wouter";
+import AppLink, { isHardNavigationHref } from "@/components/AppLink";
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  window.history.replaceState(null, "", "/");
+});
+
+describe("AppLink", () => {
+  it("classifies static crisis routes and assets as hard navigation", () => {
+    expect(isHardNavigationHref("/soforthilfe")).toBe(true);
+    expect(isHardNavigationHref("/notfall")).toBe(true);
+    expect(isHardNavigationHref("/notfallplan-krise-v03.pdf")).toBe(true);
+    expect(isHardNavigationHref("/verstehen")).toBe(false);
+  });
+
+  it("keeps browser navigation for direct crisis pages", () => {
+    const pushStateSpy = vi.spyOn(window.history, "pushState");
+
+    render(
+      <Router>
+        <AppLink href="/soforthilfe">Soforthilfe</AppLink>
+      </Router>
+    );
+
+    const link = screen.getByRole("link", { name: /soforthilfe/i });
+    let defaultPrevented = true;
+
+    link.addEventListener("click", event => {
+      defaultPrevented = event.defaultPrevented;
+      event.preventDefault();
+    });
+
+    fireEvent.click(link);
+
+    expect(defaultPrevented).toBe(false);
+    expect(pushStateSpy).not.toHaveBeenCalled();
+  });
+
+  it("uses SPA navigation for regular internal routes", () => {
+    const pushStateSpy = vi.spyOn(window.history, "pushState");
+
+    render(
+      <Router>
+        <AppLink href="/verstehen">Verstehen</AppLink>
+      </Router>
+    );
+
+    const link = screen.getByRole("link", { name: /verstehen/i });
+    fireEvent.click(link);
+
+    expect(pushStateSpy).toHaveBeenCalledWith(null, "", "/verstehen");
+    expect(window.location.pathname).toBe("/verstehen");
+  });
+});

--- a/client/src/__tests__/direct-pages-architecture.test.ts
+++ b/client/src/__tests__/direct-pages-architecture.test.ts
@@ -63,4 +63,14 @@ describe("direct pages architecture", () => {
       'const STATIC_DIRECT_PAGE_ROUTES = new Set(["/soforthilfe"])'
     );
   });
+
+  it("keeps static direct pages out of the SPA route registry", () => {
+    const routesIndex = fs.readFileSync(
+      path.join(repoRoot, "client/src/app/routes.ts"),
+      "utf8"
+    );
+
+    expect(routesIndex).not.toContain('path: "/soforthilfe"');
+    expect(routesIndex).not.toContain('path: "/notfall"');
+  });
 });

--- a/client/src/__tests__/routes-registry.test.ts
+++ b/client/src/__tests__/routes-registry.test.ts
@@ -15,18 +15,26 @@ describe("route registry", () => {
 
   it("keeps the critical public routes available", () => {
     expect(routes.some(route => route.path === "/")).toBe(true);
-    expect(routes.some(route => route.path === "/soforthilfe")).toBe(true);
     expect(routes.some(route => route.path === "/selbsttest")).toBe(true);
     expect(routes.some(route => route.path === "/faq")).toBe(true);
+    expect(routes.some(route => route.path === "/materialien")).toBe(true);
   });
 
   it("keeps known redirects configured", () => {
-    const notfallRoute = routes.find(route => route.path === "/notfall");
     const unterstuetzenRoute = routes.find(
       route => route.path === "/unterstuetzen"
     );
+    const selbsthilfegruppenRoute = routes.find(
+      route => route.path === "/selbsthilfegruppen"
+    );
+    const therapieangeboteRoute = routes.find(
+      route => route.path === "/therapieangebote"
+    );
 
-    expect(notfallRoute?.redirectTo).toBe("/soforthilfe");
     expect(unterstuetzenRoute?.redirectTo).toBe("/unterstuetzen/uebersicht");
+    expect(selbsthilfegruppenRoute?.redirectTo).toBe("/beratung");
+    expect(therapieangeboteRoute?.redirectTo).toBe(
+      "/unterstuetzen/therapie#therapieangebote"
+    );
   });
 });

--- a/client/src/app/routes.ts
+++ b/client/src/app/routes.ts
@@ -80,8 +80,6 @@ export const routes: AppRoute[] = [
     component: Selbstfuersorge,
     requiresMotion: true,
   },
-  { path: "/soforthilfe", redirectTo: "/soforthilfe" },
-  { path: "/notfall", redirectTo: "/soforthilfe" },
   { path: "/materialien/text/:handoutId", component: HandoutTextPage },
   { path: "/materialien", component: Materialien, requiresMotion: true },
   { path: "/selbsttest", component: SelbsttestPage, requiresMotion: true },

--- a/client/src/components/AppLink.tsx
+++ b/client/src/components/AppLink.tsx
@@ -1,0 +1,53 @@
+import { forwardRef } from "react";
+import { Link } from "wouter";
+
+const HARD_NAVIGATION_PATHS = new Set(["/notfall", "/soforthilfe"]);
+const HARD_NAVIGATION_EXTENSION = /\.(?:html|pdf|webp|png|jpe?g|svg)$/i;
+const EXTERNAL_HREF_PATTERN = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
+
+type AppLinkProps = Omit<
+  React.ComponentPropsWithoutRef<"a">,
+  "className" | "href"
+> & {
+  href: string;
+  className?: string | ((isActive: boolean) => string | undefined);
+};
+
+function getPathname(href: string) {
+  return href.split(/[?#]/, 1)[0];
+}
+
+export function isHardNavigationHref(href: string) {
+  if (EXTERNAL_HREF_PATTERN.test(href)) {
+    return true;
+  }
+
+  const pathname = getPathname(href);
+
+  return (
+    HARD_NAVIGATION_PATHS.has(pathname) ||
+    HARD_NAVIGATION_EXTENSION.test(pathname)
+  );
+}
+
+const AppLink = forwardRef<HTMLAnchorElement, AppLinkProps>(function AppLink(
+  { className, href, ...props },
+  ref
+) {
+  if (isHardNavigationHref(href)) {
+    return (
+      <a
+        ref={ref}
+        href={href}
+        className={
+          typeof className === "function" ? className(false) : className
+        }
+        {...props}
+      />
+    );
+  }
+
+  return <Link ref={ref} href={href} className={className} {...props} />;
+});
+
+export default AppLink;

--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -1,5 +1,6 @@
-import { Link, useLocation } from "wouter";
 import { useState, useEffect, lazy, Suspense } from "react";
+import AppLink from "@/components/AppLink";
+import { useLocation } from "wouter";
 const Search = lazy(() => import("@/components/Search"));
 import { HeaderNav } from "@/components/layout/HeaderNav";
 import { Breadcrumbs } from "@/components/layout/Breadcrumbs";
@@ -57,12 +58,12 @@ export default function Layout({ children }: LayoutProps) {
           <span className="hidden sm:inline">•</span>
           <span>Für andere Regionen bitte lokale Notrufnummern nutzen.</span>
           {showInlineSoforthilfeLink && (
-            <Link
+            <AppLink
               href="/soforthilfe"
               className="sm:hidden inline-flex min-h-9 items-center rounded-full border border-alert/25 bg-alert/10 px-3 py-1 text-sm font-medium text-alert transition-colors hover:bg-alert/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alert/40 focus-visible:ring-offset-2"
             >
               Zur Soforthilfe
-            </Link>
+            </AppLink>
           )}
         </div>
       </aside>
@@ -81,12 +82,12 @@ export default function Layout({ children }: LayoutProps) {
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-12">
             {/* Brand + Absender */}
             <div className="lg:col-span-1">
-              <Link href="/" className="flex items-center gap-2 mb-4">
+              <AppLink href="/" className="flex items-center gap-2 mb-4">
                 <BrandMark variant="dark" />
                 <span className="font-medium text-base text-white">
                   Borderline · Hilfe für Angehörige
                 </span>
-              </Link>
+              </AppLink>
               <p className="text-white/90 text-sm leading-relaxed">
                 Psychoedukatives Informationsangebot für Angehörige von Menschen
                 mit Borderline-Muster.
@@ -101,12 +102,12 @@ export default function Layout({ children }: LayoutProps) {
               <ul className="space-y-1">
                 {navItems.map(item => (
                   <li key={item.href}>
-                    <Link
+                    <AppLink
                       href={item.href}
                       className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
                     >
                       {item.label}
-                    </Link>
+                    </AppLink>
                   </li>
                 ))}
               </ul>
@@ -120,12 +121,12 @@ export default function Layout({ children }: LayoutProps) {
               <ul className="space-y-1">
                 {ressourcenItems.map(item => (
                   <li key={item.href}>
-                    <Link
+                    <AppLink
                       href={item.href}
                       className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
                     >
                       {item.label}
-                    </Link>
+                    </AppLink>
                   </li>
                 ))}
               </ul>
@@ -161,42 +162,42 @@ export default function Layout({ children }: LayoutProps) {
               © 2026 Borderline · Hilfe für Angehörige. Alle Rechte vorbehalten.
             </p>
             <div className="flex flex-wrap gap-x-4 gap-y-1">
-              <Link
+              <AppLink
                 href="/fachstelle"
                 className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Fachstelle
-              </Link>
-              <Link
+              </AppLink>
+              <AppLink
                 href="/ueber-uns"
                 className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Über uns
-              </Link>
-              <Link
+              </AppLink>
+              <AppLink
                 href="/impressum"
                 className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Impressum
-              </Link>
-              <Link
+              </AppLink>
+              <AppLink
                 href="/datenschutz"
                 className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Datenschutz
-              </Link>
-              <Link
+              </AppLink>
+              <AppLink
                 href="/barrierefreiheit"
                 className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Barrierefreiheit
-              </Link>
-              <Link
+              </AppLink>
+              <AppLink
                 href="/feedback"
                 className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
               >
                 Feedback
-              </Link>
+              </AppLink>
             </div>
           </div>
         </div>

--- a/client/src/components/RelatedLinksEditorial.tsx
+++ b/client/src/components/RelatedLinksEditorial.tsx
@@ -7,7 +7,7 @@
  * border-t in --rule-color. Das Original RelatedLinks.tsx bleibt
  * unangetastet (andere Pages nutzen es noch).
  */
-import { Link } from "wouter";
+import AppLink from "@/components/AppLink";
 
 export interface RelatedLink {
   href: string;
@@ -63,7 +63,7 @@ export default function RelatedLinksEditorial({
             className="border-t py-5"
             style={{ borderColor: "var(--rule-color)" }}
           >
-            <Link href={link.href} className="block">
+            <AppLink href={link.href} className="block">
               <p
                 className="editorial-link"
                 style={{
@@ -84,7 +84,7 @@ export default function RelatedLinksEditorial({
               >
                 {link.description}
               </p>
-            </Link>
+            </AppLink>
           </li>
         ))}
       </ul>

--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useRef, useMemo } from "react";
+import AppLink from "@/components/AppLink";
 import "./search.css";
 import { useScrollLock } from "@/hooks/useScrollLock";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
 import { Search as SearchIcon, X, ArrowRight } from "lucide-react";
-import { Link } from "wouter";
 import { motion, AnimatePresence } from "framer-motion";
 import { searchableContent, type SearchEntry } from "@/content/searchIndex";
 
@@ -285,7 +285,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                     id="search-results"
                   >
                     {results.map((result, index) => (
-                      <Link
+                      <AppLink
                         key={`${result.href}-${index}`}
                         href={result.href}
                         onClick={handleResultClick}
@@ -308,7 +308,7 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                           </p>
                         </div>
                         <ArrowRight className="w-4 h-4 text-muted-foreground group-hover:text-foreground transition-colors flex-shrink-0 mt-6" />
-                      </Link>
+                      </AppLink>
                     ))}
                   </div>
                 )}

--- a/client/src/components/Selbsttest.tsx
+++ b/client/src/components/Selbsttest.tsx
@@ -49,7 +49,7 @@
  *   Resultat ist funktional).
  */
 import { useEffect, useRef, useState } from "react";
-import { Link } from "wouter";
+import AppLink from "@/components/AppLink";
 import { motion, AnimatePresence } from "framer-motion";
 import { EditorialPillButton } from "@/components/ui/EditorialPillButton";
 
@@ -479,7 +479,7 @@ export default function Selbsttest() {
             className="mt-8 flex flex-wrap gap-x-5 gap-y-1"
             style={{ fontSize: "var(--text-md)" }}
           >
-            <Link
+            <AppLink
               href={result.primaryLink}
               className="inline-block rounded-full border px-5 py-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
               style={{
@@ -490,7 +490,7 @@ export default function Selbsttest() {
               }}
             >
               {result.primaryText}
-            </Link>
+            </AppLink>
           </p>
 
           {/* Secondary Links */}
@@ -507,13 +507,13 @@ export default function Selbsttest() {
                 style={{ fontSize: "var(--text-md)" }}
               >
                 {result.secondaryLinks.map(link => (
-                  <Link
+                  <AppLink
                     key={link.href + link.text}
                     href={link.href}
                     className="editorial-link"
                   >
                     {link.text}
-                  </Link>
+                  </AppLink>
                 ))}
               </p>
             </div>

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
-import { Link, useLocation } from "wouter";
+import AppLink from "@/components/AppLink";
+import { useLocation } from "wouter";
 import { Button } from "@/components/ui/button";
 import { MobileMenu } from "@/components/layout/MobileMenu";
 import { navItems } from "@/components/layout/navigationData";
@@ -61,7 +62,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
     <header className="sticky top-0 z-50 border-b border-border/60 bg-background/88 backdrop-blur-xl shadow-[0_10px_34px_-28px_rgba(15,23,42,0.45)]">
       <div className="container">
         <div className="flex min-h-16 items-center justify-between gap-2 py-2 md:min-h-20 md:gap-4 md:py-3">
-          <Link href="/" className="flex items-center gap-3 group shrink-0">
+          <AppLink href="/" className="flex items-center gap-3 group shrink-0">
             <BrandMark
               className="md:h-11 md:w-11"
               iconClassName="md:h-[22px] md:w-[22px]"
@@ -74,7 +75,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
                 Orientierung für belastete Beziehungssituationen
               </span>
             </span>
-          </Link>
+          </AppLink>
 
           <nav
             className="hidden lg:flex items-center gap-0.5 rounded-full border border-border/70 bg-white/82 px-2 py-1 shadow-[0_18px_34px_-30px_rgba(15,23,42,0.55)] backdrop-blur-sm shrink-0"
@@ -85,7 +86,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
                 location === item.href || location.startsWith(item.href + "/");
               const accent = getRouteAccent(item.href);
               return (
-                <Link
+                <AppLink
                   key={item.href}
                   href={item.href}
                   className={`px-2.5 lg:px-3 xl:px-3.5 py-1.5 rounded-full text-sm font-medium transition-all duration-300 whitespace-nowrap ${
@@ -95,7 +96,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
                   }`}
                 >
                   {item.label}
-                </Link>
+                </AppLink>
               );
             })}
 
@@ -132,22 +133,22 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               size="sm"
               className="hidden sm:flex h-10 rounded-full bg-alert px-4 text-white shadow-[0_18px_34px_-22px_rgba(197,95,61,0.75)] hover:bg-alert/85"
             >
-              <Link
+              <AppLink
                 href="/soforthilfe"
                 aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
               >
                 <Phone className="w-4 h-4 lg:mr-0 xl:mr-2" />
                 <span className="hidden xl:inline">Soforthilfe</span>
-              </Link>
+              </AppLink>
             </Button>
 
-            <Link
+            <AppLink
               href="/soforthilfe"
               aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
               className="sm:hidden inline-flex h-11 w-11 items-center justify-center rounded-full bg-alert text-white shadow-[0_8px_16px_-8px_rgba(197,95,61,0.6)]"
             >
               <Phone className="w-5 h-5" />
-            </Link>
+            </AppLink>
 
             <button
               ref={menuButtonRef}

--- a/client/src/components/layout/MobileMenu.tsx
+++ b/client/src/components/layout/MobileMenu.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Link } from "wouter";
+import AppLink from "@/components/AppLink";
 import {
   ChevronDown,
   FolderOpen,
@@ -87,7 +87,7 @@ export function MobileMenu({
           const isActive = location.startsWith(item.href);
           const accent = getRouteAccent(item.href);
           return (
-            <Link
+            <AppLink
               key={item.href}
               href={item.href}
               onClick={closeMenu}
@@ -99,7 +99,7 @@ export function MobileMenu({
             >
               <Icon className="w-5 h-5" />
               {item.label}
-            </Link>
+            </AppLink>
           );
         })}
 
@@ -147,7 +147,7 @@ export function MobileMenu({
                         const accent = getRouteAccent(item.href);
 
                         return (
-                          <Link
+                          <AppLink
                             key={item.href}
                             href={item.href}
                             onClick={() => {
@@ -172,7 +172,7 @@ export function MobileMenu({
                               }
                             />
                             {item.label}
-                          </Link>
+                          </AppLink>
                         );
                       })}
                     </div>
@@ -183,14 +183,14 @@ export function MobileMenu({
           )}
         </div>
 
-        <Link
+        <AppLink
           href="/soforthilfe"
           onClick={closeMenu}
           className="mt-2 flex items-center gap-3 rounded-2xl bg-alert px-4 py-3 text-base font-medium text-white shadow-[0_18px_32px_-22px_rgba(197,95,61,0.8)]"
         >
           <Phone className="w-5 h-5" />
           Soforthilfe
-        </Link>
+        </AppLink>
 
         <button
           type="button"

--- a/client/src/components/layout/RessourcenMenu.tsx
+++ b/client/src/components/layout/RessourcenMenu.tsx
@@ -1,4 +1,4 @@
-import { Link } from "wouter";
+import AppLink from "@/components/AppLink";
 import { ressourcenItems } from "@/components/layout/navigationData";
 import { getRouteAccent } from "@/components/layout/routeAccent";
 import { useRessourcenMenuA11y } from "@/components/layout/useRessourcenMenuA11y";
@@ -135,7 +135,7 @@ export function RessourcenMenu({
                     const idx = flatIndex(groups, groupIdx, itemIdx);
 
                     return (
-                      <Link
+                      <AppLink
                         key={item.href}
                         href={item.href}
                         role="menuitem"
@@ -163,7 +163,7 @@ export function RessourcenMenu({
                           className={`shrink-0 ${item.secondary ? "w-3.5 h-3.5" : "w-4 h-4"}`}
                         />
                         <span className="leading-tight">{item.label}</span>
-                      </Link>
+                      </AppLink>
                     );
                   })}
                 </div>

--- a/client/src/pages/Begleiterkrankungen.tsx
+++ b/client/src/pages/Begleiterkrankungen.tsx
@@ -32,6 +32,7 @@ import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
 import SEO from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
+import AppLink from "@/components/AppLink";
 import { emailByIdStrict, kontaktByIdStrict } from "@/data/kontakte";
 import { Link } from "wouter";
 
@@ -334,9 +335,9 @@ export default function Begleiterkrankungen() {
             </p>
             <ul className="ml-6 list-disc space-y-1">
               <li>
-                <Link href="/soforthilfe" className="editorial-link">
+                <AppLink href="/soforthilfe" className="editorial-link">
                   Soforthilfe
-                </Link>{" "}
+                </AppLink>{" "}
                 — Notfallnummern und Anlaufstellen für die akute Situation.
               </li>
               <li>
@@ -376,9 +377,9 @@ export default function Begleiterkrankungen() {
               </li>
               <li>
                 Bei Hinweisen auf Suizidalität → siehe{" "}
-                <Link href="/soforthilfe" className="editorial-link">
+                <AppLink href="/soforthilfe" className="editorial-link">
                   Soforthilfe
-                </Link>
+                </AppLink>
                 .
               </li>
             </ul>

--- a/client/src/pages/Diagnostik.tsx
+++ b/client/src/pages/Diagnostik.tsx
@@ -31,6 +31,7 @@ import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
 import SEO from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
+import AppLink from "@/components/AppLink";
 import {
   emailByIdStrict,
   kontaktByIdStrict,
@@ -458,9 +459,9 @@ export default function Diagnostik() {
               <strong>Klare Grenze:</strong> Bei akuter Gefahr — Suizidalität,
               schwerer Selbstverletzung oder Fremdgefährdung — ist die
               Diagnose-Frage nachrangig. Dann zählt die{" "}
-              <Link href="/soforthilfe" className="editorial-link">
+              <AppLink href="/soforthilfe" className="editorial-link">
                 Soforthilfe
-              </Link>
+              </AppLink>
               .
             </p>
           </EditorialProse>

--- a/client/src/pages/HandoutTextPage.tsx
+++ b/client/src/pages/HandoutTextPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import AppLink from "@/components/AppLink";
 import Layout from "@/components/Layout";
 import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { getHandoutDownloadHref, getHandoutOpenHref } from "@/content/handouts";
@@ -16,7 +17,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import NotFound from "@/pages/NotFound";
 import type { RouteComponentProps } from "wouter";
-import { Link } from "wouter";
 import {
   ArrowLeft,
   BookOpen,
@@ -154,28 +154,28 @@ export default function HandoutTextPage({
                   </a>
                 </Button>
                 <Button asChild variant="outline">
-                  <Link href="/materialien">
+                  <AppLink href="/materialien">
                     <ArrowLeft className="w-4 h-4" />
                     Zur Materialsammlung
-                  </Link>
+                  </AppLink>
                 </Button>
               </div>
 
               <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
-                <Link
+                <AppLink
                   href={pageTopicHref}
                   className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
                 >
                   <BookOpen className="w-4 h-4 text-sage-dark" />
                   Zum Themenbereich {pageTopicLabel}
-                </Link>
-                <Link
+                </AppLink>
+                <AppLink
                   href="/barrierefreiheit"
                   className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
                 >
                   <FileText className="w-4 h-4 text-sage-dark" />
                   Warum diese Textversion hilfreich ist
-                </Link>
+                </AppLink>
               </div>
             </div>
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -15,6 +15,7 @@ import {
   EditorialPullQuote,
   EditorialSection,
 } from "@/components/editorial";
+import AppLink from "@/components/AppLink";
 import Layout from "@/components/Layout";
 import SEO, { MedicalPageSchema, WebsiteSchema } from "@/components/SEO";
 import { EMAILS, INFO } from "@/data/kontakte";
@@ -168,8 +169,8 @@ export default function Home() {
               unter <Link href="/kommunizieren">Kommunizieren</Link>,{" "}
               <Link href="/grenzen">Grenzen</Link> und{" "}
               <Link href="/selbstfuersorge">Selbstfürsorge</Link>. Bei akuten
-              Krisen führt <Link href="/soforthilfe">Soforthilfe</Link> zu den
-              Schweizer Notfallnummern.
+              Krisen führt <AppLink href="/soforthilfe">Soforthilfe</AppLink> zu
+              den Schweizer Notfallnummern.
             </p>
           </EditorialProse>
           <p
@@ -236,9 +237,9 @@ export default function Home() {
             }}
           >
             In einer akuten Krise zählt der schnellste funktionierende Weg.{" "}
-            <Link href="/soforthilfe" className="editorial-link">
+            <AppLink href="/soforthilfe" className="editorial-link">
               Notfallnummern öffnen
-            </Link>
+            </AppLink>
             .
           </p>
         </section>

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -12,6 +12,7 @@ import {
   EditorialProse,
   EditorialSection,
 } from "@/components/editorial";
+import AppLink from "@/components/AppLink";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
@@ -444,9 +445,9 @@ export default function Notfallkarte() {
             }}
           >
             Sofort Hilfe brauchen?{" "}
-            <Link href="/soforthilfe" className="editorial-link">
+            <AppLink href="/soforthilfe" className="editorial-link">
               Soforthilfe-Nummern
-            </Link>{" "}
+            </AppLink>{" "}
             · Situation einschätzen?{" "}
             <Link href="/wegweiser" className="editorial-link">
               Situations-Wegweiser

--- a/client/src/pages/SelbsttestPage.tsx
+++ b/client/src/pages/SelbsttestPage.tsx
@@ -21,10 +21,10 @@ import {
   EditorialProse,
   EditorialSection,
 } from "@/components/editorial";
+import AppLink from "@/components/AppLink";
 import Layout from "@/components/Layout";
 import SEO from "@/components/SEO";
 import Selbsttest from "@/components/Selbsttest";
-import { Link } from "wouter";
 
 export default function SelbsttestPage() {
   return (
@@ -91,9 +91,9 @@ export default function SelbsttestPage() {
               lediglich als Orientierungshilfe, um Ihnen den Einstieg in unsere
               Inhalte zu erleichtern. Bei akuten Krisen wenden Sie sich bitte an
               die{" "}
-              <Link href="/soforthilfe" className="editorial-link">
+              <AppLink href="/soforthilfe" className="editorial-link">
                 Notfallressourcen
-              </Link>
+              </AppLink>
               .
             </p>
           </EditorialProse>

--- a/client/src/pages/UeberUns.tsx
+++ b/client/src/pages/UeberUns.tsx
@@ -20,6 +20,7 @@ import {
   EditorialProse,
   EditorialSection,
 } from "@/components/editorial";
+import AppLink from "@/components/AppLink";
 import EvidenceNote from "@/components/EvidenceNote";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
@@ -355,9 +356,9 @@ export default function UeberUns() {
               Diese Website ersetzt keine professionelle Beratung, Therapie oder
               medizinische Behandlung. Die Inhalte dienen der Information und
               Orientierung. Bei akuten Krisen wenden Sie sich bitte an die{" "}
-              <Link href="/soforthilfe" className="editorial-link">
+              <AppLink href="/soforthilfe" className="editorial-link">
                 Notfallnummern
-              </Link>
+              </AppLink>
               . Für eine individuelle Beratung empfehlen wir den Kontakt zu{" "}
               <Link href="/beratung" className="editorial-link">
                 Beratungsstellen

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -35,6 +35,7 @@ import SEO from "@/components/SEO";
 import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import { TableOfContents } from "@/components/UXEnhancements";
 import KrisenampelVisualisierung from "@/components/visualizations/KrisenampelVisualisierung";
+import AppLink from "@/components/AppLink";
 import { kontaktByIdStrict } from "@/data/kontakte";
 import { Link } from "wouter";
 
@@ -343,12 +344,12 @@ export default function UnterstuetzenKrise() {
                 {gruen143.label} ({gruen143.nummer})
               </a>
             </p>
-            <Link
+            <AppLink
               href="/soforthilfe"
               className="rounded bg-white px-3 py-2 text-sm font-medium text-alert hover:bg-white/90"
             >
               Alle Notfallnummern
-            </Link>
+            </AppLink>
           </div>
         </div>
       </section>
@@ -481,9 +482,9 @@ export default function UnterstuetzenKrise() {
               für emotionale Eskalationen, starke Anspannung und Rückzug. Bei
               akuter Gefahr, Suizidgefahr oder Selbstverletzung gehen Sie direkt
               zu{" "}
-              <Link href="/soforthilfe" className="editorial-link">
+              <AppLink href="/soforthilfe" className="editorial-link">
                 Soforthilfe &amp; Notfallnummern
-              </Link>
+              </AppLink>
               .
             </p>
           </EditorialProse>

--- a/client/src/pages/Wegweiser.tsx
+++ b/client/src/pages/Wegweiser.tsx
@@ -17,12 +17,12 @@
  * /soforthilfe.
  */
 import { EditorialLayout } from "@/components/editorial";
+import AppLink from "@/components/AppLink";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import SEO from "@/components/SEO";
 import SituationsWegweiser from "@/components/interactive/SituationsWegweiser";
 import { kontaktByIdStrict } from "@/data/kontakte";
-import { Link } from "wouter";
 
 const rot144 = kontaktByIdStrict("ROT_144");
 
@@ -87,9 +87,9 @@ export default function Wegweiser() {
               {rot144.nummer}
             </a>{" "}
             an. Dieser Wegweiser ersetzt keinen Notruf —{" "}
-            <Link href="/soforthilfe" className="editorial-link">
+            <AppLink href="/soforthilfe" className="editorial-link">
               alle Notfallnummern
-            </Link>
+            </AppLink>
             .
           </p>
         </header>

--- a/qa/README.md
+++ b/qa/README.md
@@ -86,8 +86,9 @@ Server. Auf macOS nutzen die Skripte System-Chrome
 `PLAYWRIGHT_EXECUTABLE_PATH` oder `playwright install chromium`.
 
 **`/soforthilfe`-Sonderfall:** Die Page ist Static-HTML, nicht React-SPA.
-Vite Preview emuliert die Netlify-`_redirects` nicht. Fuer ehrliche
-a11y-Audits dieser Page immer gegen Production testen:
+Der lokale Vite-Dev-/Preview-Server emuliert repo-intern den Direktzugriff
+auf `/soforthilfe` fuer Smoke- und Navigationschecks. Fuer ehrliche
+a11y-Audits dieser Page trotzdem immer gegen Production testen:
 
 ```sh
 AUDIT_BASE_URL=https://borderline-angehoerige.netlify.app \

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -154,6 +154,58 @@ function writeToLogFile(source: LogSource, entries: unknown[]) {
   trimLogFile(logPath, MAX_LOG_SIZE_BYTES);
 }
 
+const STATIC_DIRECT_PAGE_FILES = new Map([
+  ["/soforthilfe", "soforthilfe/index.html"],
+]);
+
+function normalizeRequestPath(reqUrl?: string) {
+  const pathname = new URL(reqUrl ?? "/", "http://localhost").pathname;
+  return pathname !== "/" ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+function createStaticDirectPageMiddleware(rootDir: string) {
+  return (
+    req: Parameters<ViteDevServer["middlewares"]["use"]>[1],
+    res: any,
+    next: () => void
+  ) => {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      return next();
+    }
+
+    const pathname = normalizeRequestPath(req.url);
+
+    if (pathname === "/notfall") {
+      res.writeHead(302, { Location: "/soforthilfe" });
+      res.end();
+      return;
+    }
+
+    const relativeFilePath = STATIC_DIRECT_PAGE_FILES.get(pathname);
+    if (!relativeFilePath) {
+      return next();
+    }
+
+    const absoluteFilePath = path.join(rootDir, relativeFilePath);
+    if (!fs.existsSync(absoluteFilePath)) {
+      return next();
+    }
+
+    const html = fs.readFileSync(absoluteFilePath);
+    res.writeHead(200, {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-cache",
+    });
+
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+
+    res.end(html);
+  };
+}
+
 /**
  * Vite plugin to collect browser debug logs
  * - POST /__manus__/logs: Browser sends logs, written directly to files
@@ -278,9 +330,36 @@ function vitePluginManusDebugCollector(): Plugin {
   };
 }
 
+function vitePluginStaticDirectPages(): Plugin {
+  return {
+    name: "static-direct-pages",
+
+    configureServer(server) {
+      server.middlewares.use(
+        createStaticDirectPageMiddleware(
+          path.join(PROJECT_ROOT, "client", "public")
+        )
+      );
+    },
+
+    configurePreviewServer(server) {
+      server.middlewares.use(
+        createStaticDirectPageMiddleware(
+          path.join(PROJECT_ROOT, "dist", "public")
+        )
+      );
+    },
+  };
+}
+
 export default defineConfig(({ command }) => {
   const isServe = command === "serve";
-  const plugins = [react(), tailwindcss(), jsxLocPlugin()];
+  const plugins = [
+    react(),
+    tailwindcss(),
+    jsxLocPlugin(),
+    vitePluginStaticDirectPages(),
+  ];
 
   if (isServe) {
     plugins.push(vitePluginManusRuntime(), vitePluginManusDebugCollector());


### PR DESCRIPTION
## What changed
- removed `/soforthilfe` and `/notfall` from the SPA route registry so the crisis page is no longer treated like a React route
- added `AppLink` to force hard browser navigation for static direct pages and file-backed assets while keeping SPA navigation for normal internal routes
- updated navigation, search, related links, handout links, and self-test links that can point to `/soforthilfe`
- added local Vite dev/preview middleware so `/soforthilfe` resolves like production during smoke checks
- added regression coverage for direct-page architecture, route expectations, and link behavior
- updated QA notes to reflect the new local preview behavior

## Why it changed
The root cause was that `/soforthilfe` is an intentional static direct page, but the app still routed to it through the SPA. That caused the emergency path to land in the wrong rendering flow and made local preview diverge from production.

## Impact
Users now reach the static Soforthilfe page reliably from in-app calls to action, and the repo has test coverage to catch a regression in this crisis-critical path.

## Validation
- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`