### PR TITLE
[codex] Fix local PDF proxy fallback on Netlify

### DIFF
--- a/client/src/__tests__/security-headers.test.ts
+++ b/client/src/__tests__/security-headers.test.ts
@@ -93,4 +93,42 @@ describe("security headers", () => {
       1000
     );
   });
+
+  it("falls back to the public asset url when a local pdf is not on disk", async () => {
+    const existsSpy = vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("pdf", {
+          status: 200,
+          headers: {
+            "content-type": "application/pdf",
+            "cache-control": "public, max-age=0, must-revalidate",
+            "content-length": "3",
+          },
+        })
+      )
+    );
+
+    const response = await createMaterialDownloadResponse(
+      "notfallplan-krise",
+      "inline",
+      "https://borderline-angehoerige.netlify.app"
+    );
+
+    expect(existsSpy).toHaveBeenCalled();
+    expect(fetch).toHaveBeenCalledWith(
+      "https://borderline-angehoerige.netlify.app/notfallplan-krise-v03.pdf",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Accept: expect.stringContaining("application/pdf"),
+        }),
+      })
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Disposition")).toContain("inline;");
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, must-revalidate"
+    );
+  });
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -28,9 +28,11 @@ async function startServer() {
   app.get("/api/material-download/:id", async (req, res) => {
     const disposition =
       req.query.disposition === "inline" ? "inline" : "attachment";
+    const publicOrigin = getPublicOrigin(req);
     const response = await createMaterialDownloadResponse(
       req.params.id,
-      disposition
+      disposition,
+      publicOrigin
     );
     await sendResponse(res, response);
   });
@@ -106,4 +108,13 @@ async function sendResponse(res: express.Response, response: Response) {
 
   const body = Buffer.from(await response.arrayBuffer());
   res.end(body);
+}
+
+function getPublicOrigin(req: express.Request) {
+  const forwardedProto = req.get("x-forwarded-proto")?.split(",")[0]?.trim();
+  const forwardedHost = req.get("x-forwarded-host")?.split(",")[0]?.trim();
+  const host = forwardedHost || req.get("host");
+  const protocol = forwardedProto || req.protocol;
+
+  return host ? `${protocol}://${host}` : undefined;
 }

--- a/server/material-download.ts
+++ b/server/material-download.ts
@@ -19,7 +19,8 @@ const LOCAL_PUBLIC_ROOTS = [
 
 export async function createMaterialDownloadResponse(
   id: string,
-  disposition: HandoutDisposition = "attachment"
+  disposition: HandoutDisposition = "attachment",
+  publicOrigin?: string
 ) {
   const download = resolveHandoutAsset(id);
   if (!download) {
@@ -30,45 +31,19 @@ export async function createMaterialDownloadResponse(
     return createLocalMaterialDownloadResponse(
       download.sourceUrl,
       download.fileName,
-      disposition
+      disposition,
+      publicOrigin
     );
   }
 
   try {
-    const upstream = await fetch(download.sourceUrl, {
-      headers: {
-        Accept: "application/pdf,application/octet-stream;q=0.9,*/*;q=0.1",
-      },
-    });
-
-    if (!upstream.ok || !upstream.body) {
-      return createTextResponse("Download derzeit nicht verfügbar.", 502);
-    }
-
-    const headers = createSecurityHeaders();
-    headers.set(
-      "Content-Type",
-      upstream.headers.get("content-type") ?? "application/pdf"
+    const upstream = await fetchPdf(download.sourceUrl);
+    return createPdfProxyResponse(
+      upstream,
+      download.fileName,
+      disposition,
+      "public, max-age=31536000"
     );
-    headers.set(
-      "Cache-Control",
-      upstream.headers.get("cache-control") ?? "public, max-age=31536000"
-    );
-    headers.set(
-      "Content-Disposition",
-      contentDisposition(download.fileName, disposition)
-    );
-    headers.set("X-Content-Type-Options", "nosniff");
-
-    const contentLength = upstream.headers.get("content-length");
-    if (contentLength) {
-      headers.set("Content-Length", contentLength);
-    }
-
-    return new Response(upstream.body, {
-      status: 200,
-      headers,
-    });
   } catch {
     return createTextResponse("Download derzeit nicht verfügbar.", 502);
   }
@@ -77,32 +52,90 @@ export async function createMaterialDownloadResponse(
 async function createLocalMaterialDownloadResponse(
   sourceUrl: string,
   fileName: string,
-  disposition: HandoutDisposition
+  disposition: HandoutDisposition,
+  publicOrigin?: string
 ) {
   const absolutePath = resolveLocalPdfPath(sourceUrl);
-  if (!absolutePath) {
+  if (absolutePath) {
+    try {
+      const body = await readFile(absolutePath);
+      const headers = createSecurityHeaders();
+      headers.set("Content-Type", "application/pdf");
+      headers.set("Cache-Control", "public, max-age=0, must-revalidate");
+      headers.set(
+        "Content-Disposition",
+        contentDisposition(fileName, disposition)
+      );
+      headers.set("Content-Length", String(body.byteLength));
+      headers.set("X-Content-Type-Options", "nosniff");
+
+      return new Response(body, {
+        status: 200,
+        headers,
+      });
+    } catch {
+      return createTextResponse("Download derzeit nicht verfügbar.", 502);
+    }
+  }
+
+  if (!publicOrigin) {
     return createTextResponse("Material nicht gefunden.", 404);
   }
 
   try {
-    const body = await readFile(absolutePath);
-    const headers = createSecurityHeaders();
-    headers.set("Content-Type", "application/pdf");
-    headers.set("Cache-Control", "public, max-age=0, must-revalidate");
-    headers.set(
-      "Content-Disposition",
-      contentDisposition(fileName, disposition)
+    const upstream = await fetchPdf(
+      new URL(sourceUrl, publicOrigin).toString()
     );
-    headers.set("Content-Length", String(body.byteLength));
-    headers.set("X-Content-Type-Options", "nosniff");
-
-    return new Response(body, {
-      status: 200,
-      headers,
-    });
+    return createPdfProxyResponse(
+      upstream,
+      fileName,
+      disposition,
+      "public, max-age=0, must-revalidate"
+    );
   } catch {
     return createTextResponse("Download derzeit nicht verfügbar.", 502);
   }
+}
+
+async function fetchPdf(sourceUrl: string) {
+  return fetch(sourceUrl, {
+    headers: {
+      Accept: "application/pdf,application/octet-stream;q=0.9,*/*;q=0.1",
+    },
+  });
+}
+
+function createPdfProxyResponse(
+  upstream: Response,
+  fileName: string,
+  disposition: HandoutDisposition,
+  fallbackCacheControl: string
+) {
+  if (!upstream.ok || !upstream.body) {
+    return createTextResponse("Download derzeit nicht verfügbar.", 502);
+  }
+
+  const headers = createSecurityHeaders();
+  headers.set(
+    "Content-Type",
+    upstream.headers.get("content-type") ?? "application/pdf"
+  );
+  headers.set(
+    "Cache-Control",
+    upstream.headers.get("cache-control") ?? fallbackCacheControl
+  );
+  headers.set("Content-Disposition", contentDisposition(fileName, disposition));
+  headers.set("X-Content-Type-Options", "nosniff");
+
+  const contentLength = upstream.headers.get("content-length");
+  if (contentLength) {
+    headers.set("Content-Length", contentLength);
+  }
+
+  return new Response(upstream.body, {
+    status: 200,
+    headers,
+  });
 }
 
 function contentDisposition(fileName: string, disposition: HandoutDisposition) {


### PR DESCRIPTION
## Was geaendert wurde

- fuer lokale PDF-Assets im Download-Proxy einen Fallback ueber die oeffentliche Asset-URL der Site eingebaut
- `server/index.ts` erweitert, damit der Proxy die oeffentliche Origin aus dem Request weitergeben kann
- Test fuer den Serverless-/Netlify-Fall ergaenzt, in dem das PDF nicht im lokalen Dateisystem des Runtime-Bundles liegt

## Warum

Nach dem ersten Runtime-Hotfix war der Syntaxfehler auf Production weg, aber lokale PDFs ueber `/api/material-download/:id` lieferten weiterhin `404 Material nicht gefunden`.

Ursache: Im Netlify-Serverless-Deploy liegen die statischen PDF-Dateien nicht zwingend im Dateisystem des Function-Bundles. Der Proxy muss deshalb bei lokalen Assets von Dateisystem-Lookup auf die oeffentliche statische URL derselben Site zurueckfallen koennen.

## Auswirkungen

- lokale PDFs wie `notfallplan-krise` und `eisberg` koennen ueber den Proxy auch im Serverless-Deploy wieder korrekt ausgeliefert werden
- Remote-PDFs bleiben unveraendert
- Security-Header, `Content-Disposition` und Cache-Verhalten bleiben erhalten

## Verifikation

- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
- lokaler Production-Server-Check fuer `http://127.0.0.1:3108/api/material-download/notfallplan-krise?disposition=inline`
