### PR TITLE
[codex] Document release gates and pnpm audit workflow

### DIFF
--- a/docs/governance/06-release-checkliste.md
+++ b/docs/governance/06-release-checkliste.md
@@ -29,3 +29,172 @@ Diese Checkliste ist vor jedem Release zwingend zu prüfen.
 
 - [ ] Fachlich geprüft
 - [ ] Release freigegeben
+
+## Release-Gates
+
+### Fach- und Kontakt-Audit
+
+Für diese Site ist das der wichtigste Gate.
+
+Prüfen:
+
+- Notfallnummern
+- PUK- und Beratungsdaten
+- rechtliche Begriffe
+- Quellen- und Krisenhinweise
+- lokale Relevanz für Schweiz / Zürich
+
+Pflicht-Scope:
+
+- `/soforthilfe`
+- `/notfallkarte`
+- `/unterstuetzen/krise`
+- `/diagnostik`
+- `/begleiterkrankungen`
+- `/grenzen`
+- `/beratung`
+- `/quellen`
+- lokale Notfall-PDFs
+- `client/src/data/kontakte.ts`
+
+Dieses Gate soll vor Release von einer fachlich verantwortlichen Person
+gegengelesen und ausdrücklich freigegeben werden.
+
+### Produktions-Crawl- und Link-Audit
+
+Vor Release systematisch prüfen:
+
+- interne Links
+- Anker-Sprünge
+- Redirects
+- `tel:`- und `mailto:`-Links
+- externe Beratungslinks
+- PDF-Links
+- direkte Sonderpfade
+- 404-Verhalten
+
+Besonderes Augenmerk:
+
+- SPA-Routen
+- statische Sonderseiten wie `/soforthilfe` und `/notfallkarte.html`
+- Material-Download-Proxy `/api/material-download/:id`
+
+### PDF- und Download-Audit
+
+Die Site hängt stark an PDFs, Downloads und Textversionen.
+
+Vor Release explizit prüfen:
+
+- Datei vorhanden
+- korrekter Dateiname
+- richtiger CTA
+- Inline-Öffnen vs. Download
+- Proxy-Verhalten
+- Preview vorhanden und korrekt
+- A4- bzw. Seitenformat plausibel
+- `verifiedAt`-Angaben aktuell
+- Konsistenz zwischen Content-Metadaten und real ausgelieferter Datei
+
+Relevante Quellen:
+
+- `client/src/content/materialien.ts`
+- `client/src/content/handouts.ts`
+- `client/src/content/handoutTextVersions.ts`
+- `server/material-download.ts`
+
+Zusätzlich prüfen:
+
+- gibt es für priorisierte Materialien eine zugängliche Textversion
+- entspricht der PDF-Textlayer bzw. die Suchbarkeit dem erwarteten
+  Qualitätsniveau
+
+### Indexierungs-, SEO- und Metadaten-Audit auf Produktion
+
+Prüfen:
+
+- `robots.txt`
+- `sitemap.xml`
+- Canonicals
+- Open Graph
+- Twitter-Metadaten
+- JSON-LD
+- Seitentitel und Descriptions
+- Redirect-Konsistenz
+
+Relevante Stellen:
+
+- `client/src/components/SEO.tsx`
+- `client/index.html`
+- `client/public/soforthilfe/index.html`
+- `client/public/robots.txt`
+- `client/public/sitemap.xml`
+
+Drift-Check:
+
+- Stimmen `lastReviewed`- und Prüfdatum-Angaben in JSON-LD,
+  Review-Badges, `pageGovernance.ts` und statischen Krisenseiten noch
+  mit dem tatsächlichen Inhaltsstand überein?
+
+### Interaktions- und Zustandsaudit der Tools
+
+Vor Release bewusst testen:
+
+- Notfallkarte speichern
+- Reload
+- Löschen
+- Druckansicht
+- `sessionStorage`-Übergabe ans Print-Template
+- Zurück / Vorwärts
+- Fokus nach Dialog oder Menü
+- Such-Overlay
+- Mobile Menu
+- Selbsttest-Navigation
+- interaktive Komponenten unter `client/src/components/interactive`
+
+Bei Hochrisiko-Flows gilt: kein stilles Fehlverhalten bei Storage-,
+Print- oder Fokuswechseln.
+
+### Voller Geräte- und Browser-Release-Test
+
+Verbindliche Release-Matrix:
+
+- iPhone Safari
+- iPhone Chrome
+- Android Chrome
+- Desktop Chrome
+- Desktop Firefox
+- optional zusätzlich macOS Safari
+
+Das ist hier release-relevant wegen langer Lesestrecken, sticky
+Navigation, Fokus-Management, Druckpfaden, lokaler Speicherung und den
+Soforthilfe- und Notfallpfaden.
+
+## Zusätzliche Audits mit hohem Nutzen
+
+### Config- und Doku-Drift-Audit
+
+Vor Release prüfen, ob Governance, QA-Doku und tatsächliche
+Repo-Realität noch zusammenpassen.
+
+Beispiele in diesem Repo:
+
+- historische `npm`-Referenzen in älteren Audit- oder `_dev`-Dokumenten
+  vs. aktuelle operative `pnpm`-Nutzung
+- Abgleich zwischen Hochrisiko-Seiten in Governance und
+  `client/src/data/pageGovernance.ts`
+- Konsistenz zwischen Audit-Doku, Sonderpfad-Architektur und realen
+  Scripts / Checks
+
+### Security- und Caching-Audit
+
+Vor Release gegen die echte Produktion prüfen:
+
+- Security-Header
+- CSP
+- Cache-Regeln für HTML
+- Cache-Regeln für Assets
+- Cache-Regeln für PDFs
+- Cache-Regeln für Proxy-Responses
+- keine unerwarteten externen Requests
+- keine Preview- oder Dev-Metadaten auf Production
+- konsistente Auslieferung statischer Sonderseiten und Download-Pfade

