### PR TITLE
[codex] Document release sign-off and browser matrix

### DIFF
--- a/docs/governance/02-fachlicher-review-prozess.md
+++ b/docs/governance/02-fachlicher-review-prozess.md
@@ -39,3 +39,6 @@ Bei jedem Review prüfen:
 Jede Hochrisiko-Seite soll sichtbar enthalten:
 
 - fachlich geprüft am: Datum
+
+Für das formale Release-Sign-off kann zusätzlich die Vorlage
+`docs/governance/10-fachliche-freigabe-vorlage.md` verwendet werden.

--- a/docs/governance/06-release-checkliste.md
+++ b/docs/governance/06-release-checkliste.md
@@ -61,6 +61,10 @@ Pflicht-Scope:
 Dieses Gate soll vor Release von einer fachlich verantwortlichen Person
 gegengelesen und ausdrücklich freigegeben werden.
 
+Dokumentation:
+
+- `docs/governance/10-fachliche-freigabe-vorlage.md`
+
 ### Produktions-Crawl- und Link-Audit
 
 Vor Release systematisch prüfen:
@@ -171,6 +175,10 @@ Verbindliche Release-Matrix:
 Das ist hier release-relevant wegen langer Lesestrecken, sticky
 Navigation, Fokus-Management, Druckpfaden, lokaler Speicherung und den
 Soforthilfe- und Notfallpfaden.
+
+Dokumentation:
+
+- `qa/release-browser-matrix.md`
 
 ## Zusätzliche Audits mit hohem Nutzen
 

--- a/docs/governance/10-fachliche-freigabe-vorlage.md
+++ b/docs/governance/10-fachliche-freigabe-vorlage.md
@@ -1,0 +1,92 @@
+# Fachliche Freigabe-Vorlage
+
+Diese Vorlage ist für das formale Sign-off des Release-Gates
+`Fach- und Kontakt-Audit` gedacht.
+
+Sie kann:
+
+- in einen PR-Kommentar
+- in ein Release-Issue
+- in ein internes Freigabeprotokoll
+
+kopiert und dort ausgefüllt werden.
+
+## Wann verwenden
+
+Vor jedem Release mit Änderungen an:
+
+- Hochrisiko-Seiten
+- Kontakt- und Kriseninhalten
+- Diagnostik-, Quellen- oder Beratungsinhalten
+- lokalen Notfall-PDFs
+
+## Pflicht-Scope
+
+Mindestens diese Stellen prüfen, wenn sie vom Release betroffen sind:
+
+- `/soforthilfe`
+- `/notfallkarte`
+- `/notfallkarte/erstellen`
+- `/unterstuetzen/krise`
+- `/diagnostik`
+- `/begleiterkrankungen`
+- `/grenzen`
+- `/beratung`
+- `/quellen`
+- lokale Notfall-PDFs
+- `client/src/data/kontakte.ts`
+
+## Copy/Paste-Vorlage
+
+```md
+## Fachliche Freigabe
+
+- Release / PR:
+- Commit / Deploy-Stand:
+- Datum der Prüfung:
+- Fachlich prüfende Person:
+- Rolle / Funktion:
+
+### Geprüfter Scope
+
+- [ ] /soforthilfe
+- [ ] /notfallkarte
+- [ ] /notfallkarte/erstellen
+- [ ] /unterstuetzen/krise
+- [ ] /diagnostik
+- [ ] /begleiterkrankungen
+- [ ] /grenzen
+- [ ] /beratung
+- [ ] /quellen
+- [ ] lokale Notfall-PDFs
+- [ ] client/src/data/kontakte.ts
+
+### Prüfgegenstände
+
+- [ ] Notfallnummern korrekt
+- [ ] PUK- und Beratungsdaten korrekt
+- [ ] rechtliche Begriffe korrekt und nicht missverständlich
+- [ ] Quellen- und Krisenhinweise korrekt
+- [ ] lokale Relevanz für Schweiz / Zürich gegeben
+- [ ] Soforthilfe-Logik intakt
+- [ ] keine neue fachliche Aussage ohne belastbare Quelle
+
+### Ergebnis
+
+- [ ] fachlich freigegeben
+- [ ] freigegeben mit Auflagen
+- [ ] nicht freigegeben
+
+### Hinweise / Auflagen
+
+-
+
+### Nächster Review-Termin
+
+-
+```
+
+## Minimalregel
+
+Ohne dokumentiertes fachliches Sign-off soll ein Release mit Änderungen an
+Hochrisiko-Seiten nicht als vollständig freigegeben gelten.

--- a/docs/governance/README.md
+++ b/docs/governance/README.md
@@ -15,6 +15,7 @@ Die Dokumente sind bewusst nicht als juristische Formalität geschrieben, sonder
 7. `07-rollen-und-verantwortlichkeiten.md` — Rollenmodell für dauerhafte Pflege.
 8. `08-seiten-risikoklassifikation.md` — Risikoeinstufung der zentralen Seiten.
 9. `09-umsetzungsplan-90-tage.md` — erste Umsetzungsetappen.
+10. `10-fachliche-freigabe-vorlage.md` — Vorlage für fachliches Sign-off vor Release.
 
 ## Grundsatz
 

