### PR TITLE
[codex] Fix Netlify PDF origin fallback

### DIFF
--- a/client/src/__tests__/security-headers.test.ts
+++ b/client/src/__tests__/security-headers.test.ts
@@ -16,6 +16,9 @@ describe("security headers", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    delete process.env.URL;
+    delete process.env.DEPLOY_PRIME_URL;
+    delete process.env.SITE_URL;
   });
 
   it("keeps Netlify headers aligned with the shared server header set", () => {
@@ -130,5 +133,32 @@ describe("security headers", () => {
     expect(response.headers.get("Cache-Control")).toBe(
       "public, max-age=0, must-revalidate"
     );
+  });
+
+  it("uses the Netlify site url when no request origin is available", async () => {
+    vi.spyOn(fs, "existsSync").mockReturnValue(false);
+    process.env.URL = "https://borderline-angehoerige.netlify.app";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response("pdf", {
+          status: 200,
+          headers: {
+            "content-type": "application/pdf",
+          },
+        })
+      )
+    );
+
+    const response = await createMaterialDownloadResponse(
+      "notfallplan-krise",
+      "inline"
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://borderline-angehoerige.netlify.app/notfallplan-krise-v03.pdf",
+      expect.any(Object)
+    );
+    expect(response.status).toBe(200);
   });
 });

--- a/server/material-download.ts
+++ b/server/material-download.ts
@@ -78,13 +78,19 @@ async function createLocalMaterialDownloadResponse(
     }
   }
 
-  if (!publicOrigin) {
+  const resolvedPublicOrigin =
+    publicOrigin ??
+    process.env.URL ??
+    process.env.DEPLOY_PRIME_URL ??
+    process.env.SITE_URL;
+
+  if (!resolvedPublicOrigin) {
     return createTextResponse("Material nicht gefunden.", 404);
   }
 
   try {
     const upstream = await fetchPdf(
-      new URL(sourceUrl, publicOrigin).toString()
+      new URL(sourceUrl, resolvedPublicOrigin).toString()
     );
     return createPdfProxyResponse(
       upstream,


### PR DESCRIPTION
## Was geaendert wurde

- fuer lokale PDF-Assets im Proxy einen zusaetzlichen Fallback auf `process.env.URL`, `process.env.DEPLOY_PRIME_URL` und `process.env.SITE_URL` eingebaut
- Test ergaenzt, der genau diesen Netlify-Fall ohne expliziten Request-Origin abdeckt

## Warum

Nach dem vorherigen Hotfix war der Runtime-Crash weg und Remote-PDFs funktionierten wieder, lokale PDFs ueber den Proxy lieferten auf Production aber weiter `404 Material nicht gefunden`.

Das deutet darauf hin, dass im Netlify-Runtime-Kontext kein nutzbarer Origin aus dem Request ankommt. Mit dem Env-Fallback kann der Proxy trotzdem auf die oeffentliche statische PDF-URL derselben Site zurueckfallen.

## Auswirkungen

- lokale PDFs wie `notfallplan-krise` und `eisberg` sollen nun auch dann ueber den Proxy funktionieren, wenn kein Request-Origin aufloesbar ist
- Remote-PDFs bleiben unveraendert

## Verifikation

- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