--- a/qa/README.md
+++ b/qa/README.md
@@ -10,10 +10,10 @@ Dieses Verzeichnis hält die repo-spezifische Audit-Arbeitsweise für
 - Phase 1 und Phase 2 bleiben read-only fuer Produktcode.
 - Audit-Artefakte duerfen in `qa/` und `qa/scripts/` entstehen.
 - Die Standard-Verifikation fuer dieses Repo ist:
-  - `npm test`
-  - `npm run check`
-  - `npm run build`
-  - `npm run lint`
+  - `pnpm test`
+  - `pnpm check`
+  - `pnpm build`
+  - `pnpm lint`
 
 ## Empfohlene Reihenfolge
 

--- a/qa/audit-plan.md
+++ b/qa/audit-plan.md
@@ -52,10 +52,10 @@ Jeder Audit-Worktree startet mit derselben Baseline:
 1. frischer `origin/main`-basierter Temp-Worktree
 2. read-only fuer Produktcode in Phase 1 und 2
 3. Standard-Verifikation:
-   - `npm test`
-   - `npm run check`
-   - `npm run build`
-   - `npm run lint`
+   - `pnpm test`
+   - `pnpm check`
+   - `pnpm build`
+   - `pnpm lint`
 
 Die Verifikation wurde im Haupt-Repo erfolgreich nachvollzogen und bleibt die
 verbindliche Ausgangsbasis fuer alle Audit-Spuren.

