### PR TITLE
[codex] Tighten audit hygiene documentation

### DIFF
--- a/docs/governance/06-release-checkliste.md
+++ b/docs/governance/06-release-checkliste.md
@@ -114,6 +114,8 @@ Zusätzlich prüfen:
   `verifiedAt`
 - entspricht der PDF-Textlayer bzw. die Suchbarkeit dem erwarteten
   Qualitätsniveau
+- eine formale PDF/UA-Prüfung ist derzeit kein Pflicht-Gate; falls sie
+  gewünscht ist, muss sie als eigener Zusatzcheck dokumentiert werden
 
 ### Indexierungs-, SEO- und Metadaten-Audit auf Produktion
 

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",
+    "baseline-browser-mapping": "^2.10.25",
     "esbuild": "^0.25.0",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -137,6 +137,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^5.2.0
         version: 5.2.0(vite@7.3.2(@types/node@24.12.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      baseline-browser-mapping:
+        specifier: ^2.10.25
+        version: 2.10.25
       esbuild:
         specifier: ^0.25.0
         version: 0.25.10
@@ -1872,8 +1875,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  baseline-browser-mapping@2.8.13:
-    resolution: {integrity: sha512-7s16KR8io8nIBWQyCYhmFhd+ebIzb9VKTzki+wOJXHTxTnV6+mFGH3+Jwn1zoKaY9/H9T/0BcKCZnzXljPnpSQ==}
+  baseline-browser-mapping@2.10.25:
+    resolution: {integrity: sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==}
+    engines: {node: '>=6.0.0'}
     hasBin: true
 
   bidi-js@1.0.3:
@@ -4642,7 +4646,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  baseline-browser-mapping@2.8.13: {}
+  baseline-browser-mapping@2.10.25: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -4668,7 +4672,7 @@ snapshots:
 
   browserslist@4.26.3:
     dependencies:
-      baseline-browser-mapping: 2.8.13
+      baseline-browser-mapping: 2.10.25
       caniuse-lite: 1.0.30001748
       electron-to-chromium: 1.5.232
       node-releases: 2.0.23

--- a/qa/audit-content-sprache.md
+++ b/qa/audit-content-sprache.md
@@ -1,5 +1,12 @@
 # audit/content-sprache
 
+> Historischer Audit-Stand:
+> Dieser Bericht beschreibt den Repo- und Produktzustand zum damaligen
+> Audit-Zeitpunkt. Einzelne Befunde zu `files.manuscdn.com` sind
+> zwischenzeitlich technisch ueberholt und nicht als aktueller
+> Produktionsbefund zu lesen. Fuer den aktuellen Stand siehe
+> `docs/manus-cdn-audit.md` und `qa/audit-pdf-handouts.md`.
+
 ## Meta
 
 - Repo: `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige`

--- a/qa/audit-pdf-handouts.md
+++ b/qa/audit-pdf-handouts.md
@@ -125,3 +125,17 @@ Weiterhin als generelle Zukunftsregel sinnvoll:
 - Das Audit bewertet technische und strukturelle PDF-Qualitaet, nicht die
   fachliche Richtigkeit der Inhalte.
 - Es wurde bewusst keine vollstaendige PDF/UA-Zertifizierung geprueft.
+
+## PDF/UA-Einordnung
+
+- Der aktuelle gruene Befund bezieht sich auf:
+  - Dateierreichbarkeit
+  - Proxy-Verhalten
+  - A4-Konsistenz
+  - `Title`-Metadaten
+  - extrahierbaren Textlayer
+- Eine formale PDF/UA-Pruefung oder Zertifizierung ist damit ausdruecklich
+  nicht ersetzt.
+- Falls kuenftig ein hoeherer Accessibility-Standard fuer PDFs verlangt wird,
+  sollte PDF/UA als eigener Zusatzcheck mit separater Dokumentation behandelt
+  werden.

--- a/qa/audit-performance.md
+++ b/qa/audit-performance.md
@@ -1,5 +1,12 @@
 # audit/performance
 
+> Historischer Audit-Stand:
+> Dieser Bericht beschreibt den damaligen Mess- und Architekturstand.
+> Einzelne Hinweise zu entfernten `files.manuscdn.com`-Assets sind
+> inzwischen technisch ueberholt und nicht als aktueller
+> Produktionsbefund zu lesen. Fuer den aktuellen Stand siehe
+> `docs/manus-cdn-audit.md` und `qa/audit-pdf-handouts.md`.
+
 ## Meta
 
 - Repo: `/Users/christaegger/Documents/Webprojekte/borderline-angehoerige`


### PR DESCRIPTION
## Was sich aendert

- aktualisiert `baseline-browser-mapping` als direkte Dev-Abhaengigkeit, damit die bekannte Lint-Hinweiswarnung verschwindet
- markiert historische Audit-Dokumente mit alten `manuscdn`-Befunden sichtbar als historischen Stand
- ergaenzt die Release- und PDF-Doku um eine klare Einordnung, dass der aktuelle gruene PDF-Befund keine formale PDF/UA-Zertifizierung ersetzt

## Warum

Nach den technischen Fixes blieb noch etwas Repo-Hygiene offen: die wiederkehrende Baseline-Warnung, zwei leicht missverstaendliche historische Audit-Berichte und eine fehlende explizite PDF/UA-Abgrenzung.

## Wirkung

- `pnpm lint` laeuft ohne die fruehere `baseline-browser-mapping`-Hinweiswarnung
- historische Manus-Befunde sind als historischer Kontext gekennzeichnet
- PDF/UA ist als optionaler Zusatzcheck klar von den aktuell gruenen PDF-Kriterien getrennt

## Validierung

- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
