### PR TITLE
[codex] Deduplicate structured data hydration

### DIFF
--- a/client/src/__tests__/seo-structured-data.test.tsx
+++ b/client/src/__tests__/seo-structured-data.test.tsx
@@ -1,0 +1,54 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { MedicalPageSchema, WebsiteSchema } from "@/components/SEO";
+
+describe("SEO structured data hydration", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    document.head.innerHTML = "";
+    document.body.innerHTML = "";
+  });
+
+  it("reuses prerendered static schema scripts instead of duplicating them", () => {
+    document.head.innerHTML = `
+      <script type="application/ld+json" data-static-schema="website">{"@type":"WebSite","url":"https://borderline-angehoerige.netlify.app"}</script>
+      <script type="application/ld+json" data-static-schema="medical-/diagnostik">{"@type":"MedicalWebPage","url":"https://borderline-angehoerige.netlify.app/diagnostik"}</script>
+    `;
+
+    render(
+      <>
+        <WebsiteSchema />
+        <MedicalPageSchema
+          title="Diagnostik"
+          description="Beschreibung"
+          path="/diagnostik"
+        />
+      </>
+    );
+
+    const scripts = document.head.querySelectorAll(
+      'script[type="application/ld+json"]'
+    );
+    expect(scripts).toHaveLength(2);
+    expect(
+      document.head.querySelectorAll('script[data-static-schema="website"]')
+    ).toHaveLength(0);
+    expect(
+      document.head.querySelectorAll(
+        'script[data-static-schema="medical-/diagnostik"]'
+      )
+    ).toHaveLength(0);
+    expect(
+      document.head.querySelectorAll('script[data-schema="website"]')
+    ).toHaveLength(1);
+    expect(
+      document.head.querySelectorAll(
+        'script[data-schema="medical-/diagnostik"]'
+      )
+    ).toHaveLength(1);
+  });
+});

--- a/client/src/components/SEO.tsx
+++ b/client/src/components/SEO.tsx
@@ -36,6 +36,34 @@ export {
   buildWebsiteSchemaData,
 };
 
+function findSchemaScripts(schemaKey: string) {
+  return Array.from(
+    document.querySelectorAll(
+      `script[data-schema="${schemaKey}"], script[data-static-schema="${schemaKey}"]`
+    )
+  ) as HTMLScriptElement[];
+}
+
+function upsertSchemaScript(schemaKey: string, schema: unknown) {
+  const scripts = findSchemaScripts(schemaKey);
+  const primary = scripts[0] ?? document.createElement("script");
+
+  if (!scripts[0]) {
+    primary.setAttribute("type", "application/ld+json");
+    document.head.appendChild(primary);
+  }
+
+  primary.setAttribute("data-schema", schemaKey);
+  primary.removeAttribute("data-static-schema");
+  primary.textContent = JSON.stringify(schema);
+
+  for (const duplicate of scripts.slice(1)) {
+    duplicate.remove();
+  }
+
+  return primary;
+}
+
 export default function SEO({
   title,
   description,
@@ -109,14 +137,7 @@ export function WebsiteSchema() {
     const siteUrl = getSiteUrl();
     const schema = buildWebsiteSchemaData(siteUrl);
 
-    let el = document.querySelector('script[data-schema="website"]');
-    if (!el) {
-      el = document.createElement("script");
-      el.setAttribute("type", "application/ld+json");
-      el.setAttribute("data-schema", "website");
-      document.head.appendChild(el);
-    }
-    el.textContent = JSON.stringify(schema);
+    const el = upsertSchemaScript("website", schema);
     return () => {
       el?.remove();
     };
@@ -151,14 +172,7 @@ export function MedicalPageSchema({
   );
 
   useEffect(() => {
-    let el = document.querySelector(`script[data-schema="medical-${path}"]`);
-    if (!el) {
-      el = document.createElement("script");
-      el.setAttribute("type", "application/ld+json");
-      el.setAttribute("data-schema", `medical-${path}`);
-      document.head.appendChild(el);
-    }
-    el.textContent = JSON.stringify(schema);
+    const el = upsertSchemaScript(`medical-${path}`, schema);
     return () => {
       el?.remove();
     };
@@ -177,14 +191,7 @@ export function BreadcrumbSchema({
 
   useEffect(() => {
     const key = items.map(i => i.url).join("-");
-    let el = document.querySelector(`script[data-schema="breadcrumb-${key}"]`);
-    if (!el) {
-      el = document.createElement("script");
-      el.setAttribute("type", "application/ld+json");
-      el.setAttribute("data-schema", `breadcrumb-${key}`);
-      document.head.appendChild(el);
-    }
-    el.textContent = JSON.stringify(schema);
+    const el = upsertSchemaScript(`breadcrumb-${key}`, schema);
     return () => {
       el?.remove();
     };
@@ -202,14 +209,7 @@ export function FAQSchema({
   const schema = useMemo(() => buildFAQSchemaData(questions), [questions]);
 
   useEffect(() => {
-    let el = document.querySelector('script[data-schema="faq"]');
-    if (!el) {
-      el = document.createElement("script");
-      el.setAttribute("type", "application/ld+json");
-      el.setAttribute("data-schema", "faq");
-      document.head.appendChild(el);
-    }
-    el.textContent = JSON.stringify(schema);
+    const el = upsertSchemaScript("faq", schema);
     return () => {
       el?.remove();
     };


### PR DESCRIPTION
## Was sich aendert
- dedupliziert JSON-LD-Skripte bei der Client-Hydration in `client/src/components/SEO.tsx`
- uebernimmt vorhandene prerendered Shell-Skripte (`data-static-schema`) statt dieselben Schemas noch einmal neu anzulegen
- ergaenzt einen Regressionstest fuer den Hydration-Fall in `client/src/__tests__/seo-structured-data.test.tsx`

## Warum
Im Live-Recheck auf Production war die strukturierte Daten-Ausgabe auf mehreren Routen nach Hydration doppelt vorhanden. Die statischen Route-Shells lieferten bereits JSON-LD aus, und die React-SEO-Komponenten fuegten dieselben Schemas im Browser ein zweites Mal hinzu.

## Auswirkung
- `/` behaelt genau `2` Schema-Skripte (`WebSite`, `MedicalWebPage`)
- medizinische Inhaltsrouten wie `/diagnostik` und `/notfallkarte/erstellen` behalten je genau `1` `MedicalWebPage`-Schema
- das SEO-/Metadaten-Audit wird damit an der auffaelligsten offenen Stelle sauberer

## Validierung
- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- lokaler Preview-Check via Playwright:
  - `/` -> `jsonLdCount: 2`
  - `/diagnostik` -> `jsonLdCount: 1`
  - `/notfallkarte/erstellen` -> `jsonLdCount: 1`
