### PR TITLE
[codex] Fix notfallkarte audit blockers

### DIFF
--- a/client/public/notfallkarte-print.html
+++ b/client/public/notfallkarte-print.html
@@ -694,11 +694,11 @@
 
     <script>
       (function () {
-        // ── Benutzerdaten aus sessionStorage laden ──────────────────────────
+        // ── Benutzerdaten aus localStorage laden ────────────────────────────
         // Die React-App schreibt die Daten unter "notfallkarte-print-data"
-        // in sessionStorage, bevor sie dieses Fenster öffnet.
+        // in localStorage, bevor sie dieses Fenster öffnet.
         try {
-          var raw = sessionStorage.getItem("notfallkarte-print-data");
+          var raw = localStorage.getItem("notfallkarte-print-data");
           if (raw) {
             var d = JSON.parse(raw);
 
@@ -744,8 +744,8 @@
               notesEl.removeAttribute("placeholder");
             }
 
-            // sessionStorage-Eintrag nach Befüllung löschen
-            sessionStorage.removeItem("notfallkarte-print-data");
+            // Temporären localStorage-Eintrag nach Befüllung löschen
+            localStorage.removeItem("notfallkarte-print-data");
           }
         } catch (e) {
           // Fehler ignorieren – Felder bleiben leer / mit Platzhaltern

--- a/client/public/notfallkarte.html
+++ b/client/public/notfallkarte.html
@@ -13,12 +13,12 @@
     <link rel="stylesheet" href="/notfallkarte.css" />
   </head>
   <body>
-    <div class="page-wrapper" id="pw">
+    <main class="page-wrapper" id="pw">
       <div class="page">
         <!-- HEADER -->
 
-        <div class="header">
-          <div class="header-title">Notfallkarte Zürich – Psychische Krise</div>
+        <header class="header">
+          <h1 class="header-title">Notfallkarte Zürich – Psychische Krise</h1>
           <div class="header-meta">
             Für Angehörige · PUK Zürich · v06 · 2026-03-10
           </div>
@@ -26,6 +26,9 @@
             <button type="button" id="print-notfallkarte" class="header-btn">
               🖨 Drucken / PDF
             </button>
+            <a href="/notfallkarte/erstellen" class="header-btn">
+              ✍ Persönlich ausfüllen
+            </a>
             <a
               href="/Notfallkarte-Zuerich-Psychische-Krise.pdf"
               download="Notfallkarte-Zuerich-Psychische-Krise.pdf"
@@ -34,7 +37,7 @@
               ⬇ Herunterladen
             </a>
           </div>
-        </div>
+        </header>
 
         <!-- BLOCK 1: LEBENSGEFAHR -->
 
@@ -85,9 +88,9 @@
               </a>
             </div>
             <div class="hinweis-small">
-              Ärztlicher Hausbesuch?
-              <a href="tel:0443604444" class="sos-link"
-                >SOS Ärzte · 044 360 44 44</a
+              Ärztliche Triage oder Hausbesuch?
+              <a href="tel:0800336655" class="sos-link"
+                >Ärztefon Zürich · 0800 33 66 55</a
               >
             </div>
             <div class="hinweis">
@@ -229,7 +232,7 @@
 
         <!-- FOOTER -->
 
-        <div class="footer">
+        <footer class="footer">
           <div class="footer-left">
             <span class="f1"
               >Fachstelle Angehörigenarbeit · Psychiatrische Universitätsklinik
@@ -258,10 +261,10 @@
               ></span
             >
           </div>
-        </div>
+        </footer>
       </div>
       <!-- .page -->
-    </div>
+    </main>
     <!-- .page-wrapper -->
 
     <script src="/notfallkarte.js"></script>

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -17,6 +17,7 @@
   <url><loc>https://borderline-angehoerige.netlify.app/wegweiser</loc><lastmod>2026-04-24</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://borderline-angehoerige.netlify.app/uebungen</loc><lastmod>2026-04-24</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://borderline-angehoerige.netlify.app/notfallkarte</loc><lastmod>2026-04-24</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://borderline-angehoerige.netlify.app/notfallkarte/erstellen</loc><lastmod>2026-05-01</lastmod><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://borderline-angehoerige.netlify.app/selbsttest</loc><lastmod>2026-04-24</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://borderline-angehoerige.netlify.app/buchempfehlungen</loc><lastmod>2026-04-24</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://borderline-angehoerige.netlify.app/glossar</loc><lastmod>2026-04-24</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>

--- a/client/public/soforthilfe-print.html
+++ b/client/public/soforthilfe-print.html
@@ -875,30 +875,30 @@
             <div class="kontakt">
               <div class="kontakt-info">
                 <div class="kontakt-nummer" style="font-size: 10pt">
-                  044 296 73 00
+                  058 384 65 00
                 </div>
                 <div class="kontakt-label">
                   Kriseninterventionszentrum (KIZ) Zürich
                 </div>
                 <div class="kontakt-hinweis">
-                  Psychiatrische Notfallambulanz – Mo–Fr 8–17 Uhr
+                  Ambulante Krisenintervention für Erwachsene
                 </div>
               </div>
-              <a class="kontakt-tel" href="tel:+41442967300">📞</a>
+              <a class="kontakt-tel" href="tel:+41583846500">📞</a>
             </div>
             <div class="kontakt">
               <div class="kontakt-info">
                 <div class="kontakt-nummer" style="font-size: 10pt">
-                  058 384 27 00
+                  058 384 38 00
                 </div>
                 <div class="kontakt-label">
                   Fachstelle Angehörigenarbeit PUK
                 </div>
                 <div class="kontakt-hinweis">
-                  Beratung für Angehörige – Mo–Fr 9–12 Uhr
+                  Beratung und Begleitung für Angehörige
                 </div>
               </div>
-              <a class="kontakt-tel" href="tel:+41583842700">📞</a>
+              <a class="kontakt-tel" href="tel:+41583843800">📞</a>
             </div>
           </div>
         </div>

--- a/client/src/__tests__/notfallkarte-architecture.test.ts
+++ b/client/src/__tests__/notfallkarte-architecture.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { INFO } from "@/data/kontakte";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+const KIZ = INFO.find(kontakt => kontakt.id === "INFO_KIZ");
+const FACHSTELLE = INFO.find(kontakt => kontakt.id === "INFO_FACHSTELLE");
+const AERZTEFON = INFO.find(kontakt => kontakt.id === "INFO_AERZTEFON");
+
+describe("notfallkarte architecture", () => {
+  it("keeps the personal tool off the static /notfallkarte URL", () => {
+    const routesIndex = fs.readFileSync(
+      path.join(repoRoot, "client/src/app/routes.ts"),
+      "utf8"
+    );
+
+    expect(routesIndex).not.toContain('path: "/notfallkarte", component');
+    expect(routesIndex).toContain("PERSONAL_NOTFALLKARTE_PATH");
+  });
+
+  it("uses localStorage for the print handoff that must survive window.open", () => {
+    const pageSource = fs.readFileSync(
+      path.join(repoRoot, "client/src/pages/Notfallkarte.tsx"),
+      "utf8"
+    );
+    const printTemplate = fs.readFileSync(
+      path.join(repoRoot, "client/public/notfallkarte-print.html"),
+      "utf8"
+    );
+
+    expect(pageSource).toContain(
+      "localStorage.setItem(NOTFALLKARTE_PRINT_STORAGE_KEY, JSON.stringify(data))"
+    );
+    expect(printTemplate).toContain(
+      'localStorage.getItem("notfallkarte-print-data")'
+    );
+    expect(printTemplate).toContain(
+      'localStorage.removeItem("notfallkarte-print-data")'
+    );
+    expect(printTemplate).not.toContain(
+      'sessionStorage.getItem("notfallkarte-print-data")'
+    );
+  });
+
+  it("keeps static crisis pages aligned with the canonical contact register", () => {
+    const browserCard = fs.readFileSync(
+      path.join(repoRoot, "client/public/notfallkarte.html"),
+      "utf8"
+    );
+    const soforthilfePrint = fs.readFileSync(
+      path.join(repoRoot, "client/public/soforthilfe-print.html"),
+      "utf8"
+    );
+
+    expect(AERZTEFON).toBeDefined();
+    expect(KIZ).toBeDefined();
+    expect(FACHSTELLE).toBeDefined();
+
+    expect(browserCard).toContain(AERZTEFON!.nummer);
+    expect(browserCard).not.toContain("044 360 44 44");
+
+    expect(soforthilfePrint).toContain(KIZ!.nummer);
+    expect(soforthilfePrint).toContain(FACHSTELLE!.nummer);
+    expect(soforthilfePrint).not.toContain("044 296 73 00");
+    expect(soforthilfePrint).not.toContain("058 384 27 00");
+  });
+});

--- a/client/src/__tests__/notfallkarte-architecture.test.ts
+++ b/client/src/__tests__/notfallkarte-architecture.test.ts
@@ -33,8 +33,8 @@ describe("notfallkarte architecture", () => {
       "utf8"
     );
 
-    expect(pageSource).toContain(
-      "localStorage.setItem(NOTFALLKARTE_PRINT_STORAGE_KEY, JSON.stringify(data))"
+    expect(pageSource).toMatch(
+      /localStorage\.setItem\(\s*NOTFALLKARTE_PRINT_STORAGE_KEY,\s*JSON\.stringify\(data\)\s*\)/
     );
     expect(printTemplate).toContain(
       'localStorage.getItem("notfallkarte-print-data")'

--- a/client/src/__tests__/routes-registry.test.ts
+++ b/client/src/__tests__/routes-registry.test.ts
@@ -18,6 +18,10 @@ describe("route registry", () => {
     expect(routes.some(route => route.path === "/selbsttest")).toBe(true);
     expect(routes.some(route => route.path === "/faq")).toBe(true);
     expect(routes.some(route => route.path === "/materialien")).toBe(true);
+    expect(routes.some(route => route.path === "/notfallkarte/erstellen")).toBe(
+      true
+    );
+    expect(routes.some(route => route.path === "/notfallkarte")).toBe(false);
   });
 
   it("keeps known redirects configured", () => {

--- a/client/src/app/routes.ts
+++ b/client/src/app/routes.ts
@@ -1,4 +1,5 @@
 import { lazy } from "react";
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 import type { RouteComponentProps } from "wouter";
 
 export interface AppRoute {
@@ -102,7 +103,7 @@ export const routes: AppRoute[] = [
   { path: "/faq", component: FAQ, requiresMotion: true },
   { path: "/ueber-uns", component: UeberUns, requiresMotion: true },
   { path: "/fachstelle", component: Fachstelle, requiresMotion: true },
-  { path: "/notfallkarte", component: Notfallkarte },
+  { path: PERSONAL_NOTFALLKARTE_PATH, component: Notfallkarte },
   { path: "/wegweiser", component: Wegweiser, requiresMotion: true },
   { path: "/uebungen", component: Uebungsszenarien, requiresMotion: true },
   { path: "/quellen", component: Quellen, requiresMotion: true },

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from "react";
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 import { useScrollLock } from "@/hooks/useScrollLock";
 import {
   ChevronUp,
@@ -80,7 +81,7 @@ const pageNames: Record<string, string> = {
   "/buchempfehlungen": "Buchempfehlungen",
   "/feedback": "Feedback",
   "/wegweiser": "Situations-Wegweiser",
-  "/notfallkarte": "Persönliche Notfallkarte",
+  [PERSONAL_NOTFALLKARTE_PATH]: "Persönliche Notfallkarte",
   "/uebungen": "Kommunikations-Übungen",
   "/quellen": "Quellen & Literatur",
   "/fachstelle": "Fachstelle Angehörigenarbeit",

--- a/client/src/components/layout/Breadcrumbs.tsx
+++ b/client/src/components/layout/Breadcrumbs.tsx
@@ -1,6 +1,7 @@
 import { Link, useLocation } from "wouter";
 import { getRouteAccent } from "@/components/layout/routeAccent";
 import { getHandoutTextVersionMeta } from "@/content/handoutTextVersions";
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 import { ArrowLeft, ChevronRight, Home } from "@/icons/root-icons";
 
 const pageNames: Record<string, string> = {
@@ -28,7 +29,7 @@ const pageNames: Record<string, string> = {
   "/buchempfehlungen": "Buchempfehlungen",
   "/feedback": "Feedback",
   "/wegweiser": "Situations-Wegweiser",
-  "/notfallkarte": "Persönliche Notfallkarte",
+  [PERSONAL_NOTFALLKARTE_PATH]: "Persönliche Notfallkarte",
   "/uebungen": "Kommunikations-Übungen",
   "/quellen": "Quellen & Literatur",
   "/fachstelle": "Fachstelle Angehörigenarbeit",

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -1,3 +1,5 @@
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
+
 export type SearchEntry = {
   title: string;
   description: string;
@@ -1824,7 +1826,7 @@ export const searchableContent: SearchEntry[] = [
       "deeskalation",
       "vorbereitung",
     ],
-    href: "/notfallkarte",
+    href: PERSONAL_NOTFALLKARTE_PATH,
     section: "Tools",
   },
 

--- a/client/src/data/kontakte.ts
+++ b/client/src/data/kontakte.ts
@@ -1,8 +1,9 @@
 /**
  * KONTAKTE – Single Source of Truth
  *
- * Alle Telefonnummern, E-Mail-Adressen, Adressen und URLs auf der Website
- * kommen ausschliesslich aus dieser Datei. Keine Nummern im Fliesstext.
+ * Diese Datei ist das kanonische Kontaktregister der Website.
+ * Statische Sonderseiten und Druckvorlagen muessen mit diesen Werten
+ * synchron bleiben; Regressionstests pruefen die Spiegelungen.
  *
  * Inventar: 20 Telefonnummern, 4 E-Mail-Adressen, 1 Adresse, 8 URLs.
  *

--- a/client/src/data/pageGovernance.ts
+++ b/client/src/data/pageGovernance.ts
@@ -22,6 +22,12 @@ export const pageGovernance: Record<string, PageGovernance> = {
     nextReviewDue: "2026-07-31",
     owner: DEFAULT_OWNER,
   },
+  "/notfallkarte/erstellen": {
+    riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-07-31",
+    owner: DEFAULT_OWNER,
+  },
   "/unterstuetzen/krise": {
     riskLevel: "high",
     lastReviewed: "2026-04-30",
@@ -41,6 +47,24 @@ export const pageGovernance: Record<string, PageGovernance> = {
     owner: DEFAULT_OWNER,
   },
   "/grenzen": {
+    riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-10-31",
+    owner: DEFAULT_OWNER,
+  },
+  "/beratung": {
+    riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-10-31",
+    owner: DEFAULT_OWNER,
+  },
+  "/datenschutz": {
+    riskLevel: "high",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2026-10-31",
+    owner: DEFAULT_OWNER,
+  },
+  "/quellen": {
     riskLevel: "high",
     lastReviewed: "2026-04-30",
     nextReviewDue: "2026-10-31",

--- a/client/src/domain/navigation.ts
+++ b/client/src/domain/navigation.ts
@@ -16,6 +16,7 @@ import {
   TrendingUp,
 } from "@/icons/root-icons";
 import type { NavigationItem } from "@/domain/content-types";
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 
 export const primaryNavigationItems: NavigationItem[] = [
   { href: "/verstehen", label: "Verstehen", icon: BookOpen },
@@ -28,7 +29,7 @@ export const primaryNavigationItems: NavigationItem[] = [
 export const resourceNavigationItems: NavigationItem[] = [
   // Gruppe: Sofortige Hilfe
   {
-    href: "/notfallkarte",
+    href: PERSONAL_NOTFALLKARTE_PATH,
     label: "Notfallkarte",
     icon: FileText,
     group: "Sofortige Hilfe",

--- a/client/src/domain/notfallkarte.ts
+++ b/client/src/domain/notfallkarte.ts
@@ -1,0 +1,4 @@
+export const PERSONAL_NOTFALLKARTE_PATH = "/notfallkarte/erstellen";
+
+export const NOTFALLKARTE_STORAGE_KEY = "notfallkarte-data";
+export const NOTFALLKARTE_PRINT_STORAGE_KEY = "notfallkarte-print-data";

--- a/client/src/pages/Datenschutz.tsx
+++ b/client/src/pages/Datenschutz.tsx
@@ -1,6 +1,7 @@
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
 import ContentSection from "@/components/ContentSection";
+import ReviewBadge from "@/components/ReviewBadge";
 import { Card, CardContent } from "@/components/ui/card";
 import { motion } from "framer-motion";
 import {
@@ -47,6 +48,7 @@ export default function Datenschutz() {
               Datenschutzerklärung informiert Sie über die Verarbeitung
               personenbezogener Daten auf dieser Website.
             </p>
+            <ReviewBadge path="/datenschutz" />
           </motion.div>
         </div>
       </section>

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -18,6 +18,11 @@ import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
 import SEO from "@/components/SEO";
 import { ROT, GELB, GRUEN, type Kontakt } from "@/data/kontakte";
+import {
+  NOTFALLKARTE_PRINT_STORAGE_KEY,
+  NOTFALLKARTE_STORAGE_KEY,
+  PERSONAL_NOTFALLKARTE_PATH,
+} from "@/domain/notfallkarte";
 import { Link } from "wouter";
 
 interface PersonalContact {
@@ -37,8 +42,6 @@ interface NotfallkarteData {
   calmingStrategies: CalmingStrategy[];
   notes: string;
 }
-
-const STORAGE_KEY = "notfallkarte-data";
 
 const DEFAULT_STRATEGIES: CalmingStrategy[] = [
   { id: "s1", text: "Langsam ein- und ausatmen (4-7-8)" },
@@ -62,7 +65,7 @@ const CARD_GRUEN = GRUEN.filter(k => k.id === "GRUEN_143");
 
 function loadData(): NotfallkarteData {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(NOTFALLKARTE_STORAGE_KEY);
     if (raw) return JSON.parse(raw);
   } catch {
     /* ignore corrupt data */
@@ -83,7 +86,7 @@ function isStorageAvailable(): boolean {
 
 function saveData(data: NotfallkarteData): boolean {
   try {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+    localStorage.setItem(NOTFALLKARTE_STORAGE_KEY, JSON.stringify(data));
     return true;
   } catch {
     return false;
@@ -92,8 +95,9 @@ function saveData(data: NotfallkarteData): boolean {
 
 function deleteStoredData(): boolean {
   try {
-    localStorage.removeItem(STORAGE_KEY);
-    sessionStorage.removeItem("notfallkarte-print-data");
+    localStorage.removeItem(NOTFALLKARTE_STORAGE_KEY);
+    localStorage.removeItem(NOTFALLKARTE_PRINT_STORAGE_KEY);
+    sessionStorage.removeItem(NOTFALLKARTE_PRINT_STORAGE_KEY);
     return true;
   } catch {
     return false;
@@ -294,7 +298,10 @@ export default function Notfallkarte() {
 
   const handlePrint = useCallback(() => {
     try {
-      sessionStorage.setItem("notfallkarte-print-data", JSON.stringify(data));
+      localStorage.setItem(
+        NOTFALLKARTE_PRINT_STORAGE_KEY,
+        JSON.stringify(data)
+      );
     } catch {
       /* ignore */
     }
@@ -366,7 +373,7 @@ export default function Notfallkarte() {
       <SEO
         title="Persönliche Notfallkarte"
         description="Erstellen Sie Ihre persönliche Notfallkarte mit den wichtigsten Nummern, Kontaktpersonen und Beruhigungsstrategien – zum Ausdrucken oder Speichern."
-        path="/notfallkarte"
+        path={PERSONAL_NOTFALLKARTE_PATH}
       />
       <div role="status" aria-live="polite" className="sr-only">
         {announcement}
@@ -453,7 +460,7 @@ export default function Notfallkarte() {
               Situations-Wegweiser
             </Link>
           </p>
-          <ReviewBadge path="/notfallkarte" />
+          <ReviewBadge path={PERSONAL_NOTFALLKARTE_PATH} />
         </header>
         <hr
           className="border-0 border-t print:hidden"

--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -19,6 +19,7 @@ import {
   EditorialSection,
 } from "@/components/editorial";
 import Layout from "@/components/Layout";
+import ReviewBadge from "@/components/ReviewBadge";
 import SEO from "@/components/SEO";
 
 interface QuelleEintrag {
@@ -455,6 +456,7 @@ export default function Quellen() {
             evidenzbasierten Methoden. Hier finden Sie alle Quellen, geordnet
             nach Bereich.
           </p>
+          <ReviewBadge path="/quellen" />
           <p
             className="mt-4"
             style={{

--- a/client/src/pages/Selbsthilfegruppen.tsx
+++ b/client/src/pages/Selbsthilfegruppen.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/components/editorial";
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
+import ReviewBadge from "@/components/ReviewBadge";
 import SEO from "@/components/SEO";
 import {
   emailByIdStrict,
@@ -167,6 +168,7 @@ export default function Selbsthilfegruppen() {
             Anlaufstellen für Angehörige in der Schweiz.
           </p>
           <LastVerifiedBadge date="24.03.2026" className="mt-6" />
+          <ReviewBadge path={canonicalPath} />
         </header>
 
         {/* ── Kategorie-Sprungleiste ── */}

--- a/client/src/pages/Wegweiser.tsx
+++ b/client/src/pages/Wegweiser.tsx
@@ -23,6 +23,7 @@ import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import SEO from "@/components/SEO";
 import SituationsWegweiser from "@/components/interactive/SituationsWegweiser";
 import { kontaktByIdStrict } from "@/data/kontakte";
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 
 const rot144 = kontaktByIdStrict("ROT_144");
 
@@ -119,7 +120,7 @@ export default function Wegweiser() {
               description: "Alle Notfallnummern.",
             },
             {
-              href: "/notfallkarte",
+              href: PERSONAL_NOTFALLKARTE_PATH,
               title: "Notfallkarte",
               description: "Persönliche Karte erstellen.",
             },

--- a/docs/governance/06-release-checkliste.md
+++ b/docs/governance/06-release-checkliste.md
@@ -48,6 +48,7 @@ Pflicht-Scope:
 
 - `/soforthilfe`
 - `/notfallkarte`
+- `/notfallkarte/erstellen`
 - `/unterstuetzen/krise`
 - `/diagnostik`
 - `/begleiterkrankungen`

--- a/docs/governance/08-seiten-risikoklassifikation.md
+++ b/docs/governance/08-seiten-risikoklassifikation.md
@@ -8,6 +8,7 @@ Diese Seiten brauchen fachliche Prüfung und regelmässige Aktualisierung:
 
 - `/soforthilfe`
 - `/notfallkarte`
+- `/notfallkarte/erstellen`
 - `/unterstuetzen/krise`
 - `/diagnostik`
 - `/begleiterkrankungen`

--- a/docs/governance/notfallkarte-privacy-fix.md
+++ b/docs/governance/notfallkarte-privacy-fix.md
@@ -7,7 +7,7 @@ Status: als Umsetzungsanleitung für `client/src/pages/Notfallkarte.tsx` dokumen
 Die Notfallkarte speichert persönliche Einträge lokal im Browser. Für gemeinsam genutzte Geräte braucht es:
 
 - einen sichtbaren Button `Daten löschen`
-- Löschung von `localStorage` und `sessionStorage`
+- Löschung von `localStorage` und des temporären Print-Transfers
 - Rücksetzen auf leere Standarddaten
 - Screenreader-Statusmeldung
 - geschärften Hinweis auf gemeinsam genutzte Geräte
@@ -26,6 +26,7 @@ const EMPTY_DATA: NotfallkarteData = {
 function deleteStoredData(): boolean {
   try {
     localStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem("notfallkarte-print-data");
     sessionStorage.removeItem("notfallkarte-print-data");
     return true;
   } catch {

--- a/qa/scripts/a11y-shared.mjs
+++ b/qa/scripts/a11y-shared.mjs
@@ -9,7 +9,13 @@ const __dirname = path.dirname(__filename);
 export const QA_DIR = path.resolve(__dirname, "..");
 export const BASE_URL = process.env.AUDIT_BASE_URL ?? "http://127.0.0.1:4173";
 
-export const ROUTES = ["/", "/soforthilfe", "/materialien", "/notfallkarte"];
+export const ROUTES = [
+  "/",
+  "/soforthilfe",
+  "/materialien",
+  "/notfallkarte",
+  "/notfallkarte/erstellen",
+];
 export const LIGHTHOUSE_ROUTES = ["/", "/soforthilfe", "/materialien"];
 
 export const VIEWPORTS = [


### PR DESCRIPTION
## What changed

- moves the interactive personal notfallkarte tool off the shadowed `/notfallkarte` URL onto `/notfallkarte/erstellen`
- keeps `/notfallkarte` as the static browser card and adds a direct link from that page into the personal tool
- switches the print handoff from `sessionStorage` to `localStorage` so data survives `window.open()` reliably
- aligns the static crisis and print pages with the canonical contact register for KIZ, Fachstelle Angehörigenarbeit, and Ärztefon Zürich
- adds regression coverage for the split-route and print-handoff failure modes
- closes the governance metadata drift for the affected high-risk routes and surfaces review badges on `/beratung`, `/datenschutz`, and `/quellen`

## Why

The release audit found two hard blockers:

1. `/notfallkarte` behaved differently depending on how users arrived there: direct load served the static HTML card, while in-app navigation rendered the React editor.
2. The editor's print flow wrote data to `sessionStorage`, but the opened print window could not reliably read that payload.

The audit also found contact drift on static crisis surfaces, where published numbers no longer matched the repo's canonical contact register.

## Impact

- direct loads and reloads of the personal tool now stay on a stable SPA route
- the static crisis card remains available as a standalone browser/download surface
- print/export from the personal tool now carries over the user's entered data
- static crisis surfaces now use the officially verified KIZ, Fachstelle, and Ärztefon values
- future regressions are covered by route and architecture tests

## Validation

- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- manual preview verification of:
  - `/notfallkarte`
  - `/notfallkarte/erstellen`
  - reload persistence on `/notfallkarte/erstellen`
  - print popup field transfer from the editor into `notfallkarte-print.html`