--- a/qa/codex-audit-prompts.md
+++ b/qa/codex-audit-prompts.md
@@ -31,7 +31,7 @@ Pruefe das Projekt `/Users/christaegger/Documents/Webprojekte/borderline-angehoe
 - Audit-Artefakte unter `qa/` und `qa/scripts/` sind in Phase 1/2 erlaubt.
 - Keine Aenderungen an `client/src`, `server`, `client/public`, `netlify.toml` in Phase 1/2.
 - Falls noetig, installiere audit-only Tools im Temp-Worktree: `playwright`, `@playwright/test`, `lighthouse`, `pa11y`, `axe-core`, `@axe-core/playwright`.
-- Nutze `npm run build` + `npm run preview` fuer lokale Browser-Pruefungen.
+- Nutze `pnpm build` + `pnpm preview` fuer lokale Browser-Pruefungen.
 
 ## Phase 1 - Inventur
 - Pruefe mindestens diese Routen: `/`, `/soforthilfe`, `/materialien`, `/verstehen`.
@@ -62,10 +62,10 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Fix eigener Commit: `audit(a11y): fix <was>`
 
 ## Phase 4 - Verifikation
-- `npm test`
-- `npm run check`
-- `npm run build`
-- `npm run lint`
+- `pnpm test`
+- `pnpm check`
+- `pnpm build`
+- `pnpm lint`
 - Lighthouse-Re-Run
 - Alle drei `qa/scripts/*` erneut ausfuehren
 - Finale Release-Readiness-Aussage
@@ -83,16 +83,16 @@ Pruefe `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige` auf Pe
 - Branch: `audit/performance`
 - Bericht: `qa/audit-performance.md`
 - Audit-Artefakte unter `qa/` sind erlaubt, keine funktionalen Aenderungen in Phase 1/2.
-- Verwende die echten Repo-Kommandos: `npm run build`, `npm test`, `npm run check`, `npm run lint`.
+- Verwende die echten Repo-Kommandos: `pnpm build`, `pnpm test`, `pnpm check`, `pnpm lint`.
 - Falls noetig, installiere audit-only Tools wie Lighthouse oder einen Vite-Bundle-Analyzer nur im Temp-Worktree.
 
 ## Phase 1 - Inventur
 - Pruefe mindestens diese Routen auf Desktop und Mobile: `/`, `/materialien`, `/soforthilfe`.
 - Ermittle pro Route Lighthouse Performance, LCP, CLS, TBT/INP, FCP und Speed Index.
-- Dokumentiere die Build-Ausgabe von `npm run build` und schluessel die erzeugten Chunks nach Dateiname, raw size, gzip size und vermuteter Funktion auf.
+- Dokumentiere die Build-Ausgabe von `pnpm build` und schluessel die erzeugten Chunks nach Dateiname, raw size, gzip size und vermuteter Funktion auf.
 - Identifiziere die Top-5 groessten JS-Chunks und die groessten CSS-/Asset-Treiber.
 - Lies `package.json` und pruefe Dependencies auf tatsaechliche Importe, doppelte Funktionalitaet und offensichtliche Altlasten.
-- Fuehre `npm audit` aus und dokumentiere Findings getrennt von reiner Performance.
+- Fuehre `pnpm audit` aus und dokumentiere Findings getrennt von reiner Performance.
 - Inventarisiere Bilder in `client/public/` und externe Bildnutzung in den Pages/Sections.
 - Pruefe speziell:
   - Hero-Bilder und `srcSet`/`sizes`
@@ -119,10 +119,10 @@ STOPP nach Phase 2. Warte auf Freigabe.
 ## Phase 4 - Verifikation
 - Lighthouse-Vergleich vorher/nachher
 - Vergleich der Build-/Chunk-Groessen
-- `npm test`
-- `npm run check`
-- `npm run build`
-- `npm run lint`
+- `pnpm test`
+- `pnpm check`
+- `pnpm build`
+- `pnpm lint`
 ```
 
 ## Audit 3 - Content-Qualitaet und Sprache
@@ -231,8 +231,8 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Massnahme eigener Commit: `audit(css): <was>`
 
 ## Phase 4 - Verifikation
-- `npm run build`
-- `npm run lint`
+- `pnpm build`
+- `pnpm lint`
 - visueller Vergleich auf mindestens `/`, `/soforthilfe`, `/materialien`
 - Token-Coverage vorher/nachher dokumentieren
 ```
@@ -263,7 +263,7 @@ Pruefe `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige` auf Si
   - `server/index.ts`
   - falls relevant `client/public/_headers` oder aehnliche Dateien
 - Pruefe CSP-Qualitaet und erklaere konkret, wofuer aktuelle Ausnahmen wie `'unsafe-inline'` noetig sind oder nicht.
-- Fuehre `npm audit` aus und gruppiere nach Schweregrad.
+- Fuehre `pnpm audit` aus und gruppiere nach Schweregrad.
 - Suche inline Scripts, inline Event-Handler und andere CSP-Hindernisse in `client/public/` und im generierten App-Pattern.
 - Pruefe Formulare und User-Input:
   - Validierung
@@ -290,11 +290,11 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Fix eigener Commit: `audit(sec): <was>`
 
 ## Phase 4 - Verifikation
-- `npm audit` ohne critical/high
+- `pnpm audit` ohne critical/high
 - keine Secrets im Code oder in der History
 - Security-Headers in Code und Live-Site konsistent
-- `npm run build`
-- `npm run lint`
+- `pnpm build`
+- `pnpm lint`
 ```
 
 ## Audit 6 - SEO, Metadaten und Informationsarchitektur
@@ -362,10 +362,10 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Aenderung eigener Commit: `audit(seo): <was>`
 
 ## Phase 4 - Verifikation
-- `npm test`
-- `npm run check`
-- `npm run build`
-- `npm run lint`
+- `pnpm test`
+- `pnpm check`
+- `pnpm build`
+- `pnpm lint`
 - Sitemap-, Robots- und Route-Matrix erneut gegenpruefen
 ```
 
@@ -424,10 +424,10 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Aenderung eigener Commit: `audit(flow): <was>`
 
 ## Phase 4 - Verifikation
-- `npm test`
-- `npm run check`
-- `npm run build`
-- `npm run lint`
+- `pnpm test`
+- `pnpm check`
+- `pnpm build`
+- `pnpm lint`
 - Strukturmatrix fuer Kernpfade erneut pruefen
 ```
 
@@ -483,10 +483,10 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Aenderung eigener Commit: `audit(pdf): <was>`
 
 ## Phase 4 - Verifikation
-- `npm test`
-- `npm run check`
-- `npm run build`
-- `npm run lint`
+- `pnpm test`
+- `pnpm check`
+- `pnpm build`
+- `pnpm lint`
 - Materialmatrix und CTA-Muster erneut pruefen
 ```
 
@@ -509,10 +509,10 @@ Routing, A11y, SEO, Materialien, Downloads und Security wichtig sind.
 
 ## Phase 1 - Inventur
 - Fuehre aus:
-  - `npm test`
-  - `npm run check`
-  - `npm run build`
-  - `npm run lint`
+  - `pnpm test`
+  - `pnpm check`
+  - `pnpm build`
+  - `pnpm lint`
 - Clustere `client/src/__tests__/*` mindestens nach:
   - Routing / Architektur
   - Security Headers
@@ -543,10 +543,10 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Aenderung eigener Commit: `audit(test): <was>`
 
 ## Phase 4 - Verifikation
-- `npm test`
-- `npm run check`
-- `npm run build`
-- `npm run lint`
+- `pnpm test`
+- `pnpm check`
+- `pnpm build`
+- `pnpm lint`
 - Matrix gegen tatsaechlich hinzugefuegte oder angepasste Absicherung abgleichen
 ```
 
@@ -597,9 +597,9 @@ STOPP nach Phase 2. Warte auf Freigabe.
 - Pro Aenderung eigener Commit: `audit(release): <was>`
 
 ## Phase 4 - Verifikation
-- `npm test`
-- `npm run check`
-- `npm run build`
-- `npm run lint`
+- `pnpm test`
+- `pnpm check`
+- `pnpm build`
+- `pnpm lint`
 - abschliessendes Release-Urteil mit verbleibenden Restrisiken
 ```


### PR DESCRIPTION
## Summary

- add repo-specific release gates to the governance release checklist
- align operative QA documentation and audit prompts from `npm` commands to `pnpm`
- clarify that older `_dev` and historic audit artifacts may still reference `npm` while active docs are now `pnpm`-based

## Why

The repo's operational docs had drifted in two places:

1. release-governance guidance was still too generic and needed adaptation to the actual `borderline-angehoerige` architecture
2. active QA docs still mixed `npm` wording into a repo that is operationally `pnpm`-based

This PR makes the release process easier to follow and reduces avoidable audit/setup confusion.

## Validation

- docs-only change
- no automated checks run