--- a/qa/README.md
+++ b/qa/README.md
@@ -38,6 +38,8 @@ Fuer den Content-Audit gilt explizit:
 
 - Repo-spezifische Prompt-Sammlung: [codex-audit-prompts.md](./codex-audit-prompts.md)
 - Vollstaendiger Repo-Plan: [audit-plan.md](./audit-plan.md)
+- Release-Matrix fuer echte Geraete-/Browser-Tests:
+  [release-browser-matrix.md](./release-browser-matrix.md)
 - Audit-Worktree-Helfer: [`_dev/create-audit-worktree.sh`](../_dev/create-audit-worktree.sh)
 
 ## Abgedeckte Audit-Spuren

--- a/qa/release-browser-matrix.md
+++ b/qa/release-browser-matrix.md
@@ -1,0 +1,103 @@
+# Release Browser Matrix
+
+Diese Matrix ist die operative Vorlage für den Release-Gate
+`Voller Geräte- und Browser-Release-Test`.
+
+Sie ist bewusst kurz gehalten und soll pro Release einmal vollständig
+abgehakt werden.
+
+## Pflicht-Matrix
+
+| Gerät          | Browser | Status   | Getestet am | Getestet von | Notizen |
+| -------------- | ------- | -------- | ----------- | ------------ | ------- |
+| iPhone         | Safari  | offen    |             |              |         |
+| iPhone         | Chrome  | offen    |             |              |         |
+| Android        | Chrome  | offen    |             |              |         |
+| Desktop        | Chrome  | offen    |             |              |         |
+| Desktop        | Firefox | offen    |             |              |         |
+| optional macOS | Safari  | optional |             |              |         |
+
+Status-Empfehlung:
+
+- `offen`
+- `bestanden`
+- `bestanden mit Hinweis`
+- `nicht bestanden`
+
+## Pflicht-Pfade pro Lauf
+
+Diese Pfade und Interaktionen sollten in jedem Matrix-Lauf mindestens
+einmal geprüft werden:
+
+### 1. Start und Navigation
+
+- `/`
+- Mobile Menu öffnen und schließen
+- Suche öffnen und schließen
+- Sticky Header über längere Scrollstrecke prüfen
+
+### 2. Krisenpfade
+
+- `/soforthilfe` direkt öffnen
+- zentrale CTAs und `tel:`-Links prüfen
+- `/notfallkarte` direkt öffnen
+- `/notfallkarte/erstellen` direkt öffnen
+
+### 3. Notfallkarte-Flow
+
+- Eingaben erfassen
+- Reload prüfen
+- Löschen prüfen
+- Zurück / Vorwärts prüfen
+- Druckpfad bzw. Druckansicht prüfen
+
+### 4. Materialien und Handouts
+
+- `/materialien`
+- Kategorien filtern
+- mindestens ein PDF inline öffnen
+- mindestens ein PDF herunterladen
+- mindestens eine Textversion öffnen
+
+### 5. Hochrisiko-Lesestrecken
+
+- `/diagnostik`
+- `/grenzen`
+- `/beratung`
+- `/quellen`
+
+Dabei prüfen:
+
+- Layout stabil
+- keine abgeschnittenen CTAs
+- Fokus sichtbar
+- keine überdeckten Klickziele
+- keine offensichtlichen Scroll- oder Schriftprobleme
+
+## Release-Protokoll
+
+```md
+## Browser-Matrix
+
+- Release / PR:
+- Datum:
+
+| Gerät          | Browser | Status | Notizen |
+| -------------- | ------- | ------ | ------- |
+| iPhone         | Safari  |        |         |
+| iPhone         | Chrome  |        |         |
+| Android        | Chrome  |        |         |
+| Desktop        | Chrome  |        |         |
+| Desktop        | Firefox |        |         |
+| optional macOS | Safari  |        |         |
+
+### Kritische Befunde
+
+-
+
+### Freigabeentscheidung
+
+- [ ] Matrix vollständig grün
+- [ ] grün mit dokumentierten Resthinweisen
+- [ ] nicht freigabefähig
+```


### PR DESCRIPTION
## Was sich aendert

- fuegt eine formale Vorlage fuer das fachliche Sign-off vor Release hinzu
- fuegt eine konkrete Release-Browser-Matrix fuer echte Geraete- und Browser-Checks hinzu
- verlinkt beide Artefakte aus Governance- und QA-Doku, damit die zwei noch offenen Release-Gates direkt abhakbar sind

## Warum

Die letzten offenen Follow-ups waren nicht mehr technische Fixes, sondern zwei organisatorische Release-Gates: fachliche Freigabe und vollstaendiger Geraete-/Browser-Test. Mit diesem PR werden beide in repo-taugliche Arbeitsartefakte uebersetzt.

## Wirkung

- fachliches Sign-off kann strukturiert dokumentiert werden
- die Browser-Matrix ist pro Release als klare Checkliste nutzbar
- die Release-Checkliste verweist jetzt direkt auf die passenden Vorlagen

## Validierung

- keine lokalen Tests ausgefuehrt, da reines Doku-Paket
- normale GitHub- und Netlify-Checks laufen im PR
