### PR TITLE
[codex] Fix notfallkarte fallback and review metadata drift

### DIFF
--- a/client/public/notfallkarte-print.html
+++ b/client/public/notfallkarte-print.html
@@ -694,62 +694,81 @@
 
     <script>
       (function () {
-        // ── Benutzerdaten aus localStorage laden ────────────────────────────
+        var PRINT_MESSAGE_TYPE = "notfallkarte-print-data";
+
+        function applyData(d) {
+          if (!d) return;
+
+          // Kontaktpersonen (bis zu 3 Zeilen)
+          var contacts = d.personalContacts || [];
+          for (var i = 0; i < 3; i++) {
+            var c = contacts[i];
+            var setField = function (id, val) {
+              var el = document.getElementById(id);
+              if (el && val) {
+                el.value = val;
+                el.removeAttribute("placeholder");
+              }
+            };
+            if (c) {
+              setField("contact-" + i + "-name", c.name);
+              setField("contact-" + i + "-phone", c.phone);
+              setField("contact-" + i + "-relation", c.relation);
+            }
+          }
+
+          // Beruhigungsstrategien (bis zu 4 Slots)
+          var strategies = d.calmingStrategies || [];
+          for (var j = 0; j < 4; j++) {
+            var s = strategies[j];
+            var sEl = document.getElementById("strategy-" + j);
+            if (sEl) {
+              if (s && s.text) {
+                sEl.value = s.text;
+                sEl.removeAttribute("placeholder");
+              } else if (j >= strategies.length) {
+                // Slot ist leer – Standardwert entfernen
+                sEl.value = "";
+                sEl.placeholder = "Eigene Strategie eingeben\u2026";
+              }
+            }
+          }
+
+          // Persönliche Notizen
+          var notesEl = document.getElementById("notes");
+          if (notesEl && d.notes) {
+            notesEl.value = d.notes;
+            notesEl.removeAttribute("placeholder");
+          }
+        }
+
+        // ── Benutzerdaten bevorzugt aus localStorage laden ─────────────────
         // Die React-App schreibt die Daten unter "notfallkarte-print-data"
-        // in localStorage, bevor sie dieses Fenster öffnet.
+        // in localStorage, bevor sie dieses Fenster öffnet. Wenn dieser
+        // Speicher blockiert ist, folgt die Übergabe per postMessage.
         try {
           var raw = localStorage.getItem("notfallkarte-print-data");
           if (raw) {
-            var d = JSON.parse(raw);
-
-            // Kontaktpersonen (bis zu 3 Zeilen)
-            var contacts = d.personalContacts || [];
-            for (var i = 0; i < 3; i++) {
-              var c = contacts[i];
-              var setField = function (id, val) {
-                var el = document.getElementById(id);
-                if (el && val) {
-                  el.value = val;
-                  el.removeAttribute("placeholder");
-                }
-              };
-              if (c) {
-                setField("contact-" + i + "-name", c.name);
-                setField("contact-" + i + "-phone", c.phone);
-                setField("contact-" + i + "-relation", c.relation);
-              }
-            }
-
-            // Beruhigungsstrategien (bis zu 4 Slots)
-            var strategies = d.calmingStrategies || [];
-            for (var j = 0; j < 4; j++) {
-              var s = strategies[j];
-              var sEl = document.getElementById("strategy-" + j);
-              if (sEl) {
-                if (s && s.text) {
-                  sEl.value = s.text;
-                  sEl.removeAttribute("placeholder");
-                } else if (j >= strategies.length) {
-                  // Slot ist leer – Standardwert entfernen
-                  sEl.value = "";
-                  sEl.placeholder = "Eigene Strategie eingeben\u2026";
-                }
-              }
-            }
-
-            // Persönliche Notizen
-            var notesEl = document.getElementById("notes");
-            if (notesEl && d.notes) {
-              notesEl.value = d.notes;
-              notesEl.removeAttribute("placeholder");
-            }
-
-            // Temporären localStorage-Eintrag nach Befüllung löschen
+            applyData(JSON.parse(raw));
             localStorage.removeItem("notfallkarte-print-data");
           }
         } catch (e) {
           // Fehler ignorieren – Felder bleiben leer / mit Platzhaltern
         }
+
+        window.addEventListener("message", function (event) {
+          if (event.origin !== window.location.origin) return;
+          var payload = event.data;
+          if (
+            !payload ||
+            payload.type !== PRINT_MESSAGE_TYPE ||
+            !payload.data
+          ) {
+            return;
+          }
+
+          applyData(payload.data);
+        });
 
         // ── Automatisch drucken wenn ?print=1 in der URL ────────────────────
         if (new URLSearchParams(window.location.search).get("print") === "1") {

--- a/client/public/notfallkarte.css
+++ b/client/public/notfallkarte.css
@@ -81,7 +81,11 @@ body {
   color: var(--nk-text-faint);
   font-size: 6.5pt;
   text-align: right;
-  white-space: nowrap;
+  line-height: 1.35;
+}
+
+.header-review {
+  color: white;
 }
 
 /* ── BLÖCKE ALLGEMEIN ─────────────────────── */

--- a/client/public/notfallkarte.html
+++ b/client/public/notfallkarte.html
@@ -83,7 +83,12 @@
         <header class="header">
           <h1 class="header-title">Notfallkarte Zürich – Psychische Krise</h1>
           <div class="header-meta">
-            Für Angehörige · PUK Zürich · v06 · 2026-03-10
+            <div>Für Angehörige · PUK Zürich · v06 · 2026-03-10</div>
+            <div class="header-review">Fachlich geprüft am: 30.04.2026</div>
+            <div class="header-review">Nächste Prüfung: 31.07.2026</div>
+            <div class="header-review">
+              Verantwortlich: Fachstelle Angehörigenarbeit
+            </div>
           </div>
           <div class="header-actions">
             <button type="button" id="print-notfallkarte" class="header-btn">

--- a/client/src/__tests__/handout-text-versions.test.tsx
+++ b/client/src/__tests__/handout-text-versions.test.tsx
@@ -101,6 +101,15 @@ describe("handout text versions", () => {
     expect(searchHrefs).toEqual(expectedTextVersionHrefs);
   });
 
+  it("keeps dedicated descriptions for unterstuetzen text versions", () => {
+    for (const item of unterstuetzenItems) {
+      const meta = getHandoutTextVersionMeta(item.id);
+
+      expect(meta?.description).toBe(item.description);
+      expect(meta?.description).not.toBe(item.title);
+    }
+  });
+
   it("keeps the html notfallkarte outside the text-version route set", () => {
     const notfallkarte = materials.find(
       item => item.id === "notfallkarte-zuerich"

--- a/client/src/__tests__/last-verified-badge.test.tsx
+++ b/client/src/__tests__/last-verified-badge.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import LastVerifiedBadge from "@/components/LastVerifiedBadge";
+import { pageGovernance } from "@/data/pageGovernance";
+
+const originalGenesung = { ...pageGovernance["/genesung"] };
+
+describe("LastVerifiedBadge", () => {
+  afterEach(() => {
+    pageGovernance["/genesung"] = { ...originalGenesung };
+  });
+
+  it("prefers governance dates when a path is provided", () => {
+    pageGovernance["/genesung"] = {
+      riskLevel: "medium",
+      lastReviewed: "2026-04-30",
+      nextReviewDue: "2027-04-30",
+      owner: "Fachstelle Angehörigenarbeit",
+    };
+
+    render(<LastVerifiedBadge path="/genesung" date="16.04.2026" />);
+
+    expect(
+      screen.getByText("Zuletzt verifiziert: 30.04.2026")
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to the explicit date when no governance metadata exists", () => {
+    render(<LastVerifiedBadge date="24.03.2026" />);
+
+    expect(
+      screen.getByText("Zuletzt verifiziert: 24.03.2026")
+    ).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/notfallkarte-architecture.test.ts
+++ b/client/src/__tests__/notfallkarte-architecture.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import { INFO } from "@/data/kontakte";
+import { pageGovernance } from "@/data/pageGovernance";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,6 +12,15 @@ const repoRoot = path.resolve(__dirname, "../../..");
 const KIZ = INFO.find(kontakt => kontakt.id === "INFO_KIZ");
 const FACHSTELLE = INFO.find(kontakt => kontakt.id === "INFO_FACHSTELLE");
 const AERZTEFON = INFO.find(kontakt => kontakt.id === "INFO_AERZTEFON");
+
+function formatDate(date?: string) {
+  if (!date) return null;
+
+  const [year, month, day] = date.split("-");
+  if (!year || !month || !day) return date;
+
+  return `${day}.${month}.${year}`;
+}
 
 describe("notfallkarte architecture", () => {
   it("keeps the personal tool off the static /notfallkarte URL", () => {
@@ -23,7 +33,7 @@ describe("notfallkarte architecture", () => {
     expect(routesIndex).toContain("PERSONAL_NOTFALLKARTE_PATH");
   });
 
-  it("uses localStorage for the print handoff that must survive window.open", () => {
+  it("keeps both persisted and direct print handoff paths available", () => {
     const pageSource = fs.readFileSync(
       path.join(repoRoot, "client/src/pages/Notfallkarte.tsx"),
       "utf8"
@@ -33,17 +43,16 @@ describe("notfallkarte architecture", () => {
       "utf8"
     );
 
+    expect(pageSource).toMatch(/savePrintData\(data\)/);
     expect(pageSource).toMatch(
-      /localStorage\.setItem\(\s*NOTFALLKARTE_PRINT_STORAGE_KEY,\s*JSON\.stringify\(data\)\s*\)/
+      /printWindow\.postMessage\(\s*payload,\s*window\.location\.origin\s*\)/
     );
     expect(printTemplate).toContain(
       'localStorage.getItem("notfallkarte-print-data")'
     );
+    expect(printTemplate).toContain('window.addEventListener("message"');
     expect(printTemplate).toContain(
       'localStorage.removeItem("notfallkarte-print-data")'
-    );
-    expect(printTemplate).not.toContain(
-      'sessionStorage.getItem("notfallkarte-print-data")'
     );
   });
 
@@ -85,5 +94,22 @@ describe("notfallkarte architecture", () => {
     expect(browserCardStyles).toContain("grid-template-columns: 1fr;");
     expect(browserCardScript).toContain("RESPONSIVE_BREAKPOINT = 860");
     expect(browserCardScript).toContain('pageWrapper.style.transform = "";');
+  });
+
+  it("shows the same review metadata on the static browser card as in governance", () => {
+    const browserCard = fs.readFileSync(
+      path.join(repoRoot, "client/public/notfallkarte.html"),
+      "utf8"
+    );
+    const governance = pageGovernance["/notfallkarte"];
+
+    expect(governance).toBeDefined();
+    expect(browserCard).toContain(
+      `Fachlich geprüft am: ${formatDate(governance?.lastReviewed)}`
+    );
+    expect(browserCard).toContain(
+      `Nächste Prüfung: ${formatDate(governance?.nextReviewDue)}`
+    );
+    expect(browserCard).toContain(`Verantwortlich: ${governance?.owner ?? ""}`);
   });
 });

--- a/client/src/__tests__/notfallkarte-storage.test.tsx
+++ b/client/src/__tests__/notfallkarte-storage.test.tsx
@@ -1,0 +1,127 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import type { ElementType, HTMLAttributes, ReactNode } from "react";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { Router } from "wouter";
+import Notfallkarte from "@/pages/Notfallkarte";
+
+const MOTION_PROPS = new Set([
+  "animate",
+  "exit",
+  "initial",
+  "layout",
+  "layoutId",
+  "onAnimationComplete",
+  "onUpdate",
+  "transition",
+  "variants",
+  "viewport",
+  "whileHover",
+  "whileInView",
+  "whileTap",
+]);
+
+function stripMotionProps(props: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(props).filter(([key]) => !MOTION_PROPS.has(key))
+  );
+}
+
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_target, tag: string) =>
+        ({
+          children,
+          ...props
+        }: HTMLAttributes<HTMLElement> & {
+          children?: ReactNode;
+        }) => {
+          const Tag = tag as ElementType;
+          return (
+            <Tag {...stripMotionProps(props as Record<string, unknown>)}>
+              {children}
+            </Tag>
+          );
+        },
+    }
+  ),
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+function renderPage() {
+  return render(
+    <Router>
+      <Notfallkarte />
+    </Router>
+  );
+}
+
+describe("Notfallkarte storage fallbacks", () => {
+  it("does not report a successful save when browser storage is blocked", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage blocked", "QuotaExceededError");
+    });
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {});
+
+    renderPage();
+
+    const saveButton = screen.getByRole("button", {
+      name: /im browser speichern/i,
+    });
+    fireEvent.click(saveButton);
+
+    expect(saveButton).toHaveTextContent("Im Browser speichern");
+    expect(screen.queryByText(/gespeichert ✓/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /speichern nicht möglich/i
+    );
+  });
+
+  it("falls back to direct window messaging for printing when localStorage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage blocked", "QuotaExceededError");
+    });
+    vi.spyOn(Storage.prototype, "removeItem").mockImplementation(() => {});
+
+    const postMessage = vi.fn();
+    const openSpy = vi.spyOn(window, "open").mockReturnValue({
+      postMessage,
+      closed: true,
+    } as unknown as Window);
+
+    renderPage();
+
+    fireEvent.click(screen.getByRole("button", { name: /jetzt drucken/i }));
+
+    expect(openSpy).toHaveBeenCalledWith("/notfallkarte-print.html", "_blank");
+    expect(postMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "notfallkarte-print-data" }),
+      window.location.origin
+    );
+  });
+});

--- a/client/src/components/LastVerifiedBadge.tsx
+++ b/client/src/components/LastVerifiedBadge.tsx
@@ -1,20 +1,36 @@
 import { RefreshCw } from "lucide-react";
+import { pageGovernance } from "@/data/pageGovernance";
 
 interface LastVerifiedBadgeProps {
-  date: string;
+  date?: string;
+  path?: string;
   className?: string;
+}
+
+function formatDate(date: string) {
+  const [year, month, day] = date.split("-");
+
+  if (!year || !month || !day) return date;
+
+  return `${day}.${month}.${year}`;
 }
 
 export default function LastVerifiedBadge({
   date,
+  path,
   className = "",
 }: LastVerifiedBadgeProps) {
+  const governanceDate = path ? pageGovernance[path]?.lastReviewed : null;
+  const resolvedDate = governanceDate ? formatDate(governanceDate) : date;
+
+  if (!resolvedDate) return null;
+
   return (
     <p
       className={`inline-flex items-center gap-1.5 rounded-full border border-border/70 bg-background px-2.5 py-1 text-xs text-muted-foreground ${className}`.trim()}
     >
       <RefreshCw className="h-3.5 w-3.5" />
-      Zuletzt verifiziert: {date}
+      Zuletzt verifiziert: {resolvedDate}
     </p>
   );
 }

--- a/client/src/content/handoutTextMetas.ts
+++ b/client/src/content/handoutTextMetas.ts
@@ -99,7 +99,7 @@ function requireMaterial(id: string) {
   if (unterstuetzenMaterial) {
     return {
       title: unterstuetzenMaterial.title,
-      description: unterstuetzenMaterial.title,
+      description: unterstuetzenMaterial.description,
       category: "unterstuetzen" as const,
       kind: "Infografik" as const,
       previewImageUrl: unterstuetzenMaterial.url,

--- a/client/src/content/unterstuetzen.ts
+++ b/client/src/content/unterstuetzen.ts
@@ -11,6 +11,8 @@ export const unterstuetzenItems = [
   {
     id: "im-krisenmodus",
     title: "Im Krisenmodus – Orientierung geben",
+    description:
+      "Das Ampel-System hilft, Anspannung, Eskalation und akute Gefahr schneller einzuordnen.",
     url: "/infografiken/ampel-das-ampel-system-v3.png",
     thumbnailUrl:
       "/infografiken/extras/thumbnails/ampel-das-ampel-system-v3.png",
@@ -20,6 +22,8 @@ export const unterstuetzenItems = [
   {
     id: "rolle-klaeren",
     title: "Ihre Rolle klären",
+    description:
+      "Klarheit über hilfreiche Unterstützung, Verantwortung und die Grenzen der Angehörigenrolle.",
     url: "/infografiken/sphären-die-einfluss-sphären-v3.png",
     thumbnailUrl:
       "/infografiken/extras/thumbnails/sphären-die-einfluss-sphären-v3.png",
@@ -29,6 +33,8 @@ export const unterstuetzenItems = [
   {
     id: "drei-saeulen",
     title: "Drei Säulen hilfreicher Unterstützung",
+    description:
+      "Drei tragende Prinzipien, damit Unterstützung stabil, klar und entlastend bleibt.",
     url: "/infografiken/manus-drei-saeulen-v1.webp",
     pdfUrl: "/infografiken/manus-drei-saeulen-v1.pdf",
     category: "grundlagen",
@@ -36,6 +42,8 @@ export const unterstuetzenItems = [
   {
     id: "konsistenz-prinzip",
     title: "Konsistenz-Prinzip",
+    description:
+      "Warum verlässliche, wiedererkennbare Reaktionen meist mehr helfen als spontane Kurswechsel.",
     url: "/infografiken/manus-konsistenz-prinzip-v1.webp",
     pdfUrl: "/infografiken/manus-konsistenz-prinzip-v1.pdf",
     category: "haltung",
@@ -43,6 +51,8 @@ export const unterstuetzenItems = [
   {
     id: "beziehungs-achtsamkeit",
     title: "Beziehungs-Achtsamkeit",
+    description:
+      "Orientierung, wie Nähe möglich bleibt, ohne Warnzeichen, Erschöpfung oder Grenzverletzungen zu übergehen.",
     url: "/infografiken/manus-beziehungs-achtsamkeit-v1.webp",
     pdfUrl: "/infografiken/manus-beziehungs-achtsamkeit-v1.pdf",
     category: "haltung",
@@ -50,6 +60,8 @@ export const unterstuetzenItems = [
   {
     id: "6-leitlinien",
     title: "6 Leitlinien für Angehörige",
+    description:
+      "Sechs alltagstaugliche Leitsätze für Präsenz, Klarheit und Selbstschutz in belasteten Phasen.",
     url: "/infografiken/manus-6-leitlinien-v1.webp",
     pdfUrl: "/infografiken/manus-6-leitlinien-v1.pdf",
     category: "alltag",
@@ -57,6 +69,8 @@ export const unterstuetzenItems = [
   {
     id: "4-alltags-tipps",
     title: "4 Alltags-Tipps",
+    description:
+      "Vier konkrete Hinweise, wie Unterstützung im Alltag ruhiger, klarer und tragfähiger werden kann.",
     url: "/infografiken/manus-4-alltags-tipps-v1.webp",
     pdfUrl: "/infografiken/manus-4-alltags-tipps-v1.pdf",
     category: "alltag",

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -175,7 +175,7 @@ export default function Genesung() {
           >
             Vollständig ca. 8 Min · Auch abschnittweise lesbar.
           </p>
-          <LastVerifiedBadge date="16.04.2026" className="mt-6" />
+          <LastVerifiedBadge path="/genesung" className="mt-6" />
         </header>
 
         {/* ── Intro: Was auf dieser Seite besonders wichtig ist ── */}

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -211,7 +211,7 @@ export default function Grenzen() {
           >
             Vollständig ca. 12 Min · Auch abschnittweise lesbar.
           </p>
-          <LastVerifiedBadge date="16.04.2026" className="mt-6" />
+          <LastVerifiedBadge path="/grenzen" className="mt-6" />
           <ReviewBadge path="/grenzen" />
         </header>
 

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -54,6 +54,7 @@ const EMPTY_DATA: NotfallkarteData = {
   calmingStrategies: DEFAULT_STRATEGIES,
   notes: "",
 };
+const NOTFALLKARTE_PRINT_MESSAGE_TYPE = "notfallkarte-print-data";
 
 function createId() {
   return Math.random().toString(36).slice(2, 9);
@@ -87,6 +88,15 @@ function isStorageAvailable(): boolean {
 function saveData(data: NotfallkarteData): boolean {
   try {
     localStorage.setItem(NOTFALLKARTE_STORAGE_KEY, JSON.stringify(data));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function savePrintData(data: NotfallkarteData): boolean {
+  try {
+    localStorage.setItem(NOTFALLKARTE_PRINT_STORAGE_KEY, JSON.stringify(data));
     return true;
   } catch {
     return false;
@@ -272,8 +282,15 @@ export default function Notfallkarte() {
   );
 
   const handleSave = useCallback(() => {
-    saveData(data);
+    if (!saveData(data)) {
+      setStorageError(true);
+      setSaved(false);
+      setAnnouncement("Speichern nicht möglich");
+      return;
+    }
+
     setSaved(true);
+    setAnnouncement("Im Browser gespeichert");
     if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
     savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
   }, [data]);
@@ -297,15 +314,47 @@ export default function Notfallkarte() {
   }, []);
 
   const handlePrint = useCallback(() => {
-    try {
-      localStorage.setItem(
-        NOTFALLKARTE_PRINT_STORAGE_KEY,
-        JSON.stringify(data)
-      );
-    } catch {
-      /* ignore */
+    const printWindow = window.open("/notfallkarte-print.html", "_blank");
+
+    if (!printWindow) {
+      setAnnouncement("Druckansicht konnte nicht geöffnet werden");
+      return;
     }
-    window.open("/notfallkarte-print.html", "_blank");
+
+    if (!savePrintData(data)) {
+      setStorageError(true);
+    }
+
+    const payload = {
+      type: NOTFALLKARTE_PRINT_MESSAGE_TYPE,
+      data,
+    };
+    let attempts = 0;
+    let intervalId: number | null = null;
+
+    const stopSending = () => {
+      if (intervalId !== null) {
+        window.clearInterval(intervalId);
+        intervalId = null;
+      }
+    };
+
+    const sendPayload = () => {
+      try {
+        printWindow.postMessage(payload, window.location.origin);
+      } catch {
+        /* ignore cross-window delivery failures */
+      }
+
+      attempts += 1;
+      if (attempts >= 10 || printWindow.closed) {
+        stopSending();
+      }
+    };
+
+    sendPayload();
+    intervalId = window.setInterval(sendPayload, 150);
+    window.setTimeout(stopSending, 1800);
   }, [data]);
 
   const addContact = useCallback(() => {

--- a/client/src/pages/Selbsthilfegruppen.tsx
+++ b/client/src/pages/Selbsthilfegruppen.tsx
@@ -172,7 +172,7 @@ export default function Selbsthilfegruppen() {
             suchen. Hier finden Sie Beratung, Selbsthilfe und weitere
             Anlaufstellen für Angehörige in der Schweiz.
           </p>
-          <LastVerifiedBadge date="24.03.2026" className="mt-6" />
+          <LastVerifiedBadge path={canonicalPath} className="mt-6" />
           <ReviewBadge path={canonicalPath} />
         </header>
 

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -31,6 +31,7 @@ import {
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
+import ReviewBadge from "@/components/ReviewBadge";
 import SEO, { MedicalPageSchema } from "@/components/SEO";
 import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import { TableOfContents } from "@/components/UXEnhancements";
@@ -405,7 +406,8 @@ export default function UnterstuetzenKrise() {
           >
             Vollständig ca. 6 Min · Auch abschnittweise lesbar.
           </p>
-          <LastVerifiedBadge date="16.04.2026" className="mt-6" />
+          <LastVerifiedBadge path="/unterstuetzen/krise" className="mt-6" />
+          <ReviewBadge path="/unterstuetzen/krise" />
         </header>
 
         {/* ── Disclaimer ── */}


### PR DESCRIPTION
## What changed
- harden the personal notfallkarte when browser storage is blocked, including a postMessage print fallback
- unify visible review badges with the central governance registry and show review metadata on the static notfallkarte page
- add real descriptions for `unterstuetzen` handouts so text-version SEO metadata is no longer title-only
- add regression coverage for storage denial, review date resolution, static review metadata, and unterstuetzen text-version descriptions

## Why
The previous audit found one real runtime bug in the emergency-card flow and two content/governance drifts:
- save/print fallback could fail silently exactly when storage was unavailable
- high-risk pages showed conflicting review freshness signals
- unterstuetzen text-version shells used the title as description

## Impact
- the notfallkarte flow is more reliable in private-mode or blocked-storage browsers
- review freshness is now sourced consistently from `pageGovernance.ts`
- text-version routes get stronger descriptions for search and previews

## Validation
- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
