### PR TITLE
Fix production route metadata and 404 shells

### DIFF
--- a/client/public/_redirects
+++ b/client/public/_redirects
@@ -1,3 +1,6 @@
+/unterstuetzen    /unterstuetzen/uebersicht   301!
+/selbsthilfegruppen    /beratung   301!
+/therapieangebote    /unterstuetzen/therapie#therapieangebote   301!
 /notfall    /soforthilfe   301!
 /soforthilfe    /soforthilfe/index.html   200!
-/*    /index.html   200
+/404    /404.html   404!

--- a/client/public/notfallkarte.html
+++ b/client/public/notfallkarte.html
@@ -8,6 +8,69 @@
       name="description"
       content="Notfallkarte Zürich: Alle wichtigen Nummern bei psychischen Krisen auf einer A4-Seite – für Angehörige."
     />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:title"
+      content="Notfallkarte Zürich – Psychische Krise v06"
+    />
+    <meta
+      property="og:description"
+      content="Notfallkarte Zürich: Alle wichtigen Nummern bei psychischen Krisen auf einer A4-Seite – für Angehörige."
+    />
+    <meta
+      property="og:url"
+      content="https://borderline-angehoerige.netlify.app/notfallkarte"
+    />
+    <meta
+      property="og:image"
+      content="https://borderline-angehoerige.netlify.app/og-image.jpg"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Notfallkarte Zürich – Psychische Krise v06"
+    />
+    <meta
+      name="twitter:description"
+      content="Notfallkarte Zürich: Alle wichtigen Nummern bei psychischen Krisen auf einer A4-Seite – für Angehörige."
+    />
+    <meta
+      name="twitter:image"
+      content="https://borderline-angehoerige.netlify.app/og-image.jpg"
+    />
+    <link
+      rel="canonical"
+      href="https://borderline-angehoerige.netlify.app/notfallkarte"
+    />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MedicalWebPage",
+        "name": "Notfallkarte Zürich – Psychische Krise",
+        "description": "Notfallkarte Zürich: Alle wichtigen Nummern bei psychischen Krisen auf einer A4-Seite – für Angehörige.",
+        "url": "https://borderline-angehoerige.netlify.app/notfallkarte",
+        "inLanguage": "de",
+        "about": {
+          "@type": "MedicalCondition",
+          "name": "Persönlichkeitsstörung mit Borderline-Muster",
+          "alternateName": ["Borderline-Muster", "Borderline pattern"],
+          "code": {
+            "@type": "MedicalCode",
+            "code": "6D11.5",
+            "codingSystem": "ICD-11"
+          }
+        },
+        "audience": {
+          "@type": "PeopleAudience",
+          "audienceType": "Angehörige von Menschen mit Borderline-Muster"
+        },
+        "lastReviewed": "2026-04-30",
+        "medicalAudience": {
+          "@type": "MedicalAudience",
+          "audienceType": "Caregiver"
+        }
+      }
+    </script>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>Notfallkarte Zürich – Psychische Krise v06</title>
     <link rel="stylesheet" href="/notfallkarte.css" />

--- a/client/public/soforthilfe/index.html
+++ b/client/public/soforthilfe/index.html
@@ -25,10 +25,52 @@
       property="og:image"
       content="https://borderline-angehoerige.netlify.app/og-image.jpg"
     />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="Soforthilfe – Borderline · Hilfe für Angehörige"
+    />
+    <meta
+      name="twitter:description"
+      content="Notfallnummern und Anlaufstellen für akute Krisen in der Schweiz."
+    />
+    <meta
+      name="twitter:image"
+      content="https://borderline-angehoerige.netlify.app/og-image.jpg"
+    />
     <link
       rel="canonical"
       href="https://borderline-angehoerige.netlify.app/soforthilfe"
     />
+    <script type="application/ld+json">
+      {
+        "@context": "https://schema.org",
+        "@type": "MedicalWebPage",
+        "name": "Soforthilfe",
+        "description": "Notfallnummern und Anlaufstellen für akute Krisen in der Schweiz. Robuste Direktseite für Soforthilfe, auch wenn die App nicht lädt.",
+        "url": "https://borderline-angehoerige.netlify.app/soforthilfe",
+        "inLanguage": "de",
+        "about": {
+          "@type": "MedicalCondition",
+          "name": "Persönlichkeitsstörung mit Borderline-Muster",
+          "alternateName": ["Borderline-Muster", "Borderline pattern"],
+          "code": {
+            "@type": "MedicalCode",
+            "code": "6D11.5",
+            "codingSystem": "ICD-11"
+          }
+        },
+        "audience": {
+          "@type": "PeopleAudience",
+          "audienceType": "Angehörige von Menschen mit Borderline-Muster"
+        },
+        "lastReviewed": "2026-04-30",
+        "medicalAudience": {
+          "@type": "MedicalAudience",
+          "audienceType": "Caregiver"
+        }
+      }
+    </script>
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <link rel="stylesheet" href="/fallback.css" />
   </head>

--- a/client/src/__tests__/direct-pages-architecture.test.ts
+++ b/client/src/__tests__/direct-pages-architecture.test.ts
@@ -36,7 +36,7 @@ describe("direct pages architecture", () => {
     expect(staticDirectPages).toEqual(["client/public/soforthilfe/index.html"]);
   });
 
-  it("keeps redirects focused on soforthilfe instead of overriding SPA routes", () => {
+  it("keeps redirects focused on real redirects instead of a SPA catch-all", () => {
     const redirects = fs.readFileSync(
       path.join(repoRoot, "client/public/_redirects"),
       "utf8"
@@ -45,23 +45,21 @@ describe("direct pages architecture", () => {
     expect(redirects).toContain(
       "/soforthilfe    /soforthilfe/index.html   200!"
     );
-    expect(redirects).not.toContain(
-      "/materialien    /materialien/index.html   200!"
+    expect(redirects).toContain(
+      "/unterstuetzen    /unterstuetzen/uebersicht   301!"
     );
-    expect(redirects).not.toContain(
-      "/selbsttest    /selbsttest/index.html   200!"
-    );
+    expect(redirects).toContain("/404    /404.html   404!");
+    expect(redirects).not.toContain("/*    /index.html   200");
   });
 
-  it("hardens the production server to explicit static direct-page routes", () => {
+  it("hardens the production server to explicit html shells plus a dedicated 404", () => {
     const serverIndex = fs.readFileSync(
       path.join(repoRoot, "server/index.ts"),
       "utf8"
     );
 
-    expect(serverIndex).toContain(
-      'const STATIC_DIRECT_PAGE_ROUTES = new Set(["/soforthilfe"])'
-    );
+    expect(serverIndex).toContain("getStaticHtmlCandidates");
+    expect(serverIndex).toContain('path.join(staticPath, "404.html")');
   });
 
   it("keeps static direct pages out of the SPA route registry", () => {

--- a/client/src/__tests__/seo-helpers.test.ts
+++ b/client/src/__tests__/seo-helpers.test.ts
@@ -52,6 +52,16 @@ describe("SEO helpers", () => {
     );
   });
 
+  it("uses page governance review dates for medical schema when available", () => {
+    const schema = buildMedicalPageSchemaData({
+      title: "Diagnostik",
+      description: "Beschreibung",
+      path: "/diagnostik",
+    });
+
+    expect(schema.lastReviewed).toBe("2026-04-30");
+  });
+
   it("builds breadcrumb schema with correct positions", () => {
     const schema = buildBreadcrumbSchemaData([
       { name: "Home", url: "https://example.com/" },

--- a/client/src/__tests__/static-route-shells.test.ts
+++ b/client/src/__tests__/static-route-shells.test.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import {
+  getGeneratedStaticRouteHeadMetadata,
+  getStaticRouteHeadMetadata,
+  renderStaticRouteHtml,
+} from "../../../shared/staticRouteShells";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "../../..");
+
+describe("static route shells", () => {
+  it("registers exact html shells for known routes and handout text pages", () => {
+    const routes = getGeneratedStaticRouteHeadMetadata().map(meta => meta.path);
+
+    expect(routes).toContain("/diagnostik");
+    expect(routes).toContain("/notfallkarte/erstellen");
+    expect(routes).toContain("/materialien/text/leuchtturm");
+    expect(routes).not.toContain("/soforthilfe");
+  });
+
+  it("renders route-specific metadata and json-ld into the startup shell html", () => {
+    const baseHtml = fs.readFileSync(
+      path.join(repoRoot, "client/index.html"),
+      "utf8"
+    );
+    const diagnostikMeta = getStaticRouteHeadMetadata("/diagnostik");
+
+    expect(diagnostikMeta).not.toBeNull();
+
+    const html = renderStaticRouteHtml(baseHtml, diagnostikMeta!);
+
+    expect(html).toContain(
+      "<title>Diagnostik – Borderline · Hilfe für Angehörige</title>"
+    );
+    expect(html).toContain(
+      'href="https://borderline-angehoerige.netlify.app/diagnostik"'
+    );
+    expect(html).toContain(
+      'property="og:title" content="Diagnostik – Borderline · Hilfe für Angehörige"'
+    );
+    expect(html).toContain('"@type":"MedicalWebPage"');
+    expect(html).toContain(">Diagnostik</h1>");
+  });
+
+  it("marks the dedicated 404 shell as noindex", () => {
+    const baseHtml = fs.readFileSync(
+      path.join(repoRoot, "client/index.html"),
+      "utf8"
+    );
+    const notFoundMeta = getStaticRouteHeadMetadata("/404");
+
+    expect(notFoundMeta).not.toBeNull();
+
+    const html = renderStaticRouteHtml(baseHtml, notFoundMeta!);
+
+    expect(html).toContain('name="robots" content="noindex, nofollow"');
+    expect(html).toContain(
+      "<title>Seite nicht gefunden – Borderline · Hilfe für Angehörige</title>"
+    );
+    expect(html).toContain(">Seite nicht gefunden</h1>");
+  });
+});

--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -1,4 +1,15 @@
 import { useEffect, useMemo } from "react";
+import {
+  buildBreadcrumbSchemaData,
+  buildCanonicalUrl,
+  buildFAQSchemaData,
+  buildFullTitle,
+  buildMedicalPageSchemaData,
+  buildMetaDescription,
+  buildOgImageUrl,
+  buildWebsiteSchemaData,
+  SITE_URL,
+} from "@/lib/seoMetadata";
 
 interface SEOProps {
   title?: string;
@@ -6,22 +17,8 @@ interface SEOProps {
   path?: string;
   type?: "website" | "article";
   canonicalPath?: string;
+  robots?: string;
 }
-
-const SITE_NAME = "Borderline · Hilfe für Angehörige";
-const BASE_DESCRIPTION =
-  "Evidenzbasierte Unterstützung für Angehörige von Menschen mit Borderline-Muster (Borderline-Persönlichkeitsstörung).";
-const DEFAULT_SITE_URL = "https://borderline-angehoerige.netlify.app";
-const SITE_URL = (import.meta.env.VITE_SITE_URL || DEFAULT_SITE_URL).replace(
-  /\/+$/,
-  ""
-);
-
-// Medical content must define review dates explicitly.
-const MEDICAL_LAST_REVIEWED =
-  import.meta.env.VITE_MEDICAL_LAST_REVIEWED || null;
-
-const buildOgImageUrl = (siteUrl = SITE_URL) => `${siteUrl}/og-image.jpg`;
 
 const getSiteUrl = () => {
   if (typeof window !== "undefined" && window.location?.origin) {
@@ -29,112 +26,15 @@ const getSiteUrl = () => {
   }
   return SITE_URL;
 };
-
-export function buildFullTitle(title?: string) {
-  return title
-    ? `${title} – ${SITE_NAME}`
-    : `${SITE_NAME} – Evidenzbasierte Unterstützung`;
-}
-
-export function buildMetaDescription(description?: string) {
-  return description || BASE_DESCRIPTION;
-}
-
-export function buildCanonicalUrl(path = "/", siteUrl = SITE_URL) {
-  return `${siteUrl}${path}`;
-}
-
-export function buildWebsiteSchemaData(siteUrl = SITE_URL) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "WebSite",
-    name: SITE_NAME,
-    alternateName: "Borderline Angehörige",
-    url: siteUrl,
-    description: BASE_DESCRIPTION,
-    publisher: {
-      "@type": "Organization",
-      name: SITE_NAME,
-      logo: {
-        "@type": "ImageObject",
-        url: buildOgImageUrl(siteUrl),
-      },
-    },
-    inLanguage: "de-CH",
-  };
-}
-
-export function buildMedicalPageSchemaData({
-  title,
-  description,
-  path,
-  siteUrl = SITE_URL,
-}: {
-  title: string;
-  description: string;
-  path: string;
-  siteUrl?: string;
-}) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "MedicalWebPage",
-    name: title,
-    description,
-    url: buildCanonicalUrl(path, siteUrl),
-    inLanguage: "de",
-    about: {
-      "@type": "MedicalCondition",
-      name: "Persönlichkeitsstörung mit Borderline-Muster",
-      alternateName: ["Borderline-Muster", "Borderline pattern"],
-      code: {
-        "@type": "MedicalCode",
-        code: "6D11.5",
-        codingSystem: "ICD-11",
-      },
-    },
-    audience: {
-      "@type": "PeopleAudience",
-      audienceType: "Angehörige von Menschen mit Borderline-Muster",
-    },
-    ...(MEDICAL_LAST_REVIEWED && { lastReviewed: MEDICAL_LAST_REVIEWED }),
-    medicalAudience: {
-      "@type": "MedicalAudience",
-      audienceType: "Caregiver",
-    },
-  };
-}
-
-export function buildBreadcrumbSchemaData(
-  items: { name: string; url: string }[]
-) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: items.map((item, i) => ({
-      "@type": "ListItem",
-      position: i + 1,
-      name: item.name,
-      item: item.url,
-    })),
-  };
-}
-
-export function buildFAQSchemaData(
-  questions: { question: string; answer: string }[]
-) {
-  return {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    mainEntity: questions.map(question => ({
-      "@type": "Question",
-      name: question.question,
-      acceptedAnswer: {
-        "@type": "Answer",
-        text: question.answer,
-      },
-    })),
-  };
-}
+export {
+  buildBreadcrumbSchemaData,
+  buildCanonicalUrl,
+  buildFAQSchemaData,
+  buildFullTitle,
+  buildMedicalPageSchemaData,
+  buildMetaDescription,
+  buildWebsiteSchemaData,
+};
 
 export default function SEO({
   title,
@@ -142,6 +42,7 @@ export default function SEO({
   path = "/",
   type = "website",
   canonicalPath,
+  robots,
 }: SEOProps) {
   const fullTitle = buildFullTitle(title);
   const metaDescription = buildMetaDescription(description);
@@ -166,6 +67,10 @@ export default function SEO({
       }
       el.setAttribute("content", content);
     };
+    const removeMeta = (name: string, isProperty = false) => {
+      const attr = isProperty ? "property" : "name";
+      document.querySelector(`meta[${attr}="${name}"]`)?.remove();
+    };
 
     updateMeta("description", metaDescription);
     updateMeta("og:title", fullTitle, true);
@@ -177,6 +82,11 @@ export default function SEO({
     updateMeta("twitter:title", fullTitle);
     updateMeta("twitter:description", metaDescription);
     updateMeta("twitter:image", ogImage);
+    if (robots) {
+      updateMeta("robots", robots);
+    } else {
+      removeMeta("robots");
+    }
 
     // Update canonical link
     let canonical = document.querySelector(
@@ -188,7 +98,7 @@ export default function SEO({
       document.head.appendChild(canonical);
     }
     canonical.href = canonicalUrl;
-  }, [canonicalPath, fullTitle, metaDescription, path, type]);
+  }, [canonicalPath, fullTitle, metaDescription, path, robots, type]);
 
   return null;
 }
@@ -220,15 +130,24 @@ export function MedicalPageSchema({
   title,
   description,
   path,
+  lastReviewed,
 }: {
   title: string;
   description: string;
   path: string;
+  lastReviewed?: string | null;
 }) {
   const siteUrl = getSiteUrl();
   const schema = useMemo(
-    () => buildMedicalPageSchemaData({ title, description, path, siteUrl }),
-    [description, path, siteUrl, title]
+    () =>
+      buildMedicalPageSchemaData({
+        title,
+        description,
+        path,
+        siteUrl,
+        lastReviewed,
+      }),
+    [description, lastReviewed, path, siteUrl, title]
   );
 
   useEffect(() => {

--- a/client/src/content/handoutTextMetas.ts
+++ b/client/src/content/handoutTextMetas.ts
@@ -1,0 +1,224 @@
+import { genesungItems } from "./genesung";
+import { grenzenItems } from "./grenzen";
+import { kommItems } from "./kommunizieren";
+import { materials, type MaterialCategory } from "./materialien";
+import { selbstfuersorgeInfografiken } from "./selbstfuersorge";
+import type { HandoutTextVersionMeta } from "./handoutTextVersionTypes";
+import { unterstuetzenItems } from "./unterstuetzen";
+import { verstehenInfografiken } from "./verstehen";
+
+const TOPIC_META: Record<
+  Exclude<MaterialCategory, "alle">,
+  { label: string; href: string }
+> = {
+  verstehen: { label: "Verstehen", href: "/verstehen" },
+  unterstuetzen: { label: "Unterstützen", href: "/unterstuetzen/uebersicht" },
+  kommunizieren: { label: "Kommunizieren", href: "/kommunizieren" },
+  grenzen: { label: "Grenzen", href: "/grenzen" },
+  selbstfuersorge: { label: "Selbstfürsorge", href: "/selbstfuersorge" },
+  genesung: { label: "Genesung", href: "/genesung" },
+  soforthilfe: { label: "Soforthilfe", href: "/soforthilfe" },
+};
+
+export const HANDOUT_TEXT_VERSION_IDS = [
+  "notfallplan-krise",
+  "leuchtturm",
+  "rolle-klaeren",
+  "im-krisenmodus",
+  "drei-saeulen",
+  "konsistenz-prinzip",
+  "beziehungs-achtsamkeit",
+  "6-leitlinien",
+  "4-alltags-tipps",
+  "eisberg",
+  "spaltung",
+  "krisenkommunikation",
+  "alarm-modus",
+  "4-phasen",
+  "gehirn",
+  "warnsignale",
+  "sauerstoffmaske",
+  "stopp-technik",
+  "energie-konto",
+  "erlaubnis-karte",
+  "schuld-verantwortung",
+  "radikale-akzeptanz",
+  "wenn-worte-treffen",
+  "gespraeche-kippen",
+  "grenzen-ohne-eskalation",
+  "pause-statt-streit",
+  "zuhoeren-ohne-zustimmen",
+  "beispiel-dialog",
+  "dear",
+  "spiegeln-statt-aufsaugen",
+  "4-arten-von-grenzen",
+  "grenzen-erkennen",
+  "lmk",
+  "genesung-zahlen",
+  "fortschritt-paradox",
+  "remission-heilung",
+  "5-faktoren-genesung",
+  "rolle-genesungsprozess",
+  "kinder",
+  "grenzen-spickzettel",
+] as const;
+
+function requireMaterial(id: string) {
+  const material = materials.find(item => item.id === id);
+  if (material) {
+    const pdfSourceUrl = material.pdfUrl ?? material.downloadUrl;
+    if (!pdfSourceUrl) {
+      throw new Error(`Material item is missing a PDF source: ${id}`);
+    }
+
+    return {
+      title: material.title,
+      description: material.description,
+      category: material.category,
+      kind: material.kind,
+      previewImageUrl: material.url,
+      topic: TOPIC_META[material.category],
+      pdfSourceUrl,
+    };
+  }
+
+  const verstehenMaterial = verstehenInfografiken.find(item => item.id === id);
+  if (verstehenMaterial) {
+    return {
+      title: verstehenMaterial.title,
+      description: verstehenMaterial.description,
+      category: "verstehen" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: verstehenMaterial.webpUrl,
+      topic: TOPIC_META.verstehen,
+      pdfSourceUrl: verstehenMaterial.pdfUrl,
+    };
+  }
+
+  const unterstuetzenMaterial = unterstuetzenItems.find(item => item.id === id);
+  if (unterstuetzenMaterial) {
+    return {
+      title: unterstuetzenMaterial.title,
+      description: unterstuetzenMaterial.title,
+      category: "unterstuetzen" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: unterstuetzenMaterial.url,
+      topic: TOPIC_META.unterstuetzen,
+      pdfSourceUrl: unterstuetzenMaterial.pdfUrl,
+    };
+  }
+
+  const kommunizierenMaterial = kommItems.find(item => item.id === id);
+  if (kommunizierenMaterial) {
+    return {
+      title: kommunizierenMaterial.title,
+      description: kommunizierenMaterial.description,
+      category: "kommunizieren" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: kommunizierenMaterial.url,
+      topic: TOPIC_META.kommunizieren,
+      pdfSourceUrl: kommunizierenMaterial.pdfUrl,
+    };
+  }
+
+  const grenzenMaterial = grenzenItems.find(item => item.id === id);
+  if (grenzenMaterial) {
+    return {
+      title: grenzenMaterial.title,
+      description: grenzenMaterial.description,
+      category: "grenzen" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: grenzenMaterial.url,
+      topic: TOPIC_META.grenzen,
+      pdfSourceUrl: grenzenMaterial.pdfUrl,
+    };
+  }
+
+  const selbstfuersorgeMaterial = selbstfuersorgeInfografiken.find(
+    item => item.id === id
+  );
+  if (selbstfuersorgeMaterial) {
+    return {
+      title: selbstfuersorgeMaterial.title,
+      description: selbstfuersorgeMaterial.desc,
+      category: "selbstfuersorge" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: selbstfuersorgeMaterial.webp,
+      topic: TOPIC_META.selbstfuersorge,
+      pdfSourceUrl: selbstfuersorgeMaterial.pdf,
+    };
+  }
+
+  const genesungMaterial = genesungItems.find(item => item.id === id);
+  if (genesungMaterial) {
+    return {
+      title: genesungMaterial.title,
+      description: genesungMaterial.desc,
+      category: "genesung" as const,
+      kind: "Infografik" as const,
+      previewImageUrl: genesungMaterial.img,
+      topic: TOPIC_META.genesung,
+      pdfSourceUrl: genesungMaterial.pdf,
+    };
+  }
+
+  throw new Error(`Unknown material item: ${id}`);
+}
+
+function createHandoutTextVersionMeta(id: string): HandoutTextVersionMeta {
+  const {
+    title,
+    description,
+    category,
+    kind,
+    previewImageUrl,
+    topic,
+    pdfSourceUrl,
+  } = requireMaterial(id);
+
+  return {
+    id,
+    path: `/materialien/text/${id}`,
+    title,
+    description,
+    topicLabel: topic.label,
+    topicHref: topic.href,
+    category,
+    kind,
+    previewImageUrl,
+    pdfSourceUrl,
+  };
+}
+
+export const handoutTextVersionMetas = HANDOUT_TEXT_VERSION_IDS.map(id =>
+  createHandoutTextVersionMeta(id)
+);
+
+const handoutTextVersionMetasById = new Map(
+  handoutTextVersionMetas.map(version => [version.id, version])
+);
+const handoutTextVersionMetasBySource = new Map(
+  handoutTextVersionMetas.map(version => [version.pdfSourceUrl, version])
+);
+
+export function getHandoutTextVersionMeta(id: string | undefined) {
+  if (!id) {
+    return null;
+  }
+
+  return handoutTextVersionMetasById.get(id) ?? null;
+}
+
+export function getHandoutTextVersionBySource(sourceUrl: string | undefined) {
+  if (!sourceUrl) {
+    return null;
+  }
+
+  return handoutTextVersionMetasBySource.get(sourceUrl) ?? null;
+}
+
+export function getHandoutTextVersionHrefBySource(
+  sourceUrl: string | undefined
+) {
+  return getHandoutTextVersionBySource(sourceUrl)?.path ?? null;
+}

--- a/client/src/content/handoutTextVersions.ts
+++ b/client/src/content/handoutTextVersions.ts
@@ -1,14 +1,10 @@
-import { materials, type MaterialCategory } from "./materialien";
-import { genesungItems } from "./genesung";
-import { grenzenItems } from "./grenzen";
-import { kommItems } from "./kommunizieren";
-import { selbstfuersorgeInfografiken } from "./selbstfuersorge";
-import type {
-  HandoutTextVersion,
-  HandoutTextVersionMeta,
-} from "./handoutTextVersionTypes";
-import { unterstuetzenItems } from "./unterstuetzen";
-import { verstehenInfografiken } from "./verstehen";
+import {
+  getHandoutTextVersionBySource as getHandoutTextMetaBySource,
+  getHandoutTextVersionHrefBySource as getHandoutTextMetaHrefBySource,
+  getHandoutTextVersionMeta,
+  handoutTextVersionMetas,
+} from "./handoutTextMetas";
+import type { HandoutTextVersion } from "./handoutTextVersionTypes";
 
 type HandoutTextVersionContentModule = {
   getFullHandoutTextVersion: (
@@ -16,192 +12,11 @@ type HandoutTextVersionContentModule = {
   ) => HandoutTextVersion | null;
 };
 
-const TOPIC_META: Record<
-  Exclude<MaterialCategory, "alle">,
-  { label: string; href: string }
-> = {
-  verstehen: { label: "Verstehen", href: "/verstehen" },
-  unterstuetzen: { label: "Unterstützen", href: "/unterstuetzen/uebersicht" },
-  kommunizieren: { label: "Kommunizieren", href: "/kommunizieren" },
-  grenzen: { label: "Grenzen", href: "/grenzen" },
-  selbstfuersorge: { label: "Selbstfürsorge", href: "/selbstfuersorge" },
-  genesung: { label: "Genesung", href: "/genesung" },
-  soforthilfe: { label: "Soforthilfe", href: "/soforthilfe" },
-};
-
-const HANDOUT_TEXT_VERSION_IDS = [
-  "notfallplan-krise",
-  "leuchtturm",
-  "rolle-klaeren",
-  "im-krisenmodus",
-  "drei-saeulen",
-  "konsistenz-prinzip",
-  "beziehungs-achtsamkeit",
-  "6-leitlinien",
-  "4-alltags-tipps",
-  "eisberg",
-  "spaltung",
-  "krisenkommunikation",
-  "alarm-modus",
-  "4-phasen",
-  "gehirn",
-  "warnsignale",
-  "sauerstoffmaske",
-  "stopp-technik",
-  "energie-konto",
-  "erlaubnis-karte",
-  "schuld-verantwortung",
-  "radikale-akzeptanz",
-  "wenn-worte-treffen",
-  "gespraeche-kippen",
-  "grenzen-ohne-eskalation",
-  "pause-statt-streit",
-  "zuhoeren-ohne-zustimmen",
-  "beispiel-dialog",
-  "dear",
-  "spiegeln-statt-aufsaugen",
-  "4-arten-von-grenzen",
-  "grenzen-erkennen",
-  "lmk",
-  "genesung-zahlen",
-  "fortschritt-paradox",
-  "remission-heilung",
-  "5-faktoren-genesung",
-  "rolle-genesungsprozess",
-  "kinder",
-  "grenzen-spickzettel",
-] as const;
-
 const lazyContentModules = import.meta.glob("./handoutTextVersionContent.ts");
 
 const loadedHandoutTextVersionsById = new Map<string, HandoutTextVersion>();
 
-function requireMaterial(id: string) {
-  const material = materials.find(item => item.id === id);
-  if (material) {
-    const pdfSourceUrl = material.pdfUrl ?? material.downloadUrl;
-    if (!pdfSourceUrl) {
-      throw new Error(`Material item is missing a PDF source: ${id}`);
-    }
-
-    return {
-      title: material.title,
-      description: material.description,
-      category: material.category,
-      kind: material.kind,
-      previewImageUrl: material.url,
-      topic: TOPIC_META[material.category],
-      pdfSourceUrl,
-    };
-  }
-
-  const verstehenMaterial = verstehenInfografiken.find(item => item.id === id);
-  if (verstehenMaterial) {
-    return {
-      title: verstehenMaterial.title,
-      description: verstehenMaterial.description,
-      category: "verstehen" as const,
-      kind: "Infografik" as const,
-      previewImageUrl: verstehenMaterial.webpUrl,
-      topic: TOPIC_META.verstehen,
-      pdfSourceUrl: verstehenMaterial.pdfUrl,
-    };
-  }
-
-  const unterstuetzenMaterial = unterstuetzenItems.find(item => item.id === id);
-  if (unterstuetzenMaterial) {
-    return {
-      title: unterstuetzenMaterial.title,
-      description: unterstuetzenMaterial.title,
-      category: "unterstuetzen" as const,
-      kind: "Infografik" as const,
-      previewImageUrl: unterstuetzenMaterial.url,
-      topic: TOPIC_META.unterstuetzen,
-      pdfSourceUrl: unterstuetzenMaterial.pdfUrl,
-    };
-  }
-
-  const kommunizierenMaterial = kommItems.find(item => item.id === id);
-  if (kommunizierenMaterial) {
-    return {
-      title: kommunizierenMaterial.title,
-      description: kommunizierenMaterial.description,
-      category: "kommunizieren" as const,
-      kind: "Infografik" as const,
-      previewImageUrl: kommunizierenMaterial.url,
-      topic: TOPIC_META.kommunizieren,
-      pdfSourceUrl: kommunizierenMaterial.pdfUrl,
-    };
-  }
-
-  const grenzenMaterial = grenzenItems.find(item => item.id === id);
-  if (grenzenMaterial) {
-    return {
-      title: grenzenMaterial.title,
-      description: grenzenMaterial.description,
-      category: "grenzen" as const,
-      kind: "Infografik" as const,
-      previewImageUrl: grenzenMaterial.url,
-      topic: TOPIC_META.grenzen,
-      pdfSourceUrl: grenzenMaterial.pdfUrl,
-    };
-  }
-
-  const selbstfuersorgeMaterial = selbstfuersorgeInfografiken.find(
-    item => item.id === id
-  );
-  if (selbstfuersorgeMaterial) {
-    return {
-      title: selbstfuersorgeMaterial.title,
-      description: selbstfuersorgeMaterial.desc,
-      category: "selbstfuersorge" as const,
-      kind: "Infografik" as const,
-      previewImageUrl: selbstfuersorgeMaterial.webp,
-      topic: TOPIC_META.selbstfuersorge,
-      pdfSourceUrl: selbstfuersorgeMaterial.pdf,
-    };
-  }
-
-  const genesungMaterial = genesungItems.find(item => item.id === id);
-  if (genesungMaterial) {
-    return {
-      title: genesungMaterial.title,
-      description: genesungMaterial.desc,
-      category: "genesung" as const,
-      kind: "Infografik" as const,
-      previewImageUrl: genesungMaterial.img,
-      topic: TOPIC_META.genesung,
-      pdfSourceUrl: genesungMaterial.pdf,
-    };
-  }
-
-  throw new Error(`Unknown material item: ${id}`);
-}
-
-function createHandoutTextVersionMeta(id: string): HandoutTextVersionMeta {
-  const {
-    title,
-    description,
-    category,
-    kind,
-    previewImageUrl,
-    topic,
-    pdfSourceUrl,
-  } = requireMaterial(id);
-
-  return {
-    id,
-    path: `/materialien/text/${id}`,
-    title,
-    description,
-    topicLabel: topic.label,
-    topicHref: topic.href,
-    category,
-    kind,
-    previewImageUrl,
-    pdfSourceUrl,
-  };
-}
+export { getHandoutTextVersionMeta, handoutTextVersionMetas };
 
 async function loadContentModule() {
   const loader = lazyContentModules["./handoutTextVersionContent.ts"];
@@ -210,25 +25,6 @@ async function loadContentModule() {
   }
 
   return (await loader()) as HandoutTextVersionContentModule;
-}
-
-export const handoutTextVersionMetas = HANDOUT_TEXT_VERSION_IDS.map(id =>
-  createHandoutTextVersionMeta(id)
-);
-
-const handoutTextVersionMetasById = new Map(
-  handoutTextVersionMetas.map(version => [version.id, version])
-);
-const handoutTextVersionMetasBySource = new Map(
-  handoutTextVersionMetas.map(version => [version.pdfSourceUrl, version])
-);
-
-export function getHandoutTextVersionMeta(id: string | undefined) {
-  if (!id) {
-    return null;
-  }
-
-  return handoutTextVersionMetasById.get(id) ?? null;
 }
 
 export function getHandoutTextVersion(id: string | undefined) {
@@ -259,15 +55,11 @@ export async function loadHandoutTextVersion(id: string | undefined) {
 }
 
 export function getHandoutTextVersionBySource(sourceUrl: string | undefined) {
-  if (!sourceUrl) {
-    return null;
-  }
-
-  return handoutTextVersionMetasBySource.get(sourceUrl) ?? null;
+  return getHandoutTextMetaBySource(sourceUrl);
 }
 
 export function getHandoutTextVersionHrefBySource(
   sourceUrl: string | undefined
 ) {
-  return getHandoutTextVersionBySource(sourceUrl)?.path ?? null;
+  return getHandoutTextMetaHrefBySource(sourceUrl);
 }

--- a/client/src/lib/seoMetadata.ts
+++ b/client/src/lib/seoMetadata.ts
@@ -1,0 +1,143 @@
+import { pageGovernance } from "../data/pageGovernance";
+
+const IMPORT_META_ENV =
+  (
+    import.meta as ImportMeta & {
+      env?: Record<string, string | undefined>;
+    }
+  ).env ?? {};
+
+export const SITE_NAME = "Borderline · Hilfe für Angehörige";
+export const BASE_DESCRIPTION =
+  "Evidenzbasierte Unterstützung für Angehörige von Menschen mit Borderline-Muster (Borderline-Persönlichkeitsstörung).";
+export const DEFAULT_SITE_URL = "https://borderline-angehoerige.netlify.app";
+export const SITE_URL = (
+  IMPORT_META_ENV.VITE_SITE_URL || DEFAULT_SITE_URL
+).replace(/\/+$/, "");
+const MEDICAL_LAST_REVIEWED =
+  IMPORT_META_ENV.VITE_MEDICAL_LAST_REVIEWED || null;
+
+export function buildOgImageUrl(siteUrl = SITE_URL) {
+  return `${siteUrl}/og-image.jpg`;
+}
+
+export function buildFullTitle(title?: string) {
+  return title
+    ? `${title} – ${SITE_NAME}`
+    : `${SITE_NAME} – Evidenzbasierte Unterstützung`;
+}
+
+export function buildMetaDescription(description?: string) {
+  return description || BASE_DESCRIPTION;
+}
+
+export function buildCanonicalUrl(path = "/", siteUrl = SITE_URL) {
+  return `${siteUrl}${path}`;
+}
+
+export function buildWebsiteSchemaData(siteUrl = SITE_URL) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    alternateName: "Borderline Angehörige",
+    url: siteUrl,
+    description: BASE_DESCRIPTION,
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      logo: {
+        "@type": "ImageObject",
+        url: buildOgImageUrl(siteUrl),
+      },
+    },
+    inLanguage: "de-CH",
+  };
+}
+
+function resolveMedicalLastReviewed(
+  path: string,
+  lastReviewed?: string | null
+): string | null {
+  if (lastReviewed) {
+    return lastReviewed;
+  }
+
+  return pageGovernance[path]?.lastReviewed ?? MEDICAL_LAST_REVIEWED;
+}
+
+export function buildMedicalPageSchemaData({
+  title,
+  description,
+  path,
+  siteUrl = SITE_URL,
+  lastReviewed,
+}: {
+  title: string;
+  description: string;
+  path: string;
+  siteUrl?: string;
+  lastReviewed?: string | null;
+}) {
+  const resolvedLastReviewed = resolveMedicalLastReviewed(path, lastReviewed);
+
+  return {
+    "@context": "https://schema.org",
+    "@type": "MedicalWebPage",
+    name: title,
+    description,
+    url: buildCanonicalUrl(path, siteUrl),
+    inLanguage: "de",
+    about: {
+      "@type": "MedicalCondition",
+      name: "Persönlichkeitsstörung mit Borderline-Muster",
+      alternateName: ["Borderline-Muster", "Borderline pattern"],
+      code: {
+        "@type": "MedicalCode",
+        code: "6D11.5",
+        codingSystem: "ICD-11",
+      },
+    },
+    audience: {
+      "@type": "PeopleAudience",
+      audienceType: "Angehörige von Menschen mit Borderline-Muster",
+    },
+    ...(resolvedLastReviewed && { lastReviewed: resolvedLastReviewed }),
+    medicalAudience: {
+      "@type": "MedicalAudience",
+      audienceType: "Caregiver",
+    },
+  };
+}
+
+export function buildBreadcrumbSchemaData(
+  items: { name: string; url: string }[]
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: items.map((item, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+export function buildFAQSchemaData(
+  questions: { question: string; answer: string }[]
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: questions.map(question => ({
+      "@type": "Question",
+      name: question.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: question.answer,
+      },
+    })),
+  };
+}

--- a/client/src/pages/Begleiterkrankungen.tsx
+++ b/client/src/pages/Begleiterkrankungen.tsx
@@ -30,7 +30,7 @@ import EvidenceNote from "@/components/EvidenceNote";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import AppLink from "@/components/AppLink";
 import { emailByIdStrict, kontaktByIdStrict } from "@/data/kontakte";
@@ -106,6 +106,11 @@ export default function Begleiterkrankungen() {
   return (
     <Layout>
       <SEO
+        title="Begleiterkrankungen"
+        description="Komorbidität bei Borderline: warum Depression so oft dazukommt, was das für Angehörige bedeutet, und wie Behandlung sich dadurch verändert."
+        path="/begleiterkrankungen"
+      />
+      <MedicalPageSchema
         title="Begleiterkrankungen"
         description="Komorbidität bei Borderline: warum Depression so oft dazukommt, was das für Angehörige bedeutet, und wie Behandlung sich dadurch verändert."
         path="/begleiterkrankungen"

--- a/client/src/pages/Diagnostik.tsx
+++ b/client/src/pages/Diagnostik.tsx
@@ -29,7 +29,7 @@ import EvidenceNote from "@/components/EvidenceNote";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import AppLink from "@/components/AppLink";
 import {
@@ -136,6 +136,11 @@ export default function Diagnostik() {
   return (
     <Layout>
       <SEO
+        title="Diagnostik"
+        description="Wie eine Borderline-Diagnose entsteht: wer sie stellen darf, wie sie abläuft, was sie für Angehörige bedeutet — und wo im Kanton Zürich eine Abklärung möglich ist."
+        path="/diagnostik"
+      />
+      <MedicalPageSchema
         title="Diagnostik"
         description="Wie eine Borderline-Diagnose entsteht: wer sie stellen darf, wie sie abläuft, was sie für Angehörige bedeutet — und wo im Kanton Zürich eine Abklärung möglich ist."
         path="/diagnostik"

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -31,7 +31,7 @@ import EvidenceNote from "@/components/EvidenceNote";
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import { genesungItems as genesungMaterialItems } from "@/content/genesung";
 import { getHandoutOpenHref } from "@/content/handouts";
@@ -119,6 +119,11 @@ export default function Genesung() {
   return (
     <Layout>
       <SEO
+        title="Genesung"
+        description="Genesung bei Borderline: realistische Hoffnung, Langzeitverlauf und was das für Angehörige bedeutet."
+        path="/genesung"
+      />
+      <MedicalPageSchema
         title="Genesung"
         description="Genesung bei Borderline: realistische Hoffnung, Langzeitverlauf und was das für Angehörige bedeutet."
         path="/genesung"

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -27,7 +27,7 @@ import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import { grenzenItems } from "@/content/grenzen";
 import { getHandoutOpenHref } from "@/content/handouts";
@@ -153,6 +153,11 @@ export default function Grenzen() {
   return (
     <Layout>
       <SEO
+        title="Grenzen setzen"
+        description="Grenzen für Angehörige: Selbstschutz, Klarheit, Konsequenz und begrenzte Verfügbarkeit."
+        path="/grenzen"
+      />
+      <MedicalPageSchema
         title="Grenzen setzen"
         description="Grenzen für Angehörige: Selbstschutz, Klarheit, Konsequenz und begrenzte Verfügbarkeit."
         path="/grenzen"

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -38,6 +38,7 @@ export default function Home() {
         title="Borderline: Orientierung für Angehörige"
         description="Psychoedukative Unterstützung für Angehörige von Menschen mit Borderline-Muster."
         path="/"
+        lastReviewed="2026-04-30"
       />
 
       <EditorialLayout width="narrow">

--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -21,7 +21,7 @@ import {
 import ValidierungsStufenleiter from "@/components/interactive/ValidierungsStufenleiter";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import KommunizierenMaterialsSection from "@/sections/KommunizierenMaterialsSection";
 import {
@@ -75,6 +75,11 @@ export default function Kommunizieren() {
   return (
     <Layout>
       <SEO
+        title="Kommunizieren"
+        description="Kommunikation für Angehörige: Validierung, Timing, Deeskalation und klare Sprache in belasteten Gesprächen."
+        path="/kommunizieren"
+      />
+      <MedicalPageSchema
         title="Kommunizieren"
         description="Kommunikation für Angehörige: Validierung, Timing, Deeskalation und klare Sprache in belasteten Gesprächen."
         path="/kommunizieren"

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -18,6 +18,7 @@ export default function NotFound() {
         title="Seite nicht gefunden"
         description="Die gesuchte Seite existiert leider nicht."
         path="/404"
+        robots="noindex, nofollow"
       />
       <div className="min-h-[70vh] w-full flex items-center justify-center">
         <Card className="w-full max-w-lg mx-4 shadow-lg border-0 bg-white/80 backdrop-blur-sm">

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -16,7 +16,7 @@ import AppLink from "@/components/AppLink";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { ROT, GELB, GRUEN, type Kontakt } from "@/data/kontakte";
 import {
   NOTFALLKARTE_PRINT_STORAGE_KEY,
@@ -371,6 +371,11 @@ export default function Notfallkarte() {
   return (
     <Layout>
       <SEO
+        title="Persönliche Notfallkarte"
+        description="Erstellen Sie Ihre persönliche Notfallkarte mit den wichtigsten Nummern, Kontaktpersonen und Beruhigungsstrategien – zum Ausdrucken oder Speichern."
+        path={PERSONAL_NOTFALLKARTE_PATH}
+      />
+      <MedicalPageSchema
         title="Persönliche Notfallkarte"
         description="Erstellen Sie Ihre persönliche Notfallkarte mit den wichtigsten Nummern, Kontaktpersonen und Beruhigungsstrategien – zum Ausdrucken oder Speichern."
         path={PERSONAL_NOTFALLKARTE_PATH}

--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -20,7 +20,7 @@ import {
 } from "@/components/editorial";
 import Layout from "@/components/Layout";
 import ReviewBadge from "@/components/ReviewBadge";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 
 interface QuelleEintrag {
   autoren: string;
@@ -418,6 +418,11 @@ export default function Quellen() {
         title="Quellen & Literatur"
         description="Wissenschaftliche Grundlagen und Fachliteratur dieser Website: klinische Studien, DBT-Literatur, Angehörigenbücher und Diagnoseklassifikationen."
         canonicalPath="/quellen"
+      />
+      <MedicalPageSchema
+        title="Quellen & Literatur"
+        description="Wissenschaftliche Grundlagen und Fachliteratur dieser Website: klinische Studien, DBT-Literatur, Angehörigenbücher und Diagnoseklassifikationen."
+        path="/quellen"
       />
 
       <EditorialLayout width="narrow">

--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -28,7 +28,7 @@ import EvidenceNote from "@/components/EvidenceNote";
 import SelbstfuersorgeCheck from "@/components/interactive/SelbstfuersorgeCheck";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import { permissionList } from "@/content/selbstfuersorge-page";
 import SelbstfuersorgeInfografikenSection from "@/sections/SelbstfuersorgeInfografikenSection";
@@ -68,6 +68,11 @@ export default function Selbstfuersorge() {
   return (
     <Layout>
       <SEO
+        title="Selbstfürsorge"
+        description="Selbstfürsorge für Angehörige: Burnout vermeiden und eigene Bedürfnisse wahrnehmen."
+        path="/selbstfuersorge"
+      />
+      <MedicalPageSchema
         title="Selbstfürsorge"
         description="Selbstfürsorge für Angehörige: Burnout vermeiden und eigene Bedürfnisse wahrnehmen."
         path="/selbstfuersorge"

--- a/client/src/pages/Selbsthilfegruppen.tsx
+++ b/client/src/pages/Selbsthilfegruppen.tsx
@@ -32,7 +32,7 @@ import {
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import ReviewBadge from "@/components/ReviewBadge";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import {
   emailByIdStrict,
   kontaktByIdStrict,
@@ -128,6 +128,11 @@ export default function Selbsthilfegruppen() {
         description="Professionelle Beratung, Selbsthilfegruppen und Netzwerke für Angehörige von Menschen mit Borderline in der Schweiz."
         path={currentPath}
         canonicalPath={canonicalPath}
+      />
+      <MedicalPageSchema
+        title="Beratung & Netzwerke"
+        description="Professionelle Beratung, Selbsthilfegruppen und Netzwerke für Angehörige von Menschen mit Borderline in der Schweiz."
+        path={canonicalPath}
       />
 
       <EditorialLayout width="narrow">

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -25,7 +25,7 @@ import {
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import { TableOfContents } from "@/components/UXEnhancements";
 import EnergieHaushaltVisualisierung from "@/components/visualizations/EnergieHaushaltVisualisierung";
@@ -268,6 +268,11 @@ export default function UnterstuetzenAlltag() {
   return (
     <Layout>
       <SEO
+        title="Unterstützen im Alltag"
+        description="Wie Angehörige im Alltag hilfreich bleiben können: verlässlich, klar und ohne sich selbst zu verlieren."
+        path="/unterstuetzen/alltag"
+      />
+      <MedicalPageSchema
         title="Unterstützen im Alltag"
         description="Wie Angehörige im Alltag hilfreich bleiben können: verlässlich, klar und ohne sich selbst zu verlieren."
         path="/unterstuetzen/alltag"

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -31,7 +31,7 @@ import {
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import { TableOfContents } from "@/components/UXEnhancements";
 import KrisenampelVisualisierung from "@/components/visualizations/KrisenampelVisualisierung";
@@ -321,6 +321,11 @@ export default function UnterstuetzenKrise() {
   return (
     <Layout>
       <SEO
+        title="Krisenbegleitung"
+        description="Krisenbegleitung bei Borderline: Wie Sie in akuten Situationen deeskalieren, Grenzen wahren und professionelle Hilfe richtig einbeziehen."
+        path="/unterstuetzen/krise"
+      />
+      <MedicalPageSchema
         title="Krisenbegleitung"
         description="Krisenbegleitung bei Borderline: Wie Sie in akuten Situationen deeskalieren, Grenzen wahren und professionelle Hilfe richtig einbeziehen."
         path="/unterstuetzen/krise"

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -28,7 +28,7 @@ import {
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import { TableOfContents } from "@/components/UXEnhancements";
 import RollenOrbitVisualisierung from "@/components/visualizations/RollenOrbitVisualisierung";
@@ -180,6 +180,11 @@ export default function UnterstuetzenTherapie() {
   return (
     <Layout>
       <SEO
+        title="Therapie unterstützen"
+        description="Wie Angehörige Behandlung unterstützen können, ohne mitzubehandeln oder die Verantwortung zu übernehmen."
+        path="/unterstuetzen/therapie"
+      />
+      <MedicalPageSchema
         title="Therapie unterstützen"
         description="Wie Angehörige Behandlung unterstützen können, ohne mitzubehandeln oder die Verantwortung zu übernehmen."
         path="/unterstuetzen/therapie"

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -25,7 +25,7 @@ import {
 } from "@/components/editorial";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import { TableOfContents } from "@/components/UXEnhancements";
 import { getHandoutOpenHref } from "@/content/handouts";
@@ -64,6 +64,11 @@ export default function UnterstuetzenUebersicht() {
   return (
     <Layout>
       <SEO
+        title="Unterstützen – Übersicht"
+        description="Wie Angehörige hilfreich bleiben können: Rolle, Krisenlogik, Grenzen und tragfähige Unterstützung."
+        path="/unterstuetzen/uebersicht"
+      />
+      <MedicalPageSchema
         title="Unterstützen – Übersicht"
         description="Wie Angehörige hilfreich bleiben können: Rolle, Krisenlogik, Grenzen und tragfähige Unterstützung."
         path="/unterstuetzen/uebersicht"

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -36,7 +36,7 @@ import {
 import EvidenceNote from "@/components/EvidenceNote";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import VerstehenMaterialsSection from "@/sections/VerstehenMaterialsSection";
 import {
@@ -94,6 +94,11 @@ export default function Verstehen() {
   return (
     <Layout>
       <SEO
+        title="Borderline verstehen"
+        description="Borderline aus Sicht von Angehörigen verstehen: Beziehungsdynamik, Überflutung, Nähe-Distanz und hilfreiche Einordnung."
+        path="/verstehen"
+      />
+      <MedicalPageSchema
         title="Borderline verstehen"
         description="Borderline aus Sicht von Angehörigen verstehen: Beziehungsdynamik, Überflutung, Nähe-Distanz und hilfreiche Einordnung."
         path="/verstehen"

--- a/client/src/pages/Wegweiser.tsx
+++ b/client/src/pages/Wegweiser.tsx
@@ -20,7 +20,7 @@ import { EditorialLayout } from "@/components/editorial";
 import AppLink from "@/components/AppLink";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
-import SEO from "@/components/SEO";
+import SEO, { MedicalPageSchema } from "@/components/SEO";
 import SituationsWegweiser from "@/components/interactive/SituationsWegweiser";
 import { kontaktByIdStrict } from "@/data/kontakte";
 import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
@@ -31,6 +31,11 @@ export default function Wegweiser() {
   return (
     <Layout>
       <SEO
+        title="Situations-Wegweiser"
+        description="Was tun, wenn Ihr Angehöriger in einer Krise ist? Unser interaktiver Wegweiser führt Sie Schritt für Schritt durch verschiedene Situationen."
+        path="/wegweiser"
+      />
+      <MedicalPageSchema
         title="Situations-Wegweiser"
         description="Was tun, wenn Ihr Angehöriger in einer Krise ist? Unser interaktiver Wegweiser führt Sie Schritt für Schritt durch verschiedene Situationen."
         path="/wegweiser"

--- a/netlify.toml
+++ b/netlify.toml
@@ -40,9 +40,33 @@
   force = true
 
 [[redirects]]
+  from = "/unterstuetzen"
+  to = "/unterstuetzen/uebersicht"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/selbsthilfegruppen"
+  to = "/beratung"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/therapieangebote"
+  to = "/unterstuetzen/therapie#therapieangebote"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/soforthilfe"
   to = "/soforthilfe/index.html"
   status = 200
+  force = true
+
+[[redirects]]
+  from = "/404"
+  to = "/404.html"
+  status = 404
   force = true
 
 [[redirects]]
@@ -56,8 +80,3 @@
   to = "/:splat.webp"
   status = 200
   force = true
-
-[[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,12 +4,14 @@ import fs from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
 import { SECURITY_HEADERS } from "../shared/securityHeaders";
+import {
+  getStaticHtmlCandidates,
+  STATIC_ROUTE_REDIRECTS,
+} from "../shared/staticRouteShells";
 import { createMaterialDownloadResponse } from "./material-download";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const STATIC_DIRECT_PAGE_ROUTES = new Set(["/soforthilfe"]);
-
 async function startServer() {
   const app = express();
   const server = createServer(app);
@@ -39,32 +41,33 @@ async function startServer() {
       ? path.resolve(__dirname, "public")
       : path.resolve(__dirname, "..", "dist", "public");
 
-  // Serve intentional static direct-access pages without the default / -> / redirect.
+  const resolveStaticHtmlFile = (pathname: string) => {
+    for (const candidate of getStaticHtmlCandidates(pathname)) {
+      const absolutePath = path.join(staticPath, candidate);
+      if (fs.existsSync(absolutePath)) {
+        return absolutePath;
+      }
+    }
+
+    return null;
+  };
+
+  // Serve prerendered HTML shells without directory redirects.
   app.get("/{*splat}", (req, res, next) => {
+    const redirect = STATIC_ROUTE_REDIRECTS.find(
+      route => route.from === req.path
+    );
+    if (redirect) {
+      return res.redirect(redirect.status, redirect.to);
+    }
+
     if (req.path === "/" || req.path.endsWith("/") || path.extname(req.path)) {
       return next();
     }
 
-    const routeDirectoryPath = path.join(
-      staticPath,
-      req.path.replace(/^\/+/, "")
-    );
-    const directPagePath = path.join(routeDirectoryPath, "index.html");
-
-    if (STATIC_DIRECT_PAGE_ROUTES.has(req.path)) {
-      if (!fs.existsSync(directPagePath)) {
-        return next();
-      }
-
-      return res.sendFile(directPagePath);
-    }
-
-    if (
-      fs.existsSync(routeDirectoryPath) &&
-      fs.statSync(routeDirectoryPath).isDirectory() &&
-      !fs.existsSync(directPagePath)
-    ) {
-      return res.sendFile(path.join(staticPath, "index.html"));
+    const staticHtmlFile = resolveStaticHtmlFile(req.path);
+    if (staticHtmlFile) {
+      return res.sendFile(staticHtmlFile);
     }
 
     return next();
@@ -72,11 +75,18 @@ async function startServer() {
 
   app.use(express.static(staticPath));
 
-  // Handle client-side routing - serve index.html for all non-file routes
-  app.get("/{*splat}", (_req, res) => {
-    // express.static already handles existing files (notfallkarte.html etc.)
-    // This catch-all is only for SPA client-side routes
-    res.sendFile(path.join(staticPath, "index.html"));
+  // Unknown HTML-like routes resolve to the dedicated 404 shell.
+  app.get("/{*splat}", (req, res, next) => {
+    if (path.extname(req.path)) {
+      return next();
+    }
+
+    const notFoundHtml = path.join(staticPath, "404.html");
+    if (fs.existsSync(notFoundHtml)) {
+      return res.status(404).sendFile(notFoundHtml);
+    }
+
+    return res.status(404).send("Seite nicht gefunden.");
   });
 
   const port = process.env.PORT || 3000;

--- a/shared/staticRouteShells.ts
+++ b/shared/staticRouteShells.ts
@@ -1,0 +1,532 @@
+import {
+  buildCanonicalUrl,
+  buildFullTitle,
+  buildMedicalPageSchemaData,
+  buildMetaDescription,
+  buildOgImageUrl,
+  buildWebsiteSchemaData,
+} from "../client/src/lib/seoMetadata";
+import { handoutTextVersionMetas } from "../client/src/content/handoutTextMetas";
+
+export interface StaticRouteHeadMetadata {
+  path: string;
+  title: string;
+  description: string;
+  canonicalPath?: string;
+  type?: "website" | "article";
+  robots?: string;
+  includeWebsiteSchema?: boolean;
+  includeMedicalSchema?: boolean;
+  medicalTitle?: string;
+  medicalDescription?: string;
+  medicalLastReviewed?: string | null;
+}
+
+export const STATIC_ROUTE_REDIRECTS = [
+  { from: "/notfall", to: "/soforthilfe", status: 301 },
+  { from: "/unterstuetzen", to: "/unterstuetzen/uebersicht", status: 301 },
+  { from: "/selbsthilfegruppen", to: "/beratung", status: 301 },
+  {
+    from: "/therapieangebote",
+    to: "/unterstuetzen/therapie#therapieangebote",
+    status: 301,
+  },
+] as const;
+
+export const SOURCE_STATIC_HTML_ROUTES = new Map<string, string>([
+  ["/soforthilfe", "soforthilfe/index.html"],
+  ["/notfallkarte", "notfallkarte.html"],
+]);
+
+const BASE_ROUTE_HEAD_METADATA: StaticRouteHeadMetadata[] = [
+  {
+    path: "/",
+    title: "Startseite",
+    description:
+      "Orientierung für Angehörige von Menschen mit Borderline: differenziert, fachlich fundiert und transparent eingeordnet.",
+    includeWebsiteSchema: true,
+    includeMedicalSchema: true,
+    medicalTitle: "Borderline: Orientierung für Angehörige",
+    medicalDescription:
+      "Psychoedukative Unterstützung für Angehörige von Menschen mit Borderline-Muster.",
+    medicalLastReviewed: "2026-04-30",
+  },
+  {
+    path: "/soforthilfe",
+    title: "Soforthilfe",
+    description:
+      "Notfallnummern und Anlaufstellen für akute Krisen in der Schweiz. Robuste Direktseite für Soforthilfe, auch wenn die App nicht lädt.",
+    includeMedicalSchema: true,
+    medicalLastReviewed: "2026-04-30",
+  },
+  {
+    path: "/notfallkarte",
+    title: "Notfallkarte Zürich – Psychische Krise v06",
+    description:
+      "Notfallkarte Zürich: Alle wichtigen Nummern bei psychischen Krisen auf einer A4-Seite – für Angehörige.",
+    includeMedicalSchema: true,
+    medicalTitle: "Notfallkarte Zürich – Psychische Krise",
+  },
+  {
+    path: "/notfallkarte/erstellen",
+    title: "Persönliche Notfallkarte",
+    description:
+      "Erstellen Sie Ihre persönliche Notfallkarte mit den wichtigsten Nummern, Kontaktpersonen und Beruhigungsstrategien – zum Ausdrucken oder Speichern.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/verstehen",
+    title: "Borderline verstehen",
+    description:
+      "Borderline aus Sicht von Angehörigen verstehen: Beziehungsdynamik, Überflutung, Nähe-Distanz und hilfreiche Einordnung.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/diagnostik",
+    title: "Diagnostik",
+    description:
+      "Wie eine Borderline-Diagnose entsteht: wer sie stellen darf, wie sie abläuft, was sie für Angehörige bedeutet — und wo im Kanton Zürich eine Abklärung möglich ist.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/begleiterkrankungen",
+    title: "Begleiterkrankungen",
+    description:
+      "Komorbidität bei Borderline: warum Depression so oft dazukommt, was das für Angehörige bedeutet, und wie Behandlung sich dadurch verändert.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/unterstuetzen/uebersicht",
+    title: "Unterstützen – Übersicht",
+    description:
+      "Wie Angehörige hilfreich bleiben können: Rolle, Krisenlogik, Grenzen und tragfähige Unterstützung.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/unterstuetzen/alltag",
+    title: "Unterstützen im Alltag",
+    description:
+      "Wie Angehörige im Alltag hilfreich bleiben können: verlässlich, klar und ohne sich selbst zu verlieren.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/unterstuetzen/therapie",
+    title: "Therapie unterstützen",
+    description:
+      "Wie Angehörige Behandlung unterstützen können, ohne mitzubehandeln oder die Verantwortung zu übernehmen.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/unterstuetzen/krise",
+    title: "Krisenbegleitung",
+    description:
+      "Krisenbegleitung bei Borderline: Wie Sie in akuten Situationen deeskalieren, Grenzen wahren und professionelle Hilfe richtig einbeziehen.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/kommunizieren",
+    title: "Kommunizieren",
+    description:
+      "Kommunikation für Angehörige: Validierung, Timing, Deeskalation und klare Sprache in belasteten Gesprächen.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/grenzen",
+    title: "Grenzen setzen",
+    description:
+      "Grenzen für Angehörige: Selbstschutz, Klarheit, Konsequenz und begrenzte Verfügbarkeit.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/selbstfuersorge",
+    title: "Selbstfürsorge",
+    description:
+      "Selbstfürsorge für Angehörige: Burnout vermeiden und eigene Bedürfnisse wahrnehmen.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/materialien",
+    title: "Materialien",
+    description:
+      "Ausgewählte Materialien, Infografiken und Notfallhilfen für Angehörige von Menschen mit Borderline.",
+  },
+  {
+    path: "/selbsttest",
+    title: "Selbsttest",
+    description:
+      "Selbsttest für Angehörige: Wie stark sind Sie gerade belastet? Anonyme Einschätzung in wenigen Minuten – mit Hinweisen auf passende Hilfsangebote.",
+  },
+  {
+    path: "/impressum",
+    title: "Impressum",
+    description: "Impressum und rechtliche Informationen.",
+  },
+  {
+    path: "/datenschutz",
+    title: "Datenschutz",
+    description:
+      "Datenschutzerklärung: Wie diese Website mit Daten umgeht, welche Cookies gesetzt werden und welche Rechte Sie haben.",
+  },
+  {
+    path: "/genesung",
+    title: "Genesung",
+    description:
+      "Genesung bei Borderline: realistische Hoffnung, Langzeitverlauf und was das für Angehörige bedeutet.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/beratung",
+    title: "Beratung & Netzwerke",
+    description:
+      "Professionelle Beratung, Selbsthilfegruppen und Netzwerke für Angehörige von Menschen mit Borderline in der Schweiz.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/feedback",
+    title: "Feedback",
+    description: "Rückmeldungen zur Website nehmen wir per E-Mail entgegen.",
+  },
+  {
+    path: "/glossar",
+    title: "Glossar",
+    description:
+      "Fachbegriffe rund um Borderline verständlich erklärt: von BPS über DBT bis Dysregulation – für Angehörige ohne Vorkenntnisse.",
+  },
+  {
+    path: "/buchempfehlungen",
+    title: "Buchempfehlungen",
+    description:
+      "Buchempfehlungen für Angehörige von Menschen mit Borderline: Ratgeber, Fachliteratur und DBT-Bücher – mit kurzen Einschätzungen zum Inhalt.",
+  },
+  {
+    path: "/faq",
+    title: "Häufige Fragen",
+    description:
+      "Häufige Fragen von Angehörigen zu Borderline: Verhalten in Krisen, Grenzen setzen, Kommunikation und Selbstschutz – klar und ohne Umschweife beantwortet.",
+  },
+  {
+    path: "/ueber-uns",
+    title: "Über uns",
+    description: "Über das Projekt Borderline · Hilfe für Angehörige.",
+  },
+  {
+    path: "/fachstelle",
+    title: "Fachstelle Angehörigenarbeit",
+    description:
+      "Fachstelle Angehörigenarbeit der Psychiatrischen Universitätsklinik Zürich (PUK). Beratung, Orientierung und Materialien für Angehörige.",
+  },
+  {
+    path: "/wegweiser",
+    title: "Situations-Wegweiser",
+    description:
+      "Was tun, wenn Ihr Angehöriger in einer Krise ist? Unser interaktiver Wegweiser führt Sie Schritt für Schritt durch verschiedene Situationen.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/uebungen",
+    title: "Kommunikations-Übungen",
+    description:
+      "Üben Sie SET, DEAR MAN und Validierung anhand realistischer Szenarien – interaktiv, mit Feedback und Erklärungen.",
+  },
+  {
+    path: "/quellen",
+    title: "Quellen & Literatur",
+    description:
+      "Wissenschaftliche Grundlagen und Fachliteratur dieser Website: klinische Studien, DBT-Literatur, Angehörigenbücher und Diagnoseklassifikationen.",
+    includeMedicalSchema: true,
+  },
+  {
+    path: "/barrierefreiheit",
+    title: "Barrierefreiheit",
+    description:
+      "Erklärung zur Barrierefreiheit dieser Website: Konformitätsziel, umgesetzte Massnahmen und Kontaktmöglichkeit bei Problemen.",
+  },
+  {
+    path: "/404",
+    title: "Seite nicht gefunden",
+    description: "Die gesuchte Seite existiert leider nicht.",
+    robots: "noindex, nofollow",
+  },
+];
+
+export const STATIC_ROUTE_HEAD_METADATA: StaticRouteHeadMetadata[] = [
+  ...BASE_ROUTE_HEAD_METADATA,
+  ...handoutTextVersionMetas.map(meta => ({
+    path: meta.path,
+    title: `${meta.title} – Textversion`,
+    description: meta.description,
+    includeMedicalSchema: true,
+  })),
+];
+
+const STATIC_ROUTE_HEAD_METADATA_BY_PATH = new Map(
+  STATIC_ROUTE_HEAD_METADATA.map(meta => [meta.path, meta])
+);
+
+export function getStaticRouteHeadMetadata(pathname: string) {
+  return STATIC_ROUTE_HEAD_METADATA_BY_PATH.get(pathname) ?? null;
+}
+
+export function getGeneratedStaticRouteHeadMetadata() {
+  return STATIC_ROUTE_HEAD_METADATA.filter(
+    meta => !SOURCE_STATIC_HTML_ROUTES.has(meta.path)
+  );
+}
+
+export function getGeneratedStaticHtmlOutputPath(pathname: string) {
+  if (pathname === "/") {
+    return "index.html";
+  }
+
+  if (pathname === "/404") {
+    return "404.html";
+  }
+
+  return `${pathname.replace(/^\/+/, "")}.html`;
+}
+
+export function getStaticHtmlCandidates(pathname: string) {
+  if (pathname === "/") {
+    return ["index.html"];
+  }
+
+  const trimmed = pathname.replace(/^\/+/, "");
+  const sourceStaticHtml = SOURCE_STATIC_HTML_ROUTES.get(pathname);
+
+  return [
+    ...(sourceStaticHtml ? [sourceStaticHtml] : []),
+    `${trimmed}.html`,
+    `${trimmed}/index.html`,
+  ];
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function removeStaticSchemaScripts(html: string) {
+  return html.replace(
+    /\s*<script[^>]+data-static-schema="[^"]+"[^>]*>[\s\S]*?<\/script>/gi,
+    ""
+  );
+}
+
+function upsertTitle(html: string, title: string) {
+  const tag = `<title>${escapeHtml(title)}</title>`;
+
+  if (/<title>[\s\S]*?<\/title>/i.test(html)) {
+    return html.replace(/<title>[\s\S]*?<\/title>/i, tag);
+  }
+
+  return html.replace("</head>", `  ${tag}\n  </head>`);
+}
+
+function upsertMetaTag(
+  html: string,
+  attribute: "name" | "property",
+  key: string,
+  content: string
+) {
+  const pattern = new RegExp(
+    `<meta[^>]+${attribute}=["']${escapeRegExp(key)}["'][^>]*>`,
+    "i"
+  );
+  const tag = `<meta ${attribute}="${key}" content="${escapeHtml(content)}" />`;
+
+  if (pattern.test(html)) {
+    return html.replace(pattern, tag);
+  }
+
+  return html.replace("</head>", `  ${tag}\n  </head>`);
+}
+
+function removeMetaTag(
+  html: string,
+  attribute: "name" | "property",
+  key: string
+) {
+  const pattern = new RegExp(
+    `\\s*<meta[^>]+${attribute}=["']${escapeRegExp(key)}["'][^>]*>`,
+    "gi"
+  );
+
+  return html.replace(pattern, "");
+}
+
+function upsertLinkTag(
+  html: string,
+  rel: string,
+  href: string,
+  extraAttributes = ""
+) {
+  const pattern = new RegExp(
+    `<link[^>]+rel=["']${escapeRegExp(rel)}["'][^>]*>`,
+    "i"
+  );
+  const tag = `<link rel="${rel}" href="${escapeHtml(href)}"${extraAttributes} />`;
+
+  if (pattern.test(html)) {
+    return html.replace(pattern, tag);
+  }
+
+  return html.replace("</head>", `  ${tag}\n  </head>`);
+}
+
+function buildStaticSchemaScripts(meta: StaticRouteHeadMetadata) {
+  const schemas: Array<{ key: string; data: Record<string, unknown> }> = [];
+
+  if (meta.includeWebsiteSchema) {
+    schemas.push({ key: "website", data: buildWebsiteSchemaData() });
+  }
+
+  if (meta.includeMedicalSchema) {
+    schemas.push({
+      key: `medical-${meta.path}`,
+      data: buildMedicalPageSchemaData({
+        title: meta.medicalTitle ?? meta.title,
+        description: meta.medicalDescription ?? meta.description,
+        path: meta.canonicalPath ?? meta.path,
+        lastReviewed: meta.medicalLastReviewed ?? null,
+      }),
+    });
+  }
+
+  return schemas
+    .map(
+      schema =>
+        `  <script type="application/ld+json" data-static-schema="${schema.key}">${JSON.stringify(schema.data).replace(/</g, "\\u003c")}</script>`
+    )
+    .join("\n");
+}
+
+function buildRoutePrerenderSection(meta: StaticRouteHeadMetadata) {
+  const primaryHref = meta.path === "/" ? "/verstehen" : "/";
+  const primaryLabel =
+    meta.path === "/" ? "Borderline besser verstehen" : "Zur Startseite";
+  const secondaryHref =
+    meta.path === "/" ? "/unterstuetzen/uebersicht" : "/materialien";
+  const secondaryLabel =
+    meta.path === "/" ? "Was hilft in meiner Lage?" : "Materialien öffnen";
+  const kicker =
+    meta.path === "/404"
+      ? "Diese Seite wurde nicht gefunden"
+      : "Die gewünschte Seite lädt";
+  const note =
+    meta.path === "/404"
+      ? "Nutzen Sie die Startseite oder Soforthilfe, um einen sicheren nächsten Schritt zu wählen."
+      : "Die vollständige Website lädt im Hintergrund.";
+
+  return [
+    '<section id="route-prerender">',
+    '  <div class="route-prerender-shell">',
+    '    <div class="route-prerender-topbar">',
+    '      <a class="route-prerender-brand" href="/">',
+    '        <span class="route-prerender-mark" aria-hidden="true">',
+    "          <svg",
+    '            viewBox="0 0 24 24"',
+    '            fill="none"',
+    '            stroke="currentColor"',
+    '            stroke-width="2"',
+    '            stroke-linecap="round"',
+    '            stroke-linejoin="round"',
+    "          >",
+    '            <path d="m16.24 7.76-1.804 5.411a2 2 0 0 1-1.265 1.265L7.76 16.24l1.804-5.411a2 2 0 0 1 1.265-1.265z" />',
+    '            <circle cx="12" cy="12" r="10" />',
+    "          </svg>",
+    "        </span>",
+    "        <span>Borderline · Hilfe für Angehörige</span>",
+    "      </a>",
+    "    </div>",
+    '    <div class="route-prerender-body">',
+    '      <div class="route-prerender-card">',
+    `        <p class="route-prerender-kicker">${escapeHtml(kicker)}</p>`,
+    `        <h1 class="route-prerender-title">${escapeHtml(meta.title)}</h1>`,
+    `        <p class="route-prerender-copy">${escapeHtml(meta.description)}</p>`,
+    '        <div class="route-prerender-actions">',
+    `          <a class="route-prerender-primary" href="${primaryHref}">${escapeHtml(primaryLabel)}</a>`,
+    `          <a href="${secondaryHref}">${escapeHtml(secondaryLabel)}</a>`,
+    "        </div>",
+    '        <a class="route-prerender-crisis" href="/soforthilfe">',
+    "          Akute Krise? Soforthilfe",
+    "        </a>",
+    `        <p class="route-prerender-note">${escapeHtml(note)}</p>`,
+    "      </div>",
+    "    </div>",
+    "  </div>",
+    "</section>",
+  ].join("\n");
+}
+
+function replaceRoutePrerenderSection(
+  html: string,
+  meta: StaticRouteHeadMetadata
+) {
+  const prerenderSection = buildRoutePrerenderSection(meta);
+
+  if (/<section id="route-prerender">[\s\S]*?<\/section>/i.test(html)) {
+    return html.replace(
+      /<section id="route-prerender">[\s\S]*?<\/section>/i,
+      prerenderSection
+    );
+  }
+
+  return html.replace("</body>", `${prerenderSection}\n  </body>`);
+}
+
+export function renderStaticRouteHtml(
+  baseHtml: string,
+  meta: StaticRouteHeadMetadata
+) {
+  const fullTitle = buildFullTitle(meta.title);
+  const description = buildMetaDescription(meta.description);
+  const canonicalUrl = buildCanonicalUrl(meta.canonicalPath ?? meta.path);
+  const htmlType = meta.type ?? "website";
+  const ogImageUrl = buildOgImageUrl();
+  const staticSchemaScripts = buildStaticSchemaScripts(meta);
+
+  let html = removeStaticSchemaScripts(baseHtml);
+
+  html = upsertTitle(html, fullTitle);
+  html = upsertMetaTag(html, "name", "description", description);
+  html = upsertMetaTag(html, "property", "og:type", htmlType);
+  html = upsertMetaTag(html, "property", "og:title", fullTitle);
+  html = upsertMetaTag(html, "property", "og:description", description);
+  html = upsertMetaTag(html, "property", "og:url", canonicalUrl);
+  html = upsertMetaTag(html, "property", "og:image", ogImageUrl);
+  html = upsertMetaTag(html, "property", "og:image:width", "1200");
+  html = upsertMetaTag(html, "property", "og:image:height", "630");
+  html = upsertMetaTag(html, "property", "og:locale", "de_CH");
+  html = upsertMetaTag(
+    html,
+    "property",
+    "og:site_name",
+    "Borderline · Hilfe für Angehörige"
+  );
+  html = upsertMetaTag(html, "name", "twitter:card", "summary_large_image");
+  html = upsertMetaTag(html, "name", "twitter:title", fullTitle);
+  html = upsertMetaTag(html, "name", "twitter:description", description);
+  html = upsertMetaTag(html, "name", "twitter:image", ogImageUrl);
+  html = upsertLinkTag(html, "canonical", canonicalUrl);
+
+  html = meta.robots
+    ? upsertMetaTag(html, "name", "robots", meta.robots)
+    : removeMetaTag(html, "name", "robots");
+
+  if (staticSchemaScripts) {
+    html = html.replace("</head>", `${staticSchemaScripts}\n</head>`);
+  }
+
+  if (meta.path !== "/") {
+    html = replaceRoutePrerenderSection(html, meta);
+  }
+
+  return html;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,14 @@ import path from "node:path";
 import { defineConfig, type Plugin, type ViteDevServer } from "vite";
 import { vitePluginManusRuntime } from "vite-plugin-manus-runtime";
 import { createMaterialDownloadResponse } from "./server/material-download";
+import {
+  getGeneratedStaticHtmlOutputPath,
+  getGeneratedStaticRouteHeadMetadata,
+  getStaticHtmlCandidates,
+  getStaticRouteHeadMetadata,
+  renderStaticRouteHtml,
+  STATIC_ROUTE_REDIRECTS,
+} from "./shared/staticRouteShells";
 
 // =============================================================================
 // Manus Debug Collector - Vite Plugin
@@ -154,20 +162,52 @@ function writeToLogFile(source: LogSource, entries: unknown[]) {
   trimLogFile(logPath, MAX_LOG_SIZE_BYTES);
 }
 
-const STATIC_DIRECT_PAGE_FILES = new Map([
-  ["/soforthilfe", "soforthilfe/index.html"],
-]);
-
 function normalizeRequestPath(reqUrl?: string) {
   const pathname = new URL(reqUrl ?? "/", "http://localhost").pathname;
   return pathname !== "/" ? pathname.replace(/\/+$/, "") : pathname;
 }
 
-function createStaticDirectPageMiddleware(rootDir: string) {
-  return (
+function resolveStaticHtmlFile(rootDir: string, pathname: string) {
+  for (const candidate of getStaticHtmlCandidates(pathname)) {
+    const absoluteFilePath = path.join(rootDir, candidate);
+    if (fs.existsSync(absoluteFilePath)) {
+      return absoluteFilePath;
+    }
+  }
+
+  return null;
+}
+
+function sendHtml(
+  req: { method?: string },
+  res: any,
+  html: Buffer | string,
+  status = 200
+) {
+  res.writeHead(status, {
+    "Content-Type": "text/html; charset=utf-8",
+    "Cache-Control": "no-cache",
+  });
+
+  if (req.method === "HEAD") {
+    res.end();
+    return;
+  }
+
+  res.end(html);
+}
+
+function createStaticHtmlRouteMiddleware(
+  rootDir: string,
+  options: {
+    dynamicShellRootDir?: string;
+    transformIndexHtml?: (url: string, html: string) => Promise<string>;
+  } = {}
+) {
+  return async (
     req: Parameters<ViteDevServer["middlewares"]["use"]>[1],
     res: any,
-    next: () => void
+    next: (error?: unknown) => void
   ) => {
     if (req.method !== "GET" && req.method !== "HEAD") {
       return next();
@@ -175,34 +215,66 @@ function createStaticDirectPageMiddleware(rootDir: string) {
 
     const pathname = normalizeRequestPath(req.url);
 
-    if (pathname === "/notfall") {
-      res.writeHead(302, { Location: "/soforthilfe" });
+    const redirect = STATIC_ROUTE_REDIRECTS.find(
+      route => route.from === pathname
+    );
+    if (redirect) {
+      res.writeHead(redirect.status, { Location: redirect.to });
       res.end();
       return;
     }
 
-    const relativeFilePath = STATIC_DIRECT_PAGE_FILES.get(pathname);
-    if (!relativeFilePath) {
-      return next();
+    if (!path.extname(pathname)) {
+      const absoluteStaticHtmlFile = resolveStaticHtmlFile(rootDir, pathname);
+      if (absoluteStaticHtmlFile) {
+        return sendHtml(
+          req,
+          res,
+          fs.readFileSync(absoluteStaticHtmlFile),
+          pathname === "/404" ? 404 : 200
+        );
+      }
     }
 
-    const absoluteFilePath = path.join(rootDir, relativeFilePath);
-    if (!fs.existsSync(absoluteFilePath)) {
-      return next();
+    if (!path.extname(pathname) && options.dynamicShellRootDir) {
+      const routeMeta = getStaticRouteHeadMetadata(pathname);
+      if (routeMeta) {
+        try {
+          const sourceIndexHtml = fs.readFileSync(
+            path.join(options.dynamicShellRootDir, "index.html"),
+            "utf8"
+          );
+          const prerenderedHtml = renderStaticRouteHtml(
+            sourceIndexHtml,
+            routeMeta
+          );
+          const transformedHtml = options.transformIndexHtml
+            ? await options.transformIndexHtml(
+                req.url ?? pathname,
+                prerenderedHtml
+              )
+            : prerenderedHtml;
+
+          return sendHtml(
+            req,
+            res,
+            transformedHtml,
+            pathname === "/404" ? 404 : 200
+          );
+        } catch (error) {
+          return next(error);
+        }
+      }
     }
 
-    const html = fs.readFileSync(absoluteFilePath);
-    res.writeHead(200, {
-      "Content-Type": "text/html; charset=utf-8",
-      "Cache-Control": "no-cache",
-    });
-
-    if (req.method === "HEAD") {
-      res.end();
-      return;
+    if (!path.extname(pathname)) {
+      const notFoundHtml = resolveStaticHtmlFile(rootDir, "/404");
+      if (notFoundHtml) {
+        return sendHtml(req, res, fs.readFileSync(notFoundHtml), 404);
+      }
     }
 
-    res.end(html);
+    return next();
   };
 }
 
@@ -336,18 +408,51 @@ function vitePluginStaticDirectPages(): Plugin {
 
     configureServer(server) {
       server.middlewares.use(
-        createStaticDirectPageMiddleware(
-          path.join(PROJECT_ROOT, "client", "public")
+        createStaticHtmlRouteMiddleware(
+          path.join(PROJECT_ROOT, "client", "public"),
+          {
+            dynamicShellRootDir: path.join(PROJECT_ROOT, "client"),
+            transformIndexHtml: (url, html) =>
+              server.transformIndexHtml(url, html),
+          }
         )
       );
     },
 
     configurePreviewServer(server) {
       server.middlewares.use(
-        createStaticDirectPageMiddleware(
+        createStaticHtmlRouteMiddleware(
           path.join(PROJECT_ROOT, "dist", "public")
         )
       );
+    },
+  };
+}
+
+function vitePluginStaticRouteShells(): Plugin {
+  return {
+    name: "static-route-shells",
+
+    closeBundle() {
+      const outputDir = path.join(PROJECT_ROOT, "dist", "public");
+      const baseHtmlPath = path.join(outputDir, "index.html");
+
+      if (!fs.existsSync(baseHtmlPath)) {
+        return;
+      }
+
+      const baseHtml = fs.readFileSync(baseHtmlPath, "utf8");
+
+      for (const routeMeta of getGeneratedStaticRouteHeadMetadata()) {
+        const renderedHtml = renderStaticRouteHtml(baseHtml, routeMeta);
+        const outputPath = path.join(
+          outputDir,
+          getGeneratedStaticHtmlOutputPath(routeMeta.path)
+        );
+
+        fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+        fs.writeFileSync(outputPath, renderedHtml, "utf8");
+      }
     },
   };
 }
@@ -359,6 +464,7 @@ export default defineConfig(({ command }) => {
     tailwindcss(),
     jsxLocPlugin(),
     vitePluginStaticDirectPages(),
+    vitePluginStaticRouteShells(),
   ];
 
   if (isServe) {


### PR DESCRIPTION
## Summary
- add prerendered static metadata shells for app routes and handout text pages
- return a dedicated 404 shell with noindex instead of falling back to generic index HTML
- align static crisis pages with canonical, Twitter, and JSON-LD metadata

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build