### PR TITLE
[codex] Fix PDF proxy runtime collision

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -10,8 +10,8 @@ import {
 } from "../shared/staticRouteShells";
 import { createMaterialDownloadResponse } from "./material-download";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const SERVER_MODULE_FILENAME = fileURLToPath(import.meta.url);
+const SERVER_MODULE_DIRNAME = path.dirname(SERVER_MODULE_FILENAME);
 async function startServer() {
   const app = express();
   const server = createServer(app);
@@ -38,8 +38,8 @@ async function startServer() {
   // Serve static files from dist/public in production
   const staticPath =
     process.env.NODE_ENV === "production"
-      ? path.resolve(__dirname, "public")
-      : path.resolve(__dirname, "..", "dist", "public");
+      ? path.resolve(SERVER_MODULE_DIRNAME, "public")
+      : path.resolve(SERVER_MODULE_DIRNAME, "..", "dist", "public");
 
   const resolveStaticHtmlFile = (pathname: string) => {
     for (const candidate of getStaticHtmlCandidates(pathname)) {

--- a/server/material-download.ts
+++ b/server/material-download.ts
@@ -8,11 +8,13 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { SECURITY_HEADERS } from "../shared/securityHeaders";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const MATERIAL_DOWNLOAD_MODULE_FILENAME = fileURLToPath(import.meta.url);
+const MATERIAL_DOWNLOAD_MODULE_DIRNAME = path.dirname(
+  MATERIAL_DOWNLOAD_MODULE_FILENAME
+);
 const LOCAL_PUBLIC_ROOTS = [
-  path.resolve(__dirname, "public"),
-  path.resolve(__dirname, "..", "client", "public"),
+  path.resolve(MATERIAL_DOWNLOAD_MODULE_DIRNAME, "public"),
+  path.resolve(MATERIAL_DOWNLOAD_MODULE_DIRNAME, "..", "client", "public"),
 ];
 
 export async function createMaterialDownloadResponse(


### PR DESCRIPTION
## Was geaendert wurde

- die modulweiten `__filename`- und `__dirname`-Konstanten in `server/index.ts` und `server/material-download.ts` auf eindeutig benannte Bezeichner umgestellt
- keine Verhaltensaenderung am Proxy selbst, nur den Runtime-Kollisionspunkt entfernt

## Warum

Production lieferte fuer `/api/material-download/:id` nur noch `502 Bad Gateway`. Der Body enthielt den Syntaxfehler:

`Identifier '__filename' has already been declared`

Der Hotfix macht die beiden Servermodule bundler-robust und beseitigt genau diesen Kollisionspunkt.

## Auswirkungen

- der PDF-Proxy kann wieder starten und lokale wie remote PDF-Responses wieder ausliefern
- keine Aenderung an den Material-IDs, Header-Regeln oder CTA-Pfaden

## Verifikation

- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- lokaler Production-Server-Check fuer:
  - `/api/material-download/notfallplan-krise?disposition=inline`
  - `/api/material-download/eisberg?disposition=inline`
  - `/api/material-download/leuchtturm?disposition=inline`
