### PR TITLE
[codex] Add infografik inventory workflow

### DIFF
--- a/client/src/__tests__/infografik-assets.test.ts
+++ b/client/src/__tests__/infografik-assets.test.ts
@@ -1,0 +1,24 @@
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { collectReferencedInfografikAssets } from "@/content/infografikAssetRefs";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../../..");
+const PUBLIC_ROOT = path.join(REPO_ROOT, "client", "public");
+
+describe("infografik assets", () => {
+  it("keeps every referenced infografik asset available in public/", () => {
+    const missingAssets = collectReferencedInfografikAssets()
+      .map(asset => ({
+        ...asset,
+        filePath: path.join(PUBLIC_ROOT, asset.path.replace(/^\//, "")),
+      }))
+      .filter(asset => !existsSync(asset.filePath))
+      .map(asset => ({
+        path: asset.path,
+        usages: asset.usages,
+      }));
+
+    expect(missingAssets).toEqual([]);
+  });
+});

--- a/client/src/content/infografikAssetRefs.ts
+++ b/client/src/content/infografikAssetRefs.ts
@@ -1,0 +1,144 @@
+import { genesungItems } from "./genesung";
+import { grenzenItems } from "./grenzen";
+import { kommItems } from "./kommunizieren";
+import { materials } from "./materialien";
+import { selbstfuersorgeInfografiken } from "./selbstfuersorge";
+import { unterstuetzenItems } from "./unterstuetzen";
+import { verstehenInfografiken } from "./verstehen";
+
+export type InfografikAssetUsage = {
+  source:
+    | "materials"
+    | "verstehen"
+    | "unterstuetzen"
+    | "kommunizieren"
+    | "grenzen"
+    | "selbstfuersorge"
+    | "genesung";
+  id: string;
+  field: string;
+};
+
+export type ReferencedInfografikAsset = {
+  path: string;
+  usages: InfografikAssetUsage[];
+};
+
+type AssetCandidate = {
+  source: InfografikAssetUsage["source"];
+  id: string;
+  fields: Record<string, string | undefined>;
+};
+
+function pushAssetReference(
+  registry: Map<string, ReferencedInfografikAsset>,
+  usage: InfografikAssetUsage,
+  assetPath: string | undefined
+) {
+  if (!assetPath || !assetPath.startsWith("/infografiken/")) {
+    return;
+  }
+
+  const existing = registry.get(assetPath);
+  if (existing) {
+    existing.usages.push(usage);
+    return;
+  }
+
+  registry.set(assetPath, {
+    path: assetPath,
+    usages: [usage],
+  });
+}
+
+function getAssetCandidates(): AssetCandidate[] {
+  return [
+    ...materials.map(item => ({
+      source: "materials" as const,
+      id: item.id,
+      fields: {
+        url: item.url,
+        thumbnailUrl: item.thumbnailUrl,
+        downloadUrl: item.downloadUrl,
+        pdfUrl: item.pdfUrl,
+        previewUrl: item.previewUrl,
+      },
+    })),
+    ...verstehenInfografiken.map(item => ({
+      source: "verstehen" as const,
+      id: item.id,
+      fields: {
+        webpUrl: item.webpUrl,
+        thumbnailUrl: item.thumbnailUrl,
+        pdfUrl: item.pdfUrl,
+      },
+    })),
+    ...unterstuetzenItems.map(item => ({
+      source: "unterstuetzen" as const,
+      id: item.id,
+      fields: {
+        url: item.url,
+        thumbnailUrl: item.thumbnailUrl,
+        pdfUrl: item.pdfUrl,
+      },
+    })),
+    ...kommItems.map(item => ({
+      source: "kommunizieren" as const,
+      id: item.id,
+      fields: {
+        url: item.url,
+        thumbnailUrl: item.thumbnailUrl,
+        pdfUrl: item.pdfUrl,
+      },
+    })),
+    ...grenzenItems.map(item => ({
+      source: "grenzen" as const,
+      id: item.id,
+      fields: {
+        url: item.url,
+        thumbnailUrl: item.thumbnailUrl,
+        pdfUrl: item.pdfUrl,
+      },
+    })),
+    ...selbstfuersorgeInfografiken.map(item => ({
+      source: "selbstfuersorge" as const,
+      id: item.id,
+      fields: {
+        webp: item.webp,
+        thumbnailUrl: item.thumbnailUrl,
+        pdf: item.pdf,
+      },
+    })),
+    ...genesungItems.map(item => ({
+      source: "genesung" as const,
+      id: item.id,
+      fields: {
+        img: item.img,
+        thumbnailUrl: item.thumbnailUrl,
+        pdf: item.pdf,
+      },
+    })),
+  ];
+}
+
+export function collectReferencedInfografikAssets() {
+  const registry = new Map<string, ReferencedInfografikAsset>();
+
+  for (const candidate of getAssetCandidates()) {
+    for (const [field, assetPath] of Object.entries(candidate.fields)) {
+      pushAssetReference(
+        registry,
+        {
+          source: candidate.source,
+          id: candidate.id,
+          field,
+        },
+        assetPath
+      );
+    }
+  }
+
+  return Array.from(registry.values()).sort((left, right) =>
+    left.path.localeCompare(right.path)
+  );
+}

--- a/docs/infografik-workflow.md
+++ b/docs/infografik-workflow.md
@@ -1,0 +1,129 @@
+# Infografik-Workflow
+
+Stand: 2026-05-02
+
+## Ziel
+
+Der Ordner `client/public/infografiken` ist produktiv wichtig, aber als
+Binarausgabe teuer in Pflege, Review und CI. Dieses Dokument beschreibt, wie
+aktive Web-Assets, Hilfsdateien und alte Versionsstaende auseinandergehalten
+werden.
+
+## Aktueller Inventarstand
+
+Der aktuelle Snapshot liegt in
+[`qa/infografik-inventory.json`](../qa/infografik-inventory.json) und wird
+ueber `pnpm audit:infografiken` erzeugt.
+
+Stand `2026-05-02`:
+
+- `167` Dateien insgesamt (`287.85 MB`)
+- `88` aktiv referenzierte Produktdateien (`131.18 MB`)
+- `5` Support-Dateien ausserhalb des Produktpfads (`41.26 MB`)
+- `74` unreferenzierte Kandidaten (`115.40 MB`)
+- `10` Versionsfamilien mit aktiven Dateien plus alten Geschwistern
+
+## Source of Truth
+
+- Produktiv aktive Pfade werden in `client/src/content/**` referenziert.
+- Das Audit-Skript liest genau diese Content-Register aus und behandelt sie als
+  kanonische Sicht auf den Bestand.
+- Eine Datei unter `client/public/infografiken` ist erst dann "aktiv", wenn sie
+  in diesen Content-Dateien referenziert wird.
+
+## Dateiklassen
+
+### 1. Aktive Produktdateien
+
+Direkt im Produkt referenzierte Assets, zum Beispiel:
+
+- `/infografiken/manus-<id>-v1.webp`
+- `/infografiken/manus-<id>-v1.pdf`
+- `/infografiken/<slug>-vN.png`
+- `/infografiken/<slug>-vN.pdf`
+- `/infografiken/extras/thumbnails/<slug>-vN.png`
+
+### 2. Support-Dateien
+
+Nicht direkt im Produkt referenziert, aber bewusst im Repo behalten:
+
+- `/infografiken/infografiken-final.zip`
+- `/infografiken/extras/README.txt`
+- `/infografiken/extras/infografiken-extras.zip`
+- `/infografiken/extras/uebersichtsbogen.png`
+- `/infografiken/extras/uebersichtsbogen.pdf`
+
+### 3. Legacy-Kandidaten
+
+Alte Versionsdateien, die im Produkt nicht mehr verwendet werden, aber noch im
+Ordner liegen, zum Beispiel fruehere `-v1` bis `-v13` Varianten einer aktuell
+nur noch mit `-v14` referenzierten Infografik.
+
+## Arbeitsregeln
+
+### Neue oder aktualisierte Infografik
+
+1. Kanonisches Asset-Paar erzeugen:
+   - Vorschau fuer Web (`.webp` oder `.png`)
+   - PDF fuer Download/Druck
+2. Falls Karten-/Galerielayout eine kleinere Vorschau braucht:
+   - Thumbnail unter `client/public/infografiken/extras/thumbnails/`
+3. Produktpfade in `client/src/content/**` aktualisieren.
+4. Audit laufen lassen:
+
+```sh
+pnpm audit:infografiken
+```
+
+5. Snapshot in `qa/infografik-inventory.json` pruefen:
+   - keine fehlenden referenzierten Dateien
+   - erwartete aktive Pfade
+   - keine unerwarteten neuen Legacy-Kandidaten
+
+### Lokalisierte ehemalige Remote-Assets
+
+- fuer lokal kontrollierte Ersatzdateien gilt weiter:
+  - `manus-<id>-v1.webp`
+  - `manus-<id>-v1.pdf`
+- die Versionsnummer bleibt bewusst ruhig, bis ein inhaltlich neuer Export
+  wirklich einen Nachfolger braucht
+
+### Alte Versionen nicht still mitschleppen
+
+- neue Exportversion nur dann im Produkt referenzieren, wenn der Content-Pfad
+  wirklich umgestellt wurde
+- nach Umstellung mit `pnpm audit:infografiken` pruefen, welche alten
+  Geschwister unreferenziert geworden sind
+- alte Versionen nicht automatisch loeschen; zuerst in Audit/Doku entscheiden,
+  ob sie fuer Historie, Druckarchiv oder externe Weitergabe noch gebraucht
+  werden
+
+## Benennung
+
+- Produktive Handout-Ersatzdateien:
+  - `manus-<id>-v1.webp`
+  - `manus-<id>-v1.pdf`
+- Produktive gestaltete Serien:
+  - `<slug>-vN.png`
+  - `<slug>-vN.pdf`
+- Thumbnail-Ableitungen:
+  - `extras/thumbnails/<slug>-vN.png`
+
+## Was das Audit bewusst nicht tut
+
+- Es loescht keine Dateien.
+- Es bewertet nicht die fachliche Richtigkeit des Inhalts.
+- Es ersetzt keine PDF-Qualitaetspruefung.
+- Es entscheidet nicht selbst, ob Legacy-Dateien archiviert oder entfernt
+  werden.
+
+## Empfohlener naechster Hygiene-Schritt
+
+Die groessten Altlasten liegen derzeit in den alten PNG/PDF-Versionsreihen der
+nicht-Manus-Infografiken. Wenn der Bestand weiter bereinigt werden soll, ist der
+naechste sinnvolle Schritt:
+
+1. Legacy-Kandidaten aus `qa/infografik-inventory.json` familyweise pruefen
+2. nur noch historisch relevante Reihen behalten
+3. den Rest aus dem produktiven Ordner in ein bewusstes Archiv ausserhalb des
+   Laufzeitpfads verschieben

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run --config vitest.config.ts",
     "check": "tsc --noEmit",
+    "audit:infografiken": "pnpm exec tsx qa/scripts/audit-infografik-inventory.ts --write",
     "format": "prettier --write .",
     "prepare": "husky"
   },

--- a/qa/README.md
+++ b/qa/README.md
@@ -38,6 +38,8 @@ Fuer den Content-Audit gilt explizit:
 
 - Repo-spezifische Prompt-Sammlung: [codex-audit-prompts.md](./codex-audit-prompts.md)
 - Vollstaendiger Repo-Plan: [audit-plan.md](./audit-plan.md)
+- Infografik-Inventar und Asset-Workflow:
+  [../docs/infografik-workflow.md](../docs/infografik-workflow.md)
 - Release-Matrix fuer echte Geraete-/Browser-Tests:
   [release-browser-matrix.md](./release-browser-matrix.md)
 - Audit-Worktree-Helfer: [`_dev/create-audit-worktree.sh`](../_dev/create-audit-worktree.sh)
@@ -67,6 +69,22 @@ _dev/create-audit-worktree.sh a11y-interaktion
 Der Helper kopiert `qa/README.md` und `qa/codex-audit-prompts.md` in jeden
 neu angelegten Audit-Worktree, damit jeder Audit-Lauf fuer sich
 selbstbeschreibend bleibt.
+
+## Asset-Inventar (`qa/scripts/audit-infografik-inventory.ts`)
+
+Das Repo fuehrt den produktiven Infografik-Bestand ueber die echten Content-
+Referenzen in `client/src/content/**`. Der Snapshot wird so aktualisiert:
+
+```sh
+pnpm audit:infografiken
+```
+
+Der Lauf:
+
+- prueft, dass jede referenzierte Datei unter `client/public/infografiken`
+  wirklich existiert
+- aktualisiert [infografik-inventory.json](./infografik-inventory.json)
+- trennt aktive Produktdateien, Support-Dateien und unreferenzierte Kandidaten
 
 ## A11y-Skripte (`qa/scripts/*.mjs`)
 

--- a/qa/infografik-inventory.json
+++ b/qa/infografik-inventory.json
@@ -1,0 +1,2417 @@
+{
+  "generatedAt": "2026-05-02T14:59:19.260Z",
+  "summary": {
+    "totalFiles": 167,
+    "totalSizeMb": 287.85,
+    "activeReferencedFiles": 88,
+    "activeReferencedSizeMb": 131.18,
+    "supportFiles": 5,
+    "supportFilesSizeMb": 41.26,
+    "unreferencedCandidates": 74,
+    "unreferencedCandidatesSizeMb": 115.4,
+    "missingReferencedFiles": 0,
+    "versionFamiliesWithLegacyCandidates": 10
+  },
+  "missingReferences": [],
+  "activeReferences": [
+    {
+      "path": "/infografiken/alarm-der-alarm-modus-v3.pdf",
+      "sizeBytes": 340805,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "alarm-modus",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "alarm-modus",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/alarm-der-alarm-modus-v3.png",
+      "sizeBytes": 346704,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "alarm-modus",
+          "field": "url"
+        },
+        {
+          "source": "verstehen",
+          "id": "alarm-modus",
+          "field": "webpUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/ampel-das-ampel-system-v3.pdf",
+      "sizeBytes": 5549657,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "im-krisenmodus",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/ampel-das-ampel-system-v3.png",
+      "sizeBytes": 4170717,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "im-krisenmodus",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v9.pdf",
+      "sizeBytes": 279830,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "krisenkommunikation",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "kommunizieren",
+          "id": "krisenkommunikation",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v9.png",
+      "sizeBytes": 276881,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "krisenkommunikation",
+          "field": "url"
+        },
+        {
+          "source": "kommunizieren",
+          "id": "krisenkommunikation",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v6.pdf",
+      "sizeBytes": 5407090,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "eisberg",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "eisberg",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v6.png",
+      "sizeBytes": 4027491,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "eisberg",
+          "field": "url"
+        },
+        {
+          "source": "verstehen",
+          "id": "eisberg",
+          "field": "webpUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/alarm-der-alarm-modus-v3.png",
+      "sizeBytes": 165597,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "alarm-modus",
+          "field": "thumbnailUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "alarm-modus",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/ampel-das-ampel-system-v3.png",
+      "sizeBytes": 466353,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "im-krisenmodus",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/deeskalation-der-deeskalations-pfad-v9.png",
+      "sizeBytes": 122994,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "krisenkommunikation",
+          "field": "thumbnailUrl"
+        },
+        {
+          "source": "kommunizieren",
+          "id": "krisenkommunikation",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/eisberg-der-eisberg-v6.png",
+      "sizeBytes": 479903,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "eisberg",
+          "field": "thumbnailUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "eisberg",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/fortschritt-das-fortschritt-paradox-v4.png",
+      "sizeBytes": 114649,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "fortschritt-paradox",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/grenzen-die-4-arten-von-grenzen-v4.png",
+      "sizeBytes": 517574,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "4-arten-von-grenzen",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/pendel-das-bewertungs-pendel-v14.png",
+      "sizeBytes": 124109,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "spaltung",
+          "field": "thumbnailUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "spaltung",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/sauerstoff-die-sauerstoffmaske-v4.png",
+      "sizeBytes": 526968,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "sauerstoffmaske",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/sphären-die-einfluss-sphären-v3.png",
+      "sizeBytes": 191274,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "rolle-klaeren",
+          "field": "thumbnailUrl"
+        },
+        {
+          "source": "unterstuetzen",
+          "id": "rolle-klaeren",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/extras/thumbnails/validierung-die-validierungs-treppe-v5.png",
+      "sizeBytes": 147220,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "zuhoeren-ohne-zustimmen",
+          "field": "thumbnailUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v4.pdf",
+      "sizeBytes": 250491,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "fortschritt-paradox",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v4.png",
+      "sizeBytes": 252722,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "fortschritt-paradox",
+          "field": "img"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v4.pdf",
+      "sizeBytes": 6180138,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "4-arten-von-grenzen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v4.png",
+      "sizeBytes": 4384176,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "4-arten-von-grenzen",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-4-alltags-tipps-v1.pdf",
+      "sizeBytes": 3112122,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "4-alltags-tipps",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-4-alltags-tipps-v1.webp",
+      "sizeBytes": 249974,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "4-alltags-tipps",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-4-phasen-v1.pdf",
+      "sizeBytes": 2678207,
+      "usages": [
+        {
+          "source": "verstehen",
+          "id": "4-phasen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-4-phasen-v1.webp",
+      "sizeBytes": 223854,
+      "usages": [
+        {
+          "source": "verstehen",
+          "id": "4-phasen",
+          "field": "webpUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-5-faktoren-genesung-v1.pdf",
+      "sizeBytes": 2770319,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "5-faktoren-genesung",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-5-faktoren-genesung-v1.webp",
+      "sizeBytes": 238610,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "5-faktoren-genesung",
+          "field": "img"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-6-leitlinien-v1.pdf",
+      "sizeBytes": 3488716,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "6-leitlinien",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-6-leitlinien-v1.webp",
+      "sizeBytes": 293128,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "6-leitlinien",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-beispiel-dialog-v1.pdf",
+      "sizeBytes": 2962611,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "beispiel-dialog",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-beispiel-dialog-v1.webp",
+      "sizeBytes": 245686,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "beispiel-dialog",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-beziehungs-achtsamkeit-v1.pdf",
+      "sizeBytes": 2464940,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "beziehungs-achtsamkeit",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-beziehungs-achtsamkeit-v1.webp",
+      "sizeBytes": 206944,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "beziehungs-achtsamkeit",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-dear-v1.pdf",
+      "sizeBytes": 2858355,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "dear",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "grenzen",
+          "id": "dear",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-dear-v1.webp",
+      "sizeBytes": 265820,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "dear",
+          "field": "url"
+        },
+        {
+          "source": "grenzen",
+          "id": "dear",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-drei-saeulen-v1.pdf",
+      "sizeBytes": 2790666,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "drei-saeulen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-drei-saeulen-v1.webp",
+      "sizeBytes": 223510,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "drei-saeulen",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-energie-konto-v1.pdf",
+      "sizeBytes": 3669652,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "energie-konto",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-energie-konto-v1.webp",
+      "sizeBytes": 318974,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "energie-konto",
+          "field": "webp"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-erlaubnis-karte-v1.pdf",
+      "sizeBytes": 2516011,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "erlaubnis-karte",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-erlaubnis-karte-v1.webp",
+      "sizeBytes": 230626,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "erlaubnis-karte",
+          "field": "webp"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-gehirn-v1.pdf",
+      "sizeBytes": 3093524,
+      "usages": [
+        {
+          "source": "verstehen",
+          "id": "gehirn",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-gehirn-v1.webp",
+      "sizeBytes": 275602,
+      "usages": [
+        {
+          "source": "verstehen",
+          "id": "gehirn",
+          "field": "webpUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-genesung-zahlen-v1.pdf",
+      "sizeBytes": 2753141,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "genesung-zahlen",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "genesung",
+          "id": "genesung-zahlen",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-genesung-zahlen-v1.webp",
+      "sizeBytes": 243030,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "genesung-zahlen",
+          "field": "url"
+        },
+        {
+          "source": "genesung",
+          "id": "genesung-zahlen",
+          "field": "img"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-gespraeche-kippen-v1.pdf",
+      "sizeBytes": 2925422,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "gespraeche-kippen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-gespraeche-kippen-v1.webp",
+      "sizeBytes": 264030,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "gespraeche-kippen",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-grenzen-erkennen-v1.pdf",
+      "sizeBytes": 2980462,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "grenzen-erkennen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-grenzen-erkennen-v1.webp",
+      "sizeBytes": 265172,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "grenzen-erkennen",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-grenzen-ohne-eskalation-v1.pdf",
+      "sizeBytes": 3132342,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "grenzen-ohne-eskalation",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-grenzen-ohne-eskalation-v1.webp",
+      "sizeBytes": 279380,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "grenzen-ohne-eskalation",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-grenzen-spickzettel-v1.pdf",
+      "sizeBytes": 2885399,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "grenzen-spickzettel",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "grenzen",
+          "id": "grenzen-spickzettel",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-grenzen-spickzettel-v1.webp",
+      "sizeBytes": 292726,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "grenzen-spickzettel",
+          "field": "url"
+        },
+        {
+          "source": "grenzen",
+          "id": "grenzen-spickzettel",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-kinder-v1.pdf",
+      "sizeBytes": 3519033,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "kinder",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "kinder",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-kinder-v1.webp",
+      "sizeBytes": 326220,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "kinder",
+          "field": "url"
+        },
+        {
+          "source": "verstehen",
+          "id": "kinder",
+          "field": "webpUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-konsistenz-prinzip-v1.pdf",
+      "sizeBytes": 2886279,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "konsistenz-prinzip",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-konsistenz-prinzip-v1.webp",
+      "sizeBytes": 244130,
+      "usages": [
+        {
+          "source": "unterstuetzen",
+          "id": "konsistenz-prinzip",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-leuchtturm-v1.pdf",
+      "sizeBytes": 3214789,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "leuchtturm",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "leuchtturm",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-leuchtturm-v1.webp",
+      "sizeBytes": 256950,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "leuchtturm",
+          "field": "url"
+        },
+        {
+          "source": "verstehen",
+          "id": "leuchtturm",
+          "field": "webpUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-lmk-v1.pdf",
+      "sizeBytes": 2823656,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "lmk",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-lmk-v1.webp",
+      "sizeBytes": 249312,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "lmk",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-pause-statt-streit-v1.pdf",
+      "sizeBytes": 3131045,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "pause-statt-streit",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-pause-statt-streit-v1.webp",
+      "sizeBytes": 276332,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "pause-statt-streit",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-radikale-akzeptanz-v1.pdf",
+      "sizeBytes": 3168314,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "radikale-akzeptanz",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "selbstfuersorge",
+          "id": "radikale-akzeptanz",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-radikale-akzeptanz-v1.webp",
+      "sizeBytes": 287344,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "radikale-akzeptanz",
+          "field": "url"
+        },
+        {
+          "source": "selbstfuersorge",
+          "id": "radikale-akzeptanz",
+          "field": "webp"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-remission-heilung-v1.pdf",
+      "sizeBytes": 3040302,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "remission-heilung",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-remission-heilung-v1.webp",
+      "sizeBytes": 251030,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "remission-heilung",
+          "field": "img"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-rolle-genesungsprozess-v1.pdf",
+      "sizeBytes": 3100913,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "rolle-genesungsprozess",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-rolle-genesungsprozess-v1.webp",
+      "sizeBytes": 289168,
+      "usages": [
+        {
+          "source": "genesung",
+          "id": "rolle-genesungsprozess",
+          "field": "img"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-schuld-verantwortung-v1.pdf",
+      "sizeBytes": 1125351,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "schuld-verantwortung",
+          "field": "downloadUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-schuld-verantwortung-v1.webp",
+      "sizeBytes": 142978,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "schuld-verantwortung",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-spiegeln-statt-aufsaugen-v1.pdf",
+      "sizeBytes": 3308758,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "spiegeln-statt-aufsaugen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-spiegeln-statt-aufsaugen-v1.webp",
+      "sizeBytes": 288288,
+      "usages": [
+        {
+          "source": "grenzen",
+          "id": "spiegeln-statt-aufsaugen",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-stopp-technik-v1.pdf",
+      "sizeBytes": 2698514,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "stopp-technik",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-stopp-technik-v1.webp",
+      "sizeBytes": 238440,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "stopp-technik",
+          "field": "webp"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-warnsignale-v1.pdf",
+      "sizeBytes": 2967379,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "warnsignale",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "selbstfuersorge",
+          "id": "warnsignale",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-warnsignale-v1.webp",
+      "sizeBytes": 243248,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "warnsignale",
+          "field": "url"
+        },
+        {
+          "source": "selbstfuersorge",
+          "id": "warnsignale",
+          "field": "webp"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-wenn-worte-treffen-v1.pdf",
+      "sizeBytes": 1032269,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "wenn-worte-treffen",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "kommunizieren",
+          "id": "wenn-worte-treffen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/manus-wenn-worte-treffen-v1.webp",
+      "sizeBytes": 135678,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "wenn-worte-treffen",
+          "field": "url"
+        },
+        {
+          "source": "kommunizieren",
+          "id": "wenn-worte-treffen",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v14.pdf",
+      "sizeBytes": 247521,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "spaltung",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "verstehen",
+          "id": "spaltung",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v14.png",
+      "sizeBytes": 264558,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "spaltung",
+          "field": "url"
+        },
+        {
+          "source": "verstehen",
+          "id": "spaltung",
+          "field": "webpUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v4.pdf",
+      "sizeBytes": 6292638,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "sauerstoffmaske",
+          "field": "pdf"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v4.png",
+      "sizeBytes": 4622441,
+      "usages": [
+        {
+          "source": "selbstfuersorge",
+          "id": "sauerstoffmaske",
+          "field": "webp"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/sphären-die-einfluss-sphären-v3.pdf",
+      "sizeBytes": 415477,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "rolle-klaeren",
+          "field": "downloadUrl"
+        },
+        {
+          "source": "unterstuetzen",
+          "id": "rolle-klaeren",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/sphären-die-einfluss-sphären-v3.png",
+      "sizeBytes": 327893,
+      "usages": [
+        {
+          "source": "materials",
+          "id": "rolle-klaeren",
+          "field": "url"
+        },
+        {
+          "source": "unterstuetzen",
+          "id": "rolle-klaeren",
+          "field": "url"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v5.pdf",
+      "sizeBytes": 316731,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "zuhoeren-ohne-zustimmen",
+          "field": "pdfUrl"
+        }
+      ]
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v5.png",
+      "sizeBytes": 301766,
+      "usages": [
+        {
+          "source": "kommunizieren",
+          "id": "zuhoeren-ohne-zustimmen",
+          "field": "url"
+        }
+      ]
+    }
+  ],
+  "supportFiles": [
+    {
+      "path": "/infografiken/extras/infografiken-extras.zip",
+      "sizeBytes": 4185696
+    },
+    {
+      "path": "/infografiken/extras/README.txt",
+      "sizeBytes": 2176
+    },
+    {
+      "path": "/infografiken/extras/uebersichtsbogen.pdf",
+      "sizeBytes": 380127
+    },
+    {
+      "path": "/infografiken/extras/uebersichtsbogen.png",
+      "sizeBytes": 1144072
+    },
+    {
+      "path": "/infografiken/infografiken-final.zip",
+      "sizeBytes": 37556162
+    }
+  ],
+  "unreferencedCandidates": [
+    {
+      "path": "/infografiken/alarm-der-alarm-modus-v1.pdf",
+      "sizeBytes": 412280,
+      "versionFamily": "/infografiken/alarm-der-alarm-modus",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/alarm-der-alarm-modus-v1.png",
+      "sizeBytes": 339155,
+      "versionFamily": "/infografiken/alarm-der-alarm-modus",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/alarm-der-alarm-modus-v2.pdf",
+      "sizeBytes": 408727,
+      "versionFamily": "/infografiken/alarm-der-alarm-modus",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/alarm-der-alarm-modus-v2.png",
+      "sizeBytes": 330680,
+      "versionFamily": "/infografiken/alarm-der-alarm-modus",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/ampel-das-ampel-system-v1.pdf",
+      "sizeBytes": 471823,
+      "versionFamily": "/infografiken/ampel-das-ampel-system",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/ampel-das-ampel-system-v1.png",
+      "sizeBytes": 4701596,
+      "versionFamily": "/infografiken/ampel-das-ampel-system",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/ampel-das-ampel-system-v2.pdf",
+      "sizeBytes": 4233504,
+      "versionFamily": "/infografiken/ampel-das-ampel-system",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/ampel-das-ampel-system-v2.png",
+      "sizeBytes": 4232819,
+      "versionFamily": "/infografiken/ampel-das-ampel-system",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v1.pdf",
+      "sizeBytes": 559285,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v1.png",
+      "sizeBytes": 8074923,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v2.pdf",
+      "sizeBytes": 355353,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v2.png",
+      "sizeBytes": 250576,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v3.pdf",
+      "sizeBytes": 370399,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v3.png",
+      "sizeBytes": 257650,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v4.pdf",
+      "sizeBytes": 254457,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 4,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v4.png",
+      "sizeBytes": 253055,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 4,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v5.pdf",
+      "sizeBytes": 262518,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 5,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v5.png",
+      "sizeBytes": 261116,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 5,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v6.pdf",
+      "sizeBytes": 262660,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 6,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v6.png",
+      "sizeBytes": 261259,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 6,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v7.pdf",
+      "sizeBytes": 259251,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 7,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v7.png",
+      "sizeBytes": 257849,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 7,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v8.pdf",
+      "sizeBytes": 263840,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 8,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/deeskalation-der-deeskalations-pfad-v8.png",
+      "sizeBytes": 262449,
+      "versionFamily": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "version": 8,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v1.pdf",
+      "sizeBytes": 415668,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v1.png",
+      "sizeBytes": 4397659,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v2.pdf",
+      "sizeBytes": 443043,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v2.png",
+      "sizeBytes": 4702632,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v3.pdf",
+      "sizeBytes": 260609,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v3.png",
+      "sizeBytes": 4665547,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v4.pdf",
+      "sizeBytes": 420532,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 4,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v4.png",
+      "sizeBytes": 4365184,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 4,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v5.pdf",
+      "sizeBytes": 250156,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 5,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/eisberg-der-eisberg-v5.png",
+      "sizeBytes": 4025187,
+      "versionFamily": "/infografiken/eisberg-der-eisberg",
+      "version": 5,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v1.pdf",
+      "sizeBytes": 315211,
+      "versionFamily": "/infografiken/fortschritt-das-fortschritt-paradox",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v1.png",
+      "sizeBytes": 239228,
+      "versionFamily": "/infografiken/fortschritt-das-fortschritt-paradox",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v2.pdf",
+      "sizeBytes": 318637,
+      "versionFamily": "/infografiken/fortschritt-das-fortschritt-paradox",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v2.png",
+      "sizeBytes": 242810,
+      "versionFamily": "/infografiken/fortschritt-das-fortschritt-paradox",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v3.pdf",
+      "sizeBytes": 320480,
+      "versionFamily": "/infografiken/fortschritt-das-fortschritt-paradox",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/fortschritt-das-fortschritt-paradox-v3.png",
+      "sizeBytes": 244562,
+      "versionFamily": "/infografiken/fortschritt-das-fortschritt-paradox",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v1.pdf",
+      "sizeBytes": 499082,
+      "versionFamily": "/infografiken/grenzen-die-4-arten-von-grenzen",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v1.png",
+      "sizeBytes": 8163706,
+      "versionFamily": "/infografiken/grenzen-die-4-arten-von-grenzen",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v2.pdf",
+      "sizeBytes": 496710,
+      "versionFamily": "/infografiken/grenzen-die-4-arten-von-grenzen",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v2.png",
+      "sizeBytes": 4633538,
+      "versionFamily": "/infografiken/grenzen-die-4-arten-von-grenzen",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v3.pdf",
+      "sizeBytes": 488462,
+      "versionFamily": "/infografiken/grenzen-die-4-arten-von-grenzen",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/grenzen-die-4-arten-von-grenzen-v3.png",
+      "sizeBytes": 4444923,
+      "versionFamily": "/infografiken/grenzen-die-4-arten-von-grenzen",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v1.pdf",
+      "sizeBytes": 332351,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v1.png",
+      "sizeBytes": 264519,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v11.pdf",
+      "sizeBytes": 339327,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 11,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v11.png",
+      "sizeBytes": 271455,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 11,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v12.pdf",
+      "sizeBytes": 342059,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 12,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v12.png",
+      "sizeBytes": 276967,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 12,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v13.pdf",
+      "sizeBytes": 330056,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 13,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v13.png",
+      "sizeBytes": 255957,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 13,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v2.pdf",
+      "sizeBytes": 339235,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 2,
+      "referencedSiblingPaths": [
+        "/infografiken/pendel-das-bewertungs-pendel-v14.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v14.png"
+      ]
+    },
+    {
+      "path": "/infografiken/pendel-das-bewertungs-pendel-v2.png",
+      "sizeBytes": 269323,
+      "versionFamily": "/infografiken/pendel-das-bewertungs-pendel",
+      "version": 2,
+      "referencedSiblingPaths": [
+        "/infografiken/pendel-das-bewertungs-pendel-v14.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v14.png"
+      ]
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v1.pdf",
+      "sizeBytes": 521186,
+      "versionFamily": "/infografiken/sauerstoff-die-sauerstoffmaske",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v1.png",
+      "sizeBytes": 8126328,
+      "versionFamily": "/infografiken/sauerstoff-die-sauerstoffmaske",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v2.pdf",
+      "sizeBytes": 505539,
+      "versionFamily": "/infografiken/sauerstoff-die-sauerstoffmaske",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v2.png",
+      "sizeBytes": 4853736,
+      "versionFamily": "/infografiken/sauerstoff-die-sauerstoffmaske",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v3.pdf",
+      "sizeBytes": 499584,
+      "versionFamily": "/infografiken/sauerstoff-die-sauerstoffmaske",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sauerstoff-die-sauerstoffmaske-v3.png",
+      "sizeBytes": 4617324,
+      "versionFamily": "/infografiken/sauerstoff-die-sauerstoffmaske",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sphären-die-einfluss-sphären-v1.pdf",
+      "sizeBytes": 334375,
+      "versionFamily": "/infografiken/sphären-die-einfluss-sphären",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sphären-die-einfluss-sphären-v1.png",
+      "sizeBytes": 4227134,
+      "versionFamily": "/infografiken/sphären-die-einfluss-sphären",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sphären-die-einfluss-sphären-v2.pdf",
+      "sizeBytes": 364207,
+      "versionFamily": "/infografiken/sphären-die-einfluss-sphären",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/sphären-die-einfluss-sphären-v2.png",
+      "sizeBytes": 4715928,
+      "versionFamily": "/infografiken/sphären-die-einfluss-sphären",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v1.pdf",
+      "sizeBytes": 505474,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v1.png",
+      "sizeBytes": 7567248,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 1,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v2.pdf",
+      "sizeBytes": 498463,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v2.png",
+      "sizeBytes": 7231857,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 2,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v3.pdf",
+      "sizeBytes": 430308,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v3.png",
+      "sizeBytes": 310616,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 3,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v4.pdf",
+      "sizeBytes": 423387,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 4,
+      "referencedSiblingPaths": []
+    },
+    {
+      "path": "/infografiken/validierung-die-validierungs-treppe-v4.png",
+      "sizeBytes": 304177,
+      "versionFamily": "/infografiken/validierung-die-validierungs-treppe",
+      "version": 4,
+      "referencedSiblingPaths": []
+    }
+  ],
+  "versionFamilies": [
+    {
+      "family": "/infografiken/alarm-der-alarm-modus",
+      "availableFiles": [
+        "/infografiken/alarm-der-alarm-modus-v1.pdf",
+        "/infografiken/alarm-der-alarm-modus-v1.png",
+        "/infografiken/alarm-der-alarm-modus-v2.pdf",
+        "/infografiken/alarm-der-alarm-modus-v2.png",
+        "/infografiken/alarm-der-alarm-modus-v3.pdf",
+        "/infografiken/alarm-der-alarm-modus-v3.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/alarm-der-alarm-modus-v3.pdf",
+        "/infografiken/alarm-der-alarm-modus-v3.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/alarm-der-alarm-modus-v1.pdf",
+        "/infografiken/alarm-der-alarm-modus-v1.png",
+        "/infografiken/alarm-der-alarm-modus-v2.pdf",
+        "/infografiken/alarm-der-alarm-modus-v2.png"
+      ]
+    },
+    {
+      "family": "/infografiken/ampel-das-ampel-system",
+      "availableFiles": [
+        "/infografiken/ampel-das-ampel-system-v1.pdf",
+        "/infografiken/ampel-das-ampel-system-v1.png",
+        "/infografiken/ampel-das-ampel-system-v2.pdf",
+        "/infografiken/ampel-das-ampel-system-v2.png",
+        "/infografiken/ampel-das-ampel-system-v3.pdf",
+        "/infografiken/ampel-das-ampel-system-v3.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/ampel-das-ampel-system-v3.pdf",
+        "/infografiken/ampel-das-ampel-system-v3.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/ampel-das-ampel-system-v1.pdf",
+        "/infografiken/ampel-das-ampel-system-v1.png",
+        "/infografiken/ampel-das-ampel-system-v2.pdf",
+        "/infografiken/ampel-das-ampel-system-v2.png"
+      ]
+    },
+    {
+      "family": "/infografiken/deeskalation-der-deeskalations-pfad",
+      "availableFiles": [
+        "/infografiken/deeskalation-der-deeskalations-pfad-v1.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v1.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v2.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v2.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v3.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v3.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v4.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v4.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v5.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v5.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v6.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v6.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v7.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v7.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v8.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v8.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v9.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v9.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/deeskalation-der-deeskalations-pfad-v9.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v9.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/deeskalation-der-deeskalations-pfad-v1.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v1.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v2.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v2.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v3.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v3.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v4.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v4.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v5.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v5.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v6.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v6.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v7.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v7.png",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v8.pdf",
+        "/infografiken/deeskalation-der-deeskalations-pfad-v8.png"
+      ]
+    },
+    {
+      "family": "/infografiken/eisberg-der-eisberg",
+      "availableFiles": [
+        "/infografiken/eisberg-der-eisberg-v1.pdf",
+        "/infografiken/eisberg-der-eisberg-v1.png",
+        "/infografiken/eisberg-der-eisberg-v2.pdf",
+        "/infografiken/eisberg-der-eisberg-v2.png",
+        "/infografiken/eisberg-der-eisberg-v3.pdf",
+        "/infografiken/eisberg-der-eisberg-v3.png",
+        "/infografiken/eisberg-der-eisberg-v4.pdf",
+        "/infografiken/eisberg-der-eisberg-v4.png",
+        "/infografiken/eisberg-der-eisberg-v5.pdf",
+        "/infografiken/eisberg-der-eisberg-v5.png",
+        "/infografiken/eisberg-der-eisberg-v6.pdf",
+        "/infografiken/eisberg-der-eisberg-v6.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/eisberg-der-eisberg-v6.pdf",
+        "/infografiken/eisberg-der-eisberg-v6.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/eisberg-der-eisberg-v1.pdf",
+        "/infografiken/eisberg-der-eisberg-v1.png",
+        "/infografiken/eisberg-der-eisberg-v2.pdf",
+        "/infografiken/eisberg-der-eisberg-v2.png",
+        "/infografiken/eisberg-der-eisberg-v3.pdf",
+        "/infografiken/eisberg-der-eisberg-v3.png",
+        "/infografiken/eisberg-der-eisberg-v4.pdf",
+        "/infografiken/eisberg-der-eisberg-v4.png",
+        "/infografiken/eisberg-der-eisberg-v5.pdf",
+        "/infografiken/eisberg-der-eisberg-v5.png"
+      ]
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/alarm-der-alarm-modus",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/alarm-der-alarm-modus-v3.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/alarm-der-alarm-modus-v3.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/ampel-das-ampel-system",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/ampel-das-ampel-system-v3.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/ampel-das-ampel-system-v3.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/deeskalation-der-deeskalations-pfad",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/deeskalation-der-deeskalations-pfad-v9.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/deeskalation-der-deeskalations-pfad-v9.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/eisberg-der-eisberg",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/eisberg-der-eisberg-v6.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/eisberg-der-eisberg-v6.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/fortschritt-das-fortschritt-paradox",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/fortschritt-das-fortschritt-paradox-v4.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/fortschritt-das-fortschritt-paradox-v4.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/grenzen-die-4-arten-von-grenzen",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/grenzen-die-4-arten-von-grenzen-v4.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/grenzen-die-4-arten-von-grenzen-v4.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/pendel-das-bewertungs-pendel",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/pendel-das-bewertungs-pendel-v14.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/pendel-das-bewertungs-pendel-v14.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/sauerstoff-die-sauerstoffmaske",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/sauerstoff-die-sauerstoffmaske-v4.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/sauerstoff-die-sauerstoffmaske-v4.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/sphären-die-einfluss-sphären",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/sphären-die-einfluss-sphären-v3.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/sphären-die-einfluss-sphären-v3.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/extras/thumbnails/validierung-die-validierungs-treppe",
+      "availableFiles": [
+        "/infografiken/extras/thumbnails/validierung-die-validierungs-treppe-v5.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/extras/thumbnails/validierung-die-validierungs-treppe-v5.png"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/fortschritt-das-fortschritt-paradox",
+      "availableFiles": [
+        "/infografiken/fortschritt-das-fortschritt-paradox-v1.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v1.png",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v2.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v2.png",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v3.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v3.png",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v4.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v4.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/fortschritt-das-fortschritt-paradox-v4.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v4.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/fortschritt-das-fortschritt-paradox-v1.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v1.png",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v2.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v2.png",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v3.pdf",
+        "/infografiken/fortschritt-das-fortschritt-paradox-v3.png"
+      ]
+    },
+    {
+      "family": "/infografiken/grenzen-die-4-arten-von-grenzen",
+      "availableFiles": [
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v1.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v1.png",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v2.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v2.png",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v3.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v3.png",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v4.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v4.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v4.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v4.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v1.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v1.png",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v2.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v2.png",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v3.pdf",
+        "/infografiken/grenzen-die-4-arten-von-grenzen-v3.png"
+      ]
+    },
+    {
+      "family": "/infografiken/manus-4-alltags-tipps",
+      "availableFiles": [
+        "/infografiken/manus-4-alltags-tipps-v1.pdf",
+        "/infografiken/manus-4-alltags-tipps-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-4-alltags-tipps-v1.pdf",
+        "/infografiken/manus-4-alltags-tipps-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-4-phasen",
+      "availableFiles": [
+        "/infografiken/manus-4-phasen-v1.pdf",
+        "/infografiken/manus-4-phasen-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-4-phasen-v1.pdf",
+        "/infografiken/manus-4-phasen-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-5-faktoren-genesung",
+      "availableFiles": [
+        "/infografiken/manus-5-faktoren-genesung-v1.pdf",
+        "/infografiken/manus-5-faktoren-genesung-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-5-faktoren-genesung-v1.pdf",
+        "/infografiken/manus-5-faktoren-genesung-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-6-leitlinien",
+      "availableFiles": [
+        "/infografiken/manus-6-leitlinien-v1.pdf",
+        "/infografiken/manus-6-leitlinien-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-6-leitlinien-v1.pdf",
+        "/infografiken/manus-6-leitlinien-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-beispiel-dialog",
+      "availableFiles": [
+        "/infografiken/manus-beispiel-dialog-v1.pdf",
+        "/infografiken/manus-beispiel-dialog-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-beispiel-dialog-v1.pdf",
+        "/infografiken/manus-beispiel-dialog-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-beziehungs-achtsamkeit",
+      "availableFiles": [
+        "/infografiken/manus-beziehungs-achtsamkeit-v1.pdf",
+        "/infografiken/manus-beziehungs-achtsamkeit-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-beziehungs-achtsamkeit-v1.pdf",
+        "/infografiken/manus-beziehungs-achtsamkeit-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-dear",
+      "availableFiles": [
+        "/infografiken/manus-dear-v1.pdf",
+        "/infografiken/manus-dear-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-dear-v1.pdf",
+        "/infografiken/manus-dear-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-drei-saeulen",
+      "availableFiles": [
+        "/infografiken/manus-drei-saeulen-v1.pdf",
+        "/infografiken/manus-drei-saeulen-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-drei-saeulen-v1.pdf",
+        "/infografiken/manus-drei-saeulen-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-energie-konto",
+      "availableFiles": [
+        "/infografiken/manus-energie-konto-v1.pdf",
+        "/infografiken/manus-energie-konto-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-energie-konto-v1.pdf",
+        "/infografiken/manus-energie-konto-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-erlaubnis-karte",
+      "availableFiles": [
+        "/infografiken/manus-erlaubnis-karte-v1.pdf",
+        "/infografiken/manus-erlaubnis-karte-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-erlaubnis-karte-v1.pdf",
+        "/infografiken/manus-erlaubnis-karte-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-gehirn",
+      "availableFiles": [
+        "/infografiken/manus-gehirn-v1.pdf",
+        "/infografiken/manus-gehirn-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-gehirn-v1.pdf",
+        "/infografiken/manus-gehirn-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-genesung-zahlen",
+      "availableFiles": [
+        "/infografiken/manus-genesung-zahlen-v1.pdf",
+        "/infografiken/manus-genesung-zahlen-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-genesung-zahlen-v1.pdf",
+        "/infografiken/manus-genesung-zahlen-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-gespraeche-kippen",
+      "availableFiles": [
+        "/infografiken/manus-gespraeche-kippen-v1.pdf",
+        "/infografiken/manus-gespraeche-kippen-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-gespraeche-kippen-v1.pdf",
+        "/infografiken/manus-gespraeche-kippen-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-grenzen-erkennen",
+      "availableFiles": [
+        "/infografiken/manus-grenzen-erkennen-v1.pdf",
+        "/infografiken/manus-grenzen-erkennen-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-grenzen-erkennen-v1.pdf",
+        "/infografiken/manus-grenzen-erkennen-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-grenzen-ohne-eskalation",
+      "availableFiles": [
+        "/infografiken/manus-grenzen-ohne-eskalation-v1.pdf",
+        "/infografiken/manus-grenzen-ohne-eskalation-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-grenzen-ohne-eskalation-v1.pdf",
+        "/infografiken/manus-grenzen-ohne-eskalation-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-grenzen-spickzettel",
+      "availableFiles": [
+        "/infografiken/manus-grenzen-spickzettel-v1.pdf",
+        "/infografiken/manus-grenzen-spickzettel-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-grenzen-spickzettel-v1.pdf",
+        "/infografiken/manus-grenzen-spickzettel-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-kinder",
+      "availableFiles": [
+        "/infografiken/manus-kinder-v1.pdf",
+        "/infografiken/manus-kinder-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-kinder-v1.pdf",
+        "/infografiken/manus-kinder-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-konsistenz-prinzip",
+      "availableFiles": [
+        "/infografiken/manus-konsistenz-prinzip-v1.pdf",
+        "/infografiken/manus-konsistenz-prinzip-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-konsistenz-prinzip-v1.pdf",
+        "/infografiken/manus-konsistenz-prinzip-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-leuchtturm",
+      "availableFiles": [
+        "/infografiken/manus-leuchtturm-v1.pdf",
+        "/infografiken/manus-leuchtturm-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-leuchtturm-v1.pdf",
+        "/infografiken/manus-leuchtturm-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-lmk",
+      "availableFiles": [
+        "/infografiken/manus-lmk-v1.pdf",
+        "/infografiken/manus-lmk-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-lmk-v1.pdf",
+        "/infografiken/manus-lmk-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-pause-statt-streit",
+      "availableFiles": [
+        "/infografiken/manus-pause-statt-streit-v1.pdf",
+        "/infografiken/manus-pause-statt-streit-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-pause-statt-streit-v1.pdf",
+        "/infografiken/manus-pause-statt-streit-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-radikale-akzeptanz",
+      "availableFiles": [
+        "/infografiken/manus-radikale-akzeptanz-v1.pdf",
+        "/infografiken/manus-radikale-akzeptanz-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-radikale-akzeptanz-v1.pdf",
+        "/infografiken/manus-radikale-akzeptanz-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-remission-heilung",
+      "availableFiles": [
+        "/infografiken/manus-remission-heilung-v1.pdf",
+        "/infografiken/manus-remission-heilung-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-remission-heilung-v1.pdf",
+        "/infografiken/manus-remission-heilung-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-rolle-genesungsprozess",
+      "availableFiles": [
+        "/infografiken/manus-rolle-genesungsprozess-v1.pdf",
+        "/infografiken/manus-rolle-genesungsprozess-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-rolle-genesungsprozess-v1.pdf",
+        "/infografiken/manus-rolle-genesungsprozess-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-schuld-verantwortung",
+      "availableFiles": [
+        "/infografiken/manus-schuld-verantwortung-v1.pdf",
+        "/infografiken/manus-schuld-verantwortung-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-schuld-verantwortung-v1.pdf",
+        "/infografiken/manus-schuld-verantwortung-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-spiegeln-statt-aufsaugen",
+      "availableFiles": [
+        "/infografiken/manus-spiegeln-statt-aufsaugen-v1.pdf",
+        "/infografiken/manus-spiegeln-statt-aufsaugen-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-spiegeln-statt-aufsaugen-v1.pdf",
+        "/infografiken/manus-spiegeln-statt-aufsaugen-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-stopp-technik",
+      "availableFiles": [
+        "/infografiken/manus-stopp-technik-v1.pdf",
+        "/infografiken/manus-stopp-technik-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-stopp-technik-v1.pdf",
+        "/infografiken/manus-stopp-technik-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-warnsignale",
+      "availableFiles": [
+        "/infografiken/manus-warnsignale-v1.pdf",
+        "/infografiken/manus-warnsignale-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-warnsignale-v1.pdf",
+        "/infografiken/manus-warnsignale-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/manus-wenn-worte-treffen",
+      "availableFiles": [
+        "/infografiken/manus-wenn-worte-treffen-v1.pdf",
+        "/infografiken/manus-wenn-worte-treffen-v1.webp"
+      ],
+      "referencedFiles": [
+        "/infografiken/manus-wenn-worte-treffen-v1.pdf",
+        "/infografiken/manus-wenn-worte-treffen-v1.webp"
+      ],
+      "legacyCandidateFiles": []
+    },
+    {
+      "family": "/infografiken/pendel-das-bewertungs-pendel",
+      "availableFiles": [
+        "/infografiken/pendel-das-bewertungs-pendel-v1.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v1.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v11.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v11.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v12.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v12.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v13.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v13.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v14.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v14.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v2.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v2.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/pendel-das-bewertungs-pendel-v14.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v14.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/pendel-das-bewertungs-pendel-v1.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v1.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v11.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v11.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v12.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v12.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v13.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v13.png",
+        "/infografiken/pendel-das-bewertungs-pendel-v2.pdf",
+        "/infografiken/pendel-das-bewertungs-pendel-v2.png"
+      ]
+    },
+    {
+      "family": "/infografiken/sauerstoff-die-sauerstoffmaske",
+      "availableFiles": [
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v1.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v1.png",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v2.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v2.png",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v3.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v3.png",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v4.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v4.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v4.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v4.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v1.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v1.png",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v2.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v2.png",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v3.pdf",
+        "/infografiken/sauerstoff-die-sauerstoffmaske-v3.png"
+      ]
+    },
+    {
+      "family": "/infografiken/sphären-die-einfluss-sphären",
+      "availableFiles": [
+        "/infografiken/sphären-die-einfluss-sphären-v1.pdf",
+        "/infografiken/sphären-die-einfluss-sphären-v1.png",
+        "/infografiken/sphären-die-einfluss-sphären-v2.pdf",
+        "/infografiken/sphären-die-einfluss-sphären-v2.png",
+        "/infografiken/sphären-die-einfluss-sphären-v3.pdf",
+        "/infografiken/sphären-die-einfluss-sphären-v3.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/sphären-die-einfluss-sphären-v3.pdf",
+        "/infografiken/sphären-die-einfluss-sphären-v3.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/sphären-die-einfluss-sphären-v1.pdf",
+        "/infografiken/sphären-die-einfluss-sphären-v1.png",
+        "/infografiken/sphären-die-einfluss-sphären-v2.pdf",
+        "/infografiken/sphären-die-einfluss-sphären-v2.png"
+      ]
+    },
+    {
+      "family": "/infografiken/validierung-die-validierungs-treppe",
+      "availableFiles": [
+        "/infografiken/validierung-die-validierungs-treppe-v1.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v1.png",
+        "/infografiken/validierung-die-validierungs-treppe-v2.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v2.png",
+        "/infografiken/validierung-die-validierungs-treppe-v3.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v3.png",
+        "/infografiken/validierung-die-validierungs-treppe-v4.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v4.png",
+        "/infografiken/validierung-die-validierungs-treppe-v5.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v5.png"
+      ],
+      "referencedFiles": [
+        "/infografiken/validierung-die-validierungs-treppe-v5.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v5.png"
+      ],
+      "legacyCandidateFiles": [
+        "/infografiken/validierung-die-validierungs-treppe-v1.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v1.png",
+        "/infografiken/validierung-die-validierungs-treppe-v2.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v2.png",
+        "/infografiken/validierung-die-validierungs-treppe-v3.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v3.png",
+        "/infografiken/validierung-die-validierungs-treppe-v4.pdf",
+        "/infografiken/validierung-die-validierungs-treppe-v4.png"
+      ]
+    }
+  ]
+}

--- a/qa/scripts/audit-infografik-inventory.ts
+++ b/qa/scripts/audit-infografik-inventory.ts
@@ -1,0 +1,277 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectReferencedInfografikAssets } from "../../client/src/content/infografikAssetRefs";
+
+type InventoryRecord = {
+  path: string;
+  sizeBytes: number;
+};
+
+type InventoryReference = InventoryRecord & {
+  usages: ReturnType<
+    typeof collectReferencedInfografikAssets
+  >[number]["usages"];
+};
+
+type VersionInfo = {
+  family: string;
+  version: number;
+};
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(SCRIPT_DIR, "../..");
+const INFOGRAFIKEN_ROOT = path.join(
+  REPO_ROOT,
+  "client",
+  "public",
+  "infografiken"
+);
+const INVENTORY_OUTPUT_PATH = path.join(
+  REPO_ROOT,
+  "qa",
+  "infografik-inventory.json"
+);
+
+function normalizePublicPath(absolutePath: string) {
+  return (
+    "/" +
+    path
+      .relative(path.join(REPO_ROOT, "client", "public"), absolutePath)
+      .split(path.sep)
+      .join("/")
+  );
+}
+
+async function walkFiles(rootDir: string): Promise<string[]> {
+  const entries = await fs.readdir(rootDir, { withFileTypes: true });
+  const nested = await Promise.all(
+    entries.map(async entry => {
+      const absolutePath = path.join(rootDir, entry.name);
+      if (entry.isDirectory()) {
+        return walkFiles(absolutePath);
+      }
+
+      if (entry.isFile()) {
+        return [absolutePath];
+      }
+
+      return [];
+    })
+  );
+
+  return nested.flat().sort((left, right) => left.localeCompare(right));
+}
+
+function getVersionInfo(publicPath: string): VersionInfo | null {
+  const parsedPath = path.posix.parse(publicPath);
+  const match = parsedPath.name.match(/^(.*)-v(\d+)$/);
+  if (!match) {
+    return null;
+  }
+
+  return {
+    family: `${parsedPath.dir}/${match[1]}`,
+    version: Number.parseInt(match[2], 10),
+  };
+}
+
+function isSupportFile(publicPath: string) {
+  return (
+    publicPath.startsWith("/infografiken/extras/") ||
+    publicPath === "/infografiken/infografiken-final.zip"
+  );
+}
+
+function sumSizes(items: InventoryRecord[]) {
+  return items.reduce((total, item) => total + item.sizeBytes, 0);
+}
+
+function toMegabytes(sizeBytes: number) {
+  return Number((sizeBytes / (1024 * 1024)).toFixed(2));
+}
+
+function buildFamilyIndex(files: InventoryRecord[]) {
+  const families = new Map<string, InventoryRecord[]>();
+
+  for (const file of files) {
+    const versionInfo = getVersionInfo(file.path);
+    if (!versionInfo) {
+      continue;
+    }
+
+    const existing = families.get(versionInfo.family);
+    if (existing) {
+      existing.push(file);
+      continue;
+    }
+
+    families.set(versionInfo.family, [file]);
+  }
+
+  for (const familyFiles of families.values()) {
+    familyFiles.sort((left, right) => left.path.localeCompare(right.path));
+  }
+
+  return families;
+}
+
+async function main() {
+  const writeOutput = process.argv.includes("--write");
+  const printJson = process.argv.includes("--json");
+  const referencedAssets = collectReferencedInfografikAssets();
+  const referencedByPath = new Map(
+    referencedAssets.map(asset => [asset.path, asset.usages])
+  );
+
+  const allFiles = await walkFiles(INFOGRAFIKEN_ROOT);
+  const fileStats = await Promise.all(
+    allFiles.map(async absolutePath => {
+      const stat = await fs.stat(absolutePath);
+      return {
+        path: normalizePublicPath(absolutePath),
+        sizeBytes: stat.size,
+      };
+    })
+  );
+
+  const allRecords = fileStats.sort((left, right) =>
+    left.path.localeCompare(right.path)
+  );
+  const familyIndex = buildFamilyIndex(allRecords);
+
+  const activeReferences: InventoryReference[] = [];
+  const supportFiles: InventoryRecord[] = [];
+  const unreferencedCandidates: Array<
+    InventoryRecord & {
+      versionFamily: string | null;
+      version: number | null;
+      referencedSiblingPaths: string[];
+    }
+  > = [];
+  const missingReferences = referencedAssets.filter(
+    asset => !allRecords.some(record => record.path === asset.path)
+  );
+
+  for (const record of allRecords) {
+    const usages = referencedByPath.get(record.path);
+    if (usages) {
+      activeReferences.push({
+        ...record,
+        usages,
+      });
+      continue;
+    }
+
+    if (isSupportFile(record.path)) {
+      supportFiles.push(record);
+      continue;
+    }
+
+    const versionInfo = getVersionInfo(record.path);
+    const relatedReferencedSiblings = versionInfo
+      ? activeReferences
+          .filter(item => {
+            const activeVersion = getVersionInfo(item.path);
+            return activeVersion?.family === versionInfo.family;
+          })
+          .map(item => item.path)
+      : [];
+
+    unreferencedCandidates.push({
+      ...record,
+      versionFamily: versionInfo?.family ?? null,
+      version: versionInfo?.version ?? null,
+      referencedSiblingPaths: relatedReferencedSiblings,
+    });
+  }
+
+  const versionFamilies = Array.from(familyIndex.entries())
+    .map(([family, files]) => {
+      const referencedPaths = activeReferences
+        .map(item => item.path)
+        .filter(itemPath => getVersionInfo(itemPath)?.family === family);
+      const legacyCandidates = unreferencedCandidates
+        .filter(item => item.versionFamily === family)
+        .map(item => item.path);
+
+      return {
+        family,
+        availableFiles: files.map(file => file.path),
+        referencedFiles: referencedPaths,
+        legacyCandidateFiles: legacyCandidates,
+      };
+    })
+    .filter(
+      item =>
+        item.referencedFiles.length > 0 || item.legacyCandidateFiles.length > 0
+    )
+    .sort((left, right) => left.family.localeCompare(right.family));
+
+  const inventory = {
+    generatedAt: new Date().toISOString(),
+    summary: {
+      totalFiles: allRecords.length,
+      totalSizeMb: toMegabytes(sumSizes(allRecords)),
+      activeReferencedFiles: activeReferences.length,
+      activeReferencedSizeMb: toMegabytes(sumSizes(activeReferences)),
+      supportFiles: supportFiles.length,
+      supportFilesSizeMb: toMegabytes(sumSizes(supportFiles)),
+      unreferencedCandidates: unreferencedCandidates.length,
+      unreferencedCandidatesSizeMb: toMegabytes(
+        sumSizes(unreferencedCandidates)
+      ),
+      missingReferencedFiles: missingReferences.length,
+      versionFamiliesWithLegacyCandidates: versionFamilies.filter(
+        item => item.legacyCandidateFiles.length > 0
+      ).length,
+    },
+    missingReferences,
+    activeReferences,
+    supportFiles,
+    unreferencedCandidates,
+    versionFamilies,
+  };
+
+  if (writeOutput) {
+    await fs.writeFile(
+      INVENTORY_OUTPUT_PATH,
+      `${JSON.stringify(inventory, null, 2)}\n`,
+      "utf8"
+    );
+  }
+
+  if (missingReferences.length > 0) {
+    console.error(
+      `Missing referenced infografik assets: ${missingReferences
+        .map(item => item.path)
+        .join(", ")}`
+    );
+    process.exitCode = 1;
+  }
+
+  if (printJson) {
+    console.log(JSON.stringify(inventory, null, 2));
+    return;
+  }
+
+  const summaryLines = [
+    "Infografik inventory summary",
+    `- total files: ${inventory.summary.totalFiles} (${inventory.summary.totalSizeMb} MB)`,
+    `- active referenced files: ${inventory.summary.activeReferencedFiles} (${inventory.summary.activeReferencedSizeMb} MB)`,
+    `- support files: ${inventory.summary.supportFiles} (${inventory.summary.supportFilesSizeMb} MB)`,
+    `- unreferenced candidates: ${inventory.summary.unreferencedCandidates} (${inventory.summary.unreferencedCandidatesSizeMb} MB)`,
+    `- version families with legacy candidates: ${inventory.summary.versionFamiliesWithLegacyCandidates}`,
+    `- missing referenced files: ${inventory.summary.missingReferencedFiles}`,
+  ];
+
+  if (writeOutput) {
+    summaryLines.push(
+      `- wrote snapshot: ${path.relative(REPO_ROOT, INVENTORY_OUTPUT_PATH)}`
+    );
+  }
+
+  console.log(summaryLines.join("\n"));
+}
+
+await main();


### PR DESCRIPTION
## What changed

- add a shared infografik asset reference registry plus a regression test that fails when content references a missing asset
- add `qa/scripts/audit-infografik-inventory.ts` and `pnpm audit:infografiken` to snapshot the productive infografik inventory
- document the asset workflow and inventory handling in `docs/infografik-workflow.md` and link it from `qa/README.md`
- check in the first inventory snapshot at `qa/infografik-inventory.json`

## Why

`client/public/infografiken` has grown into a large mixed asset store. We needed a reproducible way to distinguish active production files from support files and legacy candidates, and a guardrail that catches broken content references early.

## Impact

- referenced infografik assets are now validated in tests
- the repo has a repeatable inventory command for the asset corpus
- cleanup decisions can now be driven by a checked-in snapshot instead of directory guesswork
- current inventory baseline: 167 files total, 88 actively referenced, 74 unreferenced candidates, 10 version families with active + legacy siblings

## Validation

- `pnpm audit:infografiken`
- `pnpm check`
- `pnpm lint`
- `pnpm test`
- `pnpm build`
