### PR TITLE
Extend browser matrix to WebKit and Firefox

### DIFF
--- a/qa/release-browser-matrix.json
+++ b/qa/release-browser-matrix.json
@@ -1,23 +1,253 @@
 {
   "label": "Production Browser Matrix 2026-05-02",
-  "createdAt": "2026-05-02T16:56:16.034Z",
+  "createdAt": "2026-05-02T17:16:49.161Z",
   "baseUrl": "https://borderline-angehoerige.netlify.app",
-  "gitHead": "03acade",
+  "gitHead": "3225022",
   "profiles": [
     {
       "device": "iPhone",
       "browser": "Safari",
-      "status": "offen",
+      "optional": false,
+      "status": "bestanden mit Hinweis",
       "testedAt": "2026-05-02",
       "testedBy": "Codex",
-      "notes": "offen – kein echter iOS/WebKit-Lauf auf diesem Rechner ohne zusätzliche Browser-Binaries oder Hardware",
+      "notes": "Playwright WebKit mit iPhone-13-Emulation; starke WebKit-Abdeckung, aber kein physisches iOS-Gerät",
       "findings": [],
-      "steps": [],
-      "available": false
+      "steps": [
+        {
+          "name": "Startseite direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:08.811Z",
+          "finishedAt": "2026-05-02T17:15:09.985Z"
+        },
+        {
+          "name": "Suche öffnen und schließen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:09.985Z",
+          "finishedAt": "2026-05-02T17:15:10.880Z"
+        },
+        {
+          "name": "Mobiles Menü öffnen und schließen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:10.880Z",
+          "finishedAt": "2026-05-02T17:15:10.947Z"
+        },
+        {
+          "name": "Sticky Header über Scrollstrecke sichtbar",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:10.947Z",
+          "finishedAt": "2026-05-02T17:15:10.951Z"
+        },
+        {
+          "name": "/soforthilfe direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:10.951Z",
+          "finishedAt": "2026-05-02T17:15:11.858Z"
+        },
+        {
+          "name": "/notfallkarte direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:11.858Z",
+          "finishedAt": "2026-05-02T17:15:12.859Z"
+        },
+        {
+          "name": "/notfallkarte/erstellen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:12.859Z",
+          "finishedAt": "2026-05-02T17:15:13.922Z"
+        },
+        {
+          "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:13.922Z",
+          "finishedAt": "2026-05-02T17:15:16.784Z"
+        },
+        {
+          "name": "Notfallkarte Druckansicht",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:16.784Z",
+          "finishedAt": "2026-05-02T17:15:18.770Z"
+        },
+        {
+          "name": "Notfallkarte löschen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:18.770Z",
+          "finishedAt": "2026-05-02T17:15:18.820Z"
+        },
+        {
+          "name": "/materialien + Filter",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:18.820Z",
+          "finishedAt": "2026-05-02T17:15:19.877Z"
+        },
+        {
+          "name": "Materialien Textversion öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:19.877Z",
+          "finishedAt": "2026-05-02T17:15:20.726Z"
+        },
+        {
+          "name": "Materialien PDF inline öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:20.726Z",
+          "finishedAt": "2026-05-02T17:15:21.557Z"
+        },
+        {
+          "name": "Materialien PDF herunterladen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:21.557Z",
+          "finishedAt": "2026-05-02T17:15:21.786Z"
+        },
+        {
+          "name": "/diagnostik direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:21.786Z",
+          "finishedAt": "2026-05-02T17:15:22.657Z"
+        },
+        {
+          "name": "/grenzen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:22.657Z",
+          "finishedAt": "2026-05-02T17:15:23.606Z"
+        },
+        {
+          "name": "/beratung direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:23.606Z",
+          "finishedAt": "2026-05-02T17:15:24.442Z"
+        },
+        {
+          "name": "/quellen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:24.442Z",
+          "finishedAt": "2026-05-02T17:15:25.293Z"
+        }
+      ],
+      "available": true,
+      "startedAt": "2026-05-02T17:15:08.489Z",
+      "finishedAt": "2026-05-02T17:15:25.293Z"
+    },
+    {
+      "device": "optional macOS",
+      "browser": "Safari",
+      "optional": true,
+      "status": "bestanden mit Hinweis",
+      "testedAt": "2026-05-02",
+      "testedBy": "Codex",
+      "notes": "Playwright WebKit-Desktoplauf als Safari-Näherung; optionaler Zusatzcheck",
+      "findings": [],
+      "steps": [
+        {
+          "name": "Startseite direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:25.427Z",
+          "finishedAt": "2026-05-02T17:15:26.149Z"
+        },
+        {
+          "name": "Suche öffnen und schließen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:26.149Z",
+          "finishedAt": "2026-05-02T17:15:27.030Z"
+        },
+        {
+          "name": "Sticky Header über Scrollstrecke sichtbar",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:27.030Z",
+          "finishedAt": "2026-05-02T17:15:27.032Z"
+        },
+        {
+          "name": "/soforthilfe direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:27.032Z",
+          "finishedAt": "2026-05-02T17:15:27.608Z"
+        },
+        {
+          "name": "/notfallkarte direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:27.608Z",
+          "finishedAt": "2026-05-02T17:15:28.190Z"
+        },
+        {
+          "name": "/notfallkarte/erstellen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:28.190Z",
+          "finishedAt": "2026-05-02T17:15:28.814Z"
+        },
+        {
+          "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:28.814Z",
+          "finishedAt": "2026-05-02T17:15:31.636Z"
+        },
+        {
+          "name": "Notfallkarte Druckansicht",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:31.636Z",
+          "finishedAt": "2026-05-02T17:15:33.075Z"
+        },
+        {
+          "name": "Notfallkarte löschen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:33.075Z",
+          "finishedAt": "2026-05-02T17:15:33.099Z"
+        },
+        {
+          "name": "/materialien + Filter",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:33.099Z",
+          "finishedAt": "2026-05-02T17:15:34.077Z"
+        },
+        {
+          "name": "Materialien Textversion öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:34.077Z",
+          "finishedAt": "2026-05-02T17:15:34.920Z"
+        },
+        {
+          "name": "Materialien PDF inline öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:34.920Z",
+          "finishedAt": "2026-05-02T17:15:36.085Z"
+        },
+        {
+          "name": "Materialien PDF herunterladen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:36.085Z",
+          "finishedAt": "2026-05-02T17:15:36.619Z"
+        },
+        {
+          "name": "/diagnostik direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:36.619Z",
+          "finishedAt": "2026-05-02T17:15:37.243Z"
+        },
+        {
+          "name": "/grenzen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:37.243Z",
+          "finishedAt": "2026-05-02T17:15:37.878Z"
+        },
+        {
+          "name": "/beratung direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:37.878Z",
+          "finishedAt": "2026-05-02T17:15:38.497Z"
+        },
+        {
+          "name": "/quellen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:15:38.497Z",
+          "finishedAt": "2026-05-02T17:15:39.105Z"
+        }
+      ],
+      "available": true,
+      "startedAt": "2026-05-02T17:15:25.298Z",
+      "finishedAt": "2026-05-02T17:15:39.105Z"
     },
     {
       "device": "iPhone",
       "browser": "Chrome",
+      "optional": false,
       "status": "bestanden mit Hinweis",
       "testedAt": "2026-05-02",
       "testedBy": "Codex",
@@ -27,119 +257,120 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:23.125Z",
-          "finishedAt": "2026-05-02T16:55:24.577Z"
+          "startedAt": "2026-05-02T17:15:39.919Z",
+          "finishedAt": "2026-05-02T17:15:41.347Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:24.577Z",
-          "finishedAt": "2026-05-02T16:55:25.484Z"
+          "startedAt": "2026-05-02T17:15:41.347Z",
+          "finishedAt": "2026-05-02T17:15:42.229Z"
         },
         {
           "name": "Mobiles Menü öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:25.484Z",
-          "finishedAt": "2026-05-02T16:55:25.550Z"
+          "startedAt": "2026-05-02T17:15:42.229Z",
+          "finishedAt": "2026-05-02T17:15:42.294Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:25.550Z",
-          "finishedAt": "2026-05-02T16:55:25.552Z"
+          "startedAt": "2026-05-02T17:15:42.294Z",
+          "finishedAt": "2026-05-02T17:15:42.296Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:25.552Z",
-          "finishedAt": "2026-05-02T16:55:26.530Z"
+          "startedAt": "2026-05-02T17:15:42.296Z",
+          "finishedAt": "2026-05-02T17:15:43.070Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:26.530Z",
-          "finishedAt": "2026-05-02T16:55:27.706Z"
+          "startedAt": "2026-05-02T17:15:43.070Z",
+          "finishedAt": "2026-05-02T17:15:43.885Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:27.706Z",
-          "finishedAt": "2026-05-02T16:55:28.873Z"
+          "startedAt": "2026-05-02T17:15:43.886Z",
+          "finishedAt": "2026-05-02T17:15:44.852Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:28.873Z",
-          "finishedAt": "2026-05-02T16:55:31.648Z"
+          "startedAt": "2026-05-02T17:15:44.852Z",
+          "finishedAt": "2026-05-02T17:15:47.644Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:31.648Z",
-          "finishedAt": "2026-05-02T16:55:33.576Z"
+          "startedAt": "2026-05-02T17:15:47.644Z",
+          "finishedAt": "2026-05-02T17:15:49.549Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:33.576Z",
-          "finishedAt": "2026-05-02T16:55:33.645Z"
+          "startedAt": "2026-05-02T17:15:49.549Z",
+          "finishedAt": "2026-05-02T17:15:49.624Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:33.645Z",
-          "finishedAt": "2026-05-02T16:55:34.774Z"
+          "startedAt": "2026-05-02T17:15:49.624Z",
+          "finishedAt": "2026-05-02T17:15:50.650Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:34.774Z",
-          "finishedAt": "2026-05-02T16:55:35.629Z"
+          "startedAt": "2026-05-02T17:15:50.650Z",
+          "finishedAt": "2026-05-02T17:15:51.490Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:35.629Z",
-          "finishedAt": "2026-05-02T16:55:37.372Z"
+          "startedAt": "2026-05-02T17:15:51.490Z",
+          "finishedAt": "2026-05-02T17:15:52.205Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:37.372Z",
-          "finishedAt": "2026-05-02T16:55:38.168Z"
+          "startedAt": "2026-05-02T17:15:52.205Z",
+          "finishedAt": "2026-05-02T17:15:52.798Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:38.168Z",
-          "finishedAt": "2026-05-02T16:55:39.239Z"
+          "startedAt": "2026-05-02T17:15:52.798Z",
+          "finishedAt": "2026-05-02T17:15:53.784Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:39.239Z",
-          "finishedAt": "2026-05-02T16:55:40.311Z"
+          "startedAt": "2026-05-02T17:15:53.784Z",
+          "finishedAt": "2026-05-02T17:15:54.621Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:40.311Z",
-          "finishedAt": "2026-05-02T16:55:41.207Z"
+          "startedAt": "2026-05-02T17:15:54.621Z",
+          "finishedAt": "2026-05-02T17:15:55.507Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:41.207Z",
-          "finishedAt": "2026-05-02T16:55:42.219Z"
+          "startedAt": "2026-05-02T17:15:55.508Z",
+          "finishedAt": "2026-05-02T17:15:56.319Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-02T16:55:22.819Z",
-      "finishedAt": "2026-05-02T16:55:42.219Z"
+      "startedAt": "2026-05-02T17:15:39.721Z",
+      "finishedAt": "2026-05-02T17:15:56.319Z"
     },
     {
       "device": "Android",
       "browser": "Chrome",
+      "optional": false,
       "status": "bestanden mit Hinweis",
       "testedAt": "2026-05-02",
       "testedBy": "Codex",
@@ -149,119 +380,120 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:42.352Z",
-          "finishedAt": "2026-05-02T16:55:43.728Z"
+          "startedAt": "2026-05-02T17:15:56.465Z",
+          "finishedAt": "2026-05-02T17:15:57.864Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:43.728Z",
-          "finishedAt": "2026-05-02T16:55:44.622Z"
+          "startedAt": "2026-05-02T17:15:57.864Z",
+          "finishedAt": "2026-05-02T17:15:58.727Z"
         },
         {
           "name": "Mobiles Menü öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:44.622Z",
-          "finishedAt": "2026-05-02T16:55:44.684Z"
+          "startedAt": "2026-05-02T17:15:58.727Z",
+          "finishedAt": "2026-05-02T17:15:58.793Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:44.684Z",
-          "finishedAt": "2026-05-02T16:55:44.686Z"
+          "startedAt": "2026-05-02T17:15:58.793Z",
+          "finishedAt": "2026-05-02T17:15:58.794Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:44.686Z",
-          "finishedAt": "2026-05-02T16:55:45.547Z"
+          "startedAt": "2026-05-02T17:15:58.794Z",
+          "finishedAt": "2026-05-02T17:15:59.571Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:45.547Z",
-          "finishedAt": "2026-05-02T16:55:46.546Z"
+          "startedAt": "2026-05-02T17:15:59.571Z",
+          "finishedAt": "2026-05-02T17:16:00.352Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:46.546Z",
-          "finishedAt": "2026-05-02T16:55:47.521Z"
+          "startedAt": "2026-05-02T17:16:00.352Z",
+          "finishedAt": "2026-05-02T17:16:01.326Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:47.522Z",
-          "finishedAt": "2026-05-02T16:55:50.297Z"
+          "startedAt": "2026-05-02T17:16:01.326Z",
+          "finishedAt": "2026-05-02T17:16:04.077Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:50.297Z",
-          "finishedAt": "2026-05-02T16:55:52.022Z"
+          "startedAt": "2026-05-02T17:16:04.077Z",
+          "finishedAt": "2026-05-02T17:16:05.812Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:52.022Z",
-          "finishedAt": "2026-05-02T16:55:52.089Z"
+          "startedAt": "2026-05-02T17:16:05.812Z",
+          "finishedAt": "2026-05-02T17:16:05.886Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:52.089Z",
-          "finishedAt": "2026-05-02T16:55:53.684Z"
+          "startedAt": "2026-05-02T17:16:05.886Z",
+          "finishedAt": "2026-05-02T17:16:07.067Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:53.684Z",
-          "finishedAt": "2026-05-02T16:55:54.525Z"
+          "startedAt": "2026-05-02T17:16:07.067Z",
+          "finishedAt": "2026-05-02T17:16:07.930Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:54.525Z",
-          "finishedAt": "2026-05-02T16:55:54.967Z"
+          "startedAt": "2026-05-02T17:16:07.930Z",
+          "finishedAt": "2026-05-02T17:16:08.661Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:54.967Z",
-          "finishedAt": "2026-05-02T16:55:55.621Z"
+          "startedAt": "2026-05-02T17:16:08.661Z",
+          "finishedAt": "2026-05-02T17:16:09.285Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:55.621Z",
-          "finishedAt": "2026-05-02T16:55:56.548Z"
+          "startedAt": "2026-05-02T17:16:09.285Z",
+          "finishedAt": "2026-05-02T17:16:10.100Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:56.549Z",
-          "finishedAt": "2026-05-02T16:55:57.523Z"
+          "startedAt": "2026-05-02T17:16:10.100Z",
+          "finishedAt": "2026-05-02T17:16:10.921Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:57.523Z",
-          "finishedAt": "2026-05-02T16:55:58.470Z"
+          "startedAt": "2026-05-02T17:16:10.921Z",
+          "finishedAt": "2026-05-02T17:16:11.787Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:58.470Z",
-          "finishedAt": "2026-05-02T16:55:59.364Z"
+          "startedAt": "2026-05-02T17:16:11.787Z",
+          "finishedAt": "2026-05-02T17:16:12.907Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-02T16:55:42.228Z",
-      "finishedAt": "2026-05-02T16:55:59.364Z"
+      "startedAt": "2026-05-02T17:15:56.329Z",
+      "finishedAt": "2026-05-02T17:16:12.907Z"
     },
     {
       "device": "Desktop",
       "browser": "Chrome",
+      "optional": false,
       "status": "bestanden",
       "testedAt": "2026-05-02",
       "testedBy": "Codex",
@@ -271,132 +503,227 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:55:59.508Z",
-          "finishedAt": "2026-05-02T16:56:00.778Z"
+          "startedAt": "2026-05-02T17:16:13.046Z",
+          "finishedAt": "2026-05-02T17:16:14.601Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:00.778Z",
-          "finishedAt": "2026-05-02T16:56:01.651Z"
+          "startedAt": "2026-05-02T17:16:14.601Z",
+          "finishedAt": "2026-05-02T17:16:15.478Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:01.651Z",
-          "finishedAt": "2026-05-02T16:56:01.652Z"
+          "startedAt": "2026-05-02T17:16:15.478Z",
+          "finishedAt": "2026-05-02T17:16:15.480Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:01.652Z",
-          "finishedAt": "2026-05-02T16:56:02.427Z"
+          "startedAt": "2026-05-02T17:16:15.480Z",
+          "finishedAt": "2026-05-02T17:16:16.355Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:02.428Z",
-          "finishedAt": "2026-05-02T16:56:03.236Z"
+          "startedAt": "2026-05-02T17:16:16.355Z",
+          "finishedAt": "2026-05-02T17:16:17.251Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:03.236Z",
-          "finishedAt": "2026-05-02T16:56:04.604Z"
+          "startedAt": "2026-05-02T17:16:17.251Z",
+          "finishedAt": "2026-05-02T17:16:18.245Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:04.604Z",
-          "finishedAt": "2026-05-02T16:56:07.400Z"
+          "startedAt": "2026-05-02T17:16:18.245Z",
+          "finishedAt": "2026-05-02T17:16:21.043Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:07.400Z",
-          "finishedAt": "2026-05-02T16:56:09.231Z"
+          "startedAt": "2026-05-02T17:16:21.043Z",
+          "finishedAt": "2026-05-02T17:16:22.907Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:09.231Z",
-          "finishedAt": "2026-05-02T16:56:09.282Z"
+          "startedAt": "2026-05-02T17:16:22.907Z",
+          "finishedAt": "2026-05-02T17:16:22.968Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:09.282Z",
-          "finishedAt": "2026-05-02T16:56:10.723Z"
+          "startedAt": "2026-05-02T17:16:22.968Z",
+          "finishedAt": "2026-05-02T17:16:24.283Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:10.723Z",
-          "finishedAt": "2026-05-02T16:56:11.070Z"
+          "startedAt": "2026-05-02T17:16:24.283Z",
+          "finishedAt": "2026-05-02T17:16:25.126Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:11.070Z",
-          "finishedAt": "2026-05-02T16:56:11.427Z"
+          "startedAt": "2026-05-02T17:16:25.126Z",
+          "finishedAt": "2026-05-02T17:16:25.979Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:11.427Z",
-          "finishedAt": "2026-05-02T16:56:12.154Z"
+          "startedAt": "2026-05-02T17:16:25.979Z",
+          "finishedAt": "2026-05-02T17:16:26.358Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:12.154Z",
-          "finishedAt": "2026-05-02T16:56:13.234Z"
+          "startedAt": "2026-05-02T17:16:26.358Z",
+          "finishedAt": "2026-05-02T17:16:27.222Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:13.234Z",
-          "finishedAt": "2026-05-02T16:56:14.315Z"
+          "startedAt": "2026-05-02T17:16:27.222Z",
+          "finishedAt": "2026-05-02T17:16:28.352Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:14.315Z",
-          "finishedAt": "2026-05-02T16:56:15.215Z"
+          "startedAt": "2026-05-02T17:16:28.352Z",
+          "finishedAt": "2026-05-02T17:16:29.382Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-02T16:56:15.215Z",
-          "finishedAt": "2026-05-02T16:56:16.023Z"
+          "startedAt": "2026-05-02T17:16:29.382Z",
+          "finishedAt": "2026-05-02T17:16:30.332Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-02T16:55:59.372Z",
-      "finishedAt": "2026-05-02T16:56:16.023Z"
+      "startedAt": "2026-05-02T17:16:12.915Z",
+      "finishedAt": "2026-05-02T17:16:30.333Z"
     },
     {
       "device": "Desktop",
       "browser": "Firefox",
-      "status": "offen",
+      "optional": false,
+      "status": "bestanden",
       "testedAt": "2026-05-02",
       "testedBy": "Codex",
-      "notes": "offen – Firefox ist auf diesem Rechner nicht installiert; Installation wurde in diesem Lauf bewusst nicht vorausgesetzt",
+      "notes": "Playwright-Firefox-Lauf gegen Production",
       "findings": [],
-      "steps": [],
-      "available": false
-    },
-    {
-      "device": "optional macOS",
-      "browser": "Safari",
-      "status": "optional",
-      "testedAt": "2026-05-02",
-      "testedBy": "Codex",
-      "notes": "optional – in diesem Lauf nicht automatisiert abgedeckt",
-      "findings": [],
-      "steps": [],
-      "available": false
+      "steps": [
+        {
+          "name": "Startseite direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:31.303Z",
+          "finishedAt": "2026-05-02T17:16:33.035Z"
+        },
+        {
+          "name": "Suche öffnen und schließen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:33.035Z",
+          "finishedAt": "2026-05-02T17:16:33.966Z"
+        },
+        {
+          "name": "Sticky Header über Scrollstrecke sichtbar",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:33.966Z",
+          "finishedAt": "2026-05-02T17:16:33.969Z"
+        },
+        {
+          "name": "/soforthilfe direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:33.970Z",
+          "finishedAt": "2026-05-02T17:16:34.878Z"
+        },
+        {
+          "name": "/notfallkarte direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:34.878Z",
+          "finishedAt": "2026-05-02T17:16:35.716Z"
+        },
+        {
+          "name": "/notfallkarte/erstellen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:35.716Z",
+          "finishedAt": "2026-05-02T17:16:36.695Z"
+        },
+        {
+          "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:36.695Z",
+          "finishedAt": "2026-05-02T17:16:39.998Z"
+        },
+        {
+          "name": "Notfallkarte Druckansicht",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:39.998Z",
+          "finishedAt": "2026-05-02T17:16:41.806Z"
+        },
+        {
+          "name": "Notfallkarte löschen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:41.806Z",
+          "finishedAt": "2026-05-02T17:16:41.909Z"
+        },
+        {
+          "name": "/materialien + Filter",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:41.910Z",
+          "finishedAt": "2026-05-02T17:16:42.957Z"
+        },
+        {
+          "name": "Materialien Textversion öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:42.957Z",
+          "finishedAt": "2026-05-02T17:16:43.830Z"
+        },
+        {
+          "name": "Materialien PDF inline öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:43.830Z",
+          "finishedAt": "2026-05-02T17:16:44.809Z"
+        },
+        {
+          "name": "Materialien PDF herunterladen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:44.809Z",
+          "finishedAt": "2026-05-02T17:16:45.056Z"
+        },
+        {
+          "name": "/diagnostik direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:45.056Z",
+          "finishedAt": "2026-05-02T17:16:45.897Z"
+        },
+        {
+          "name": "/grenzen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:45.897Z",
+          "finishedAt": "2026-05-02T17:16:46.935Z"
+        },
+        {
+          "name": "/beratung direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:46.935Z",
+          "finishedAt": "2026-05-02T17:16:47.958Z"
+        },
+        {
+          "name": "/quellen direkt öffnen",
+          "status": "passed",
+          "startedAt": "2026-05-02T17:16:47.958Z",
+          "finishedAt": "2026-05-02T17:16:48.899Z"
+        }
+      ],
+      "available": true,
+      "startedAt": "2026-05-02T17:16:30.942Z",
+      "finishedAt": "2026-05-02T17:16:48.899Z"
     }
   ],
-  "releaseDecision": "blocked"
+  "releaseDecision": "green-with-notes"
 }

--- a/qa/release-browser-matrix.md
+++ b/qa/release-browser-matrix.md
@@ -107,18 +107,18 @@ Dabei prüfen:
 ## Browser-Matrix
 
 - Release / PR: main
-- Commit / Deploy-Stand: 03acade
+- Commit / Deploy-Stand: 3225022
 - Datum: 2026-05-02
 - Basis-URL: https://borderline-angehoerige.netlify.app
 
-| Gerät          | Browser | Status                | Notizen                                                                                                                 |
-| -------------- | ------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| iPhone         | Safari  | offen                 | offen – kein echter iOS/WebKit-Lauf auf diesem Rechner ohne zusätzliche Browser-Binaries oder Hardware                  |
-| iPhone         | Chrome  | bestanden mit Hinweis | mobile Chrome-Emulation in Chromium; kein echter iOS-Lauf, aber Pflichtpfade und Flows technisch grün                   |
-| Android        | Chrome  | bestanden mit Hinweis | mobile Chrome-Emulation in Chromium; Pflichtpfade und Flows technisch grün                                              |
-| Desktop        | Chrome  | bestanden             | Playwright-Lauf gegen Production mit System-Chrome/Chromium                                                             |
-| Desktop        | Firefox | offen                 | offen – Firefox ist auf diesem Rechner nicht installiert; Installation wurde in diesem Lauf bewusst nicht vorausgesetzt |
-| optional macOS | Safari  | optional              | optional – in diesem Lauf nicht automatisiert abgedeckt                                                                 |
+| Gerät          | Browser | Status                | Notizen                                                                                               |
+| -------------- | ------- | --------------------- | ----------------------------------------------------------------------------------------------------- |
+| iPhone         | Safari  | bestanden mit Hinweis | Playwright WebKit mit iPhone-13-Emulation; starke WebKit-Abdeckung, aber kein physisches iOS-Gerät    |
+| optional macOS | Safari  | bestanden mit Hinweis | Playwright WebKit-Desktoplauf als Safari-Näherung; optionaler Zusatzcheck                             |
+| iPhone         | Chrome  | bestanden mit Hinweis | mobile Chrome-Emulation in Chromium; kein echter iOS-Lauf, aber Pflichtpfade und Flows technisch grün |
+| Android        | Chrome  | bestanden mit Hinweis | mobile Chrome-Emulation in Chromium; Pflichtpfade und Flows technisch grün                            |
+| Desktop        | Chrome  | bestanden             | Playwright-Lauf gegen Production mit System-Chrome/Chromium                                           |
+| Desktop        | Firefox | bestanden             | Playwright-Firefox-Lauf gegen Production                                                              |
 
 ### Kritische Befunde
 
@@ -127,12 +127,12 @@ Dabei prüfen:
 ### Freigabeentscheidung
 
 - [ ] Matrix vollständig grün
-- [ ] grün mit dokumentierten Resthinweisen
-- [x] nicht freigabefähig
+- [x] grün mit dokumentierten Resthinweisen
+- [ ] nicht freigabefähig
 
 ### Methodik
 
-- Desktop Chrome wurde automatisiert über Playwright gegen Production geprüft.
-- iPhone Chrome und Android Chrome wurden als mobile Chrome-Profile in Chromium emuliert; ohne den gemeinsamen Druck-Befund wären sie als `bestanden mit Hinweis` einzuordnen.
-- iPhone Safari und Desktop Firefox bleiben offen, weil auf diesem Rechner weder ein echter iOS/WebKit-Lauf noch Firefox-Automation ohne zusätzliche Softwareinstallation verfügbar war.
-- Optionales macOS Safari wurde in diesem Lauf nicht automatisiert erfasst und bleibt separat optional.
+- Desktop Chrome und Desktop Firefox wurden automatisiert über Playwright gegen Production geprüft, sofern die jeweiligen Browser-Binaries auf diesem Rechner verfügbar waren.
+- iPhone Safari wurde als Playwright-WebKit-Profil mit iPhone-13-Emulation geprüft; das ist eine starke WebKit-Abdeckung, aber kein physischer iOS-Hardwarelauf.
+- iPhone Chrome und Android Chrome wurden als mobile Chrome-Profile in Chromium emuliert und als technische Cross-Checks mitgeführt.
+- Optionales macOS Safari wird als zusätzlicher WebKit-Desktoplauf geführt, wenn WebKit lokal verfügbar ist; es bleibt ein Zusatzcheck außerhalb der Pflichtmatrix.

--- a/qa/scripts/release-browser-matrix.mjs
+++ b/qa/scripts/release-browser-matrix.mjs
@@ -1,12 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { chromium, devices, firefox, webkit } from "playwright";
-import {
-  BASE_URL,
-  qaPath,
-  routeUrl,
-  writeJson,
-} from "./a11y-shared.mjs";
+import { BASE_URL, qaPath, routeUrl, writeJson } from "./a11y-shared.mjs";
 
 const TODAY = "2026-05-02";
 const REPORT_NAME = "release-browser-matrix.json";
@@ -642,17 +637,14 @@ async function main() {
   const hasHardFailure = profiles.some(
     profile => profile.status === "nicht bestanden" && !profile.optional
   );
-    const hasMandatoryOpen =
-      profiles.some(
-        profile =>
-          !profile.optional && profile.status === "offen"
-      ) ||
-      profiles.some(
-        profile =>
-          profile.device === "iPhone" &&
-          profile.browser === "Safari" &&
-          profile.status === "offen"
-      );
+  const hasMandatoryOpen =
+    profiles.some(profile => !profile.optional && profile.status === "offen") ||
+    profiles.some(
+      profile =>
+        profile.device === "iPhone" &&
+        profile.browser === "Safari" &&
+        profile.status === "offen"
+    );
 
   const report = {
     label: runLabel(),

--- a/qa/scripts/release-browser-matrix.mjs
+++ b/qa/scripts/release-browser-matrix.mjs
@@ -1,9 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { devices } from "playwright";
+import { chromium, devices, firefox, webkit } from "playwright";
 import {
   BASE_URL,
-  launchBrowser,
   qaPath,
   routeUrl,
   writeJson,
@@ -36,7 +35,34 @@ function chromeContextOptions() {
   };
 }
 
+function desktopFirefoxContextOptions() {
+  return {
+    viewport: { width: 1440, height: 960 },
+    locale: "de-CH",
+    ignoreHTTPSErrors: true,
+    acceptDownloads: true,
+  };
+}
+
+function desktopSafariContextOptions() {
+  return {
+    viewport: { width: 1440, height: 960 },
+    locale: "de-CH",
+    ignoreHTTPSErrors: true,
+    acceptDownloads: true,
+  };
+}
+
 function iPhoneChromeEmulation() {
+  return {
+    ...devices["iPhone 13"],
+    locale: "de-CH",
+    acceptDownloads: true,
+    ignoreHTTPSErrors: true,
+  };
+}
+
+function iPhoneSafariEmulation() {
   return {
     ...devices["iPhone 13"],
     locale: "de-CH",
@@ -52,6 +78,27 @@ function androidChromeEmulation() {
     acceptDownloads: true,
     ignoreHTTPSErrors: true,
   };
+}
+
+async function launchBrowserForEngine(engine) {
+  if (engine === "chromium") {
+    return chromium.launch({
+      headless: true,
+      executablePath:
+        process.env.PLAYWRIGHT_EXECUTABLE_PATH ??
+        "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    });
+  }
+
+  if (engine === "firefox") {
+    return firefox.launch({ headless: true });
+  }
+
+  if (engine === "webkit") {
+    return webkit.launch({ headless: true });
+  }
+
+  throw new Error(`Unbekannte Browser-Engine: ${engine}`);
 }
 
 async function openPage(browser, contextOptions) {
@@ -284,12 +331,30 @@ async function runFlow(page, profile) {
     }
 
     const inlinePage = await page.context().newPage();
-    await inlinePage.goto(new URL(inlineHref, BASE_URL).toString(), {
-      waitUntil: "domcontentloaded",
-    });
-    if (!inlinePage.url().includes("/api/material-download/")) {
-      throw new Error(`unerwartete Inline-PDF-URL: ${inlinePage.url()}`);
+    const inlineUrl = new URL(inlineHref, BASE_URL).toString();
+
+    try {
+      await inlinePage.goto(inlineUrl, {
+        waitUntil: "domcontentloaded",
+      });
+      if (!inlinePage.url().includes("/api/material-download/")) {
+        throw new Error(`unerwartete Inline-PDF-URL: ${inlinePage.url()}`);
+      }
+    } catch (error) {
+      const message = normalizeError(error);
+      if (!message.includes("Download is starting")) {
+        throw error;
+      }
     }
+
+    const response = await fetch(inlineUrl, { redirect: "follow" });
+    const contentType = response.headers.get("content-type") ?? "";
+    if (!response.ok || !contentType.includes("application/pdf")) {
+      throw new Error(
+        `Inline-PDF-Response unerwartet: ${response.status} ${contentType}`
+      );
+    }
+
     await inlinePage.close();
   });
 
@@ -327,6 +392,7 @@ function unavailableProfile({ device, browser, optional = false, notes }) {
   return {
     device,
     browser,
+    optional,
     status: optional ? "optional" : "offen",
     testedAt: TODAY,
     testedBy: "Codex",
@@ -349,6 +415,7 @@ async function runProfile(browser, profile) {
     return {
       device: profile.device,
       browser: profile.browser,
+      optional: Boolean(profile.optional),
       status: hasFailures ? "nicht bestanden" : profile.passStatus,
       testedAt: TODAY,
       testedBy: "Codex",
@@ -362,6 +429,35 @@ async function runProfile(browser, profile) {
   } finally {
     console.error(`[browser-matrix] finish profile ${profile.slug}`);
     await context.close();
+  }
+}
+
+async function runProfileBatch({ engine, profiles, unavailableNotes }) {
+  let browser;
+
+  try {
+    browser = await launchBrowserForEngine(engine);
+  } catch (error) {
+    return profiles.map(profile =>
+      unavailableProfile({
+        device: profile.device,
+        browser: profile.browser,
+        optional: profile.optional,
+        notes: unavailableNotes(profile, error),
+      })
+    );
+  }
+
+  try {
+    const results = [];
+
+    for (const profile of profiles) {
+      results.push(await runProfile(browser, profile));
+    }
+
+    return results;
+  } finally {
+    await browser.close();
   }
 }
 
@@ -417,16 +513,16 @@ function markdownReport(report) {
 
   lines.push("", "### Methodik", "");
   lines.push(
-    "- Desktop Chrome wurde automatisiert über Playwright gegen Production geprüft."
+    "- Desktop Chrome und Desktop Firefox wurden automatisiert über Playwright gegen Production geprüft, sofern die jeweiligen Browser-Binaries auf diesem Rechner verfügbar waren."
   );
   lines.push(
-    "- iPhone Chrome und Android Chrome wurden als mobile Chrome-Profile in Chromium emuliert; ohne den gemeinsamen Druck-Befund wären sie als `bestanden mit Hinweis` einzuordnen."
+    "- iPhone Safari wurde als Playwright-WebKit-Profil mit iPhone-13-Emulation geprüft; das ist eine starke WebKit-Abdeckung, aber kein physischer iOS-Hardwarelauf."
   );
   lines.push(
-    "- iPhone Safari und Desktop Firefox bleiben offen, weil auf diesem Rechner weder ein echter iOS/WebKit-Lauf noch Firefox-Automation ohne zusätzliche Softwareinstallation verfügbar war."
+    "- iPhone Chrome und Android Chrome wurden als mobile Chrome-Profile in Chromium emuliert und als technische Cross-Checks mitgeführt."
   );
   lines.push(
-    "- Optionales macOS Safari wurde in diesem Lauf nicht automatisiert erfasst und bleibt separat optional."
+    "- Optionales macOS Safari wird als zusätzlicher WebKit-Desktoplauf geführt, wenn WebKit lokal verfügbar ist; es bleibt ein Zusatzcheck außerhalb der Pflichtmatrix."
   );
 
   return `${lines.join("\n")}\n`;
@@ -450,79 +546,106 @@ async function gitHead() {
 
 async function main() {
   const write = process.argv.includes("--write");
-  const browser = await launchBrowser();
+  const profiles = [];
 
-  try {
-    const profiles = [];
+  profiles.push(
+    ...(await runProfileBatch({
+      engine: "webkit",
+      profiles: [
+        {
+          slug: "iphone-safari",
+          device: "iPhone",
+          browser: "Safari",
+          kind: "mobile",
+          contextOptions: iPhoneSafariEmulation(),
+          passStatus: "bestanden mit Hinweis",
+          notes:
+            "Playwright WebKit mit iPhone-13-Emulation; starke WebKit-Abdeckung, aber kein physisches iOS-Gerät",
+        },
+        {
+          slug: "desktop-safari",
+          device: "optional macOS",
+          browser: "Safari",
+          kind: "desktop",
+          optional: true,
+          contextOptions: desktopSafariContextOptions(),
+          passStatus: "bestanden mit Hinweis",
+          notes:
+            "Playwright WebKit-Desktoplauf als Safari-Näherung; optionaler Zusatzcheck",
+        },
+      ],
+      unavailableNotes: (profile, error) =>
+        profile.optional
+          ? `optional – WebKit nicht verfügbar: ${normalizeError(error)}`
+          : `offen – WebKit nicht verfügbar: ${normalizeError(error)}`,
+    }))
+  );
 
-    profiles.push(
-      unavailableProfile({
-        device: "iPhone",
-        browser: "Safari",
-        notes:
-          "offen – kein echter iOS/WebKit-Lauf auf diesem Rechner ohne zusätzliche Browser-Binaries oder Hardware",
-      })
-    );
+  profiles.push(
+    ...(await runProfileBatch({
+      engine: "chromium",
+      profiles: [
+        {
+          slug: "iphone-chrome",
+          device: "iPhone",
+          browser: "Chrome",
+          kind: "mobile",
+          contextOptions: iPhoneChromeEmulation(),
+          passStatus: "bestanden mit Hinweis",
+          notes:
+            "mobile Chrome-Emulation in Chromium; kein echter iOS-Lauf, aber Pflichtpfade und Flows technisch grün",
+        },
+        {
+          slug: "android-chrome",
+          device: "Android",
+          browser: "Chrome",
+          kind: "mobile",
+          contextOptions: androidChromeEmulation(),
+          passStatus: "bestanden mit Hinweis",
+          notes:
+            "mobile Chrome-Emulation in Chromium; Pflichtpfade und Flows technisch grün",
+        },
+        {
+          slug: "desktop-chrome",
+          device: "Desktop",
+          browser: "Chrome",
+          kind: "desktop",
+          contextOptions: chromeContextOptions(),
+          passStatus: "bestanden",
+          notes: "Playwright-Lauf gegen Production mit System-Chrome/Chromium",
+        },
+      ],
+      unavailableNotes: (_profile, error) =>
+        `offen – Chromium/Chrome nicht verfügbar: ${normalizeError(error)}`,
+    }))
+  );
 
-    for (const profile of [
-      {
-        slug: "iphone-chrome",
-        device: "iPhone",
-        browser: "Chrome",
-        kind: "mobile",
-        contextOptions: iPhoneChromeEmulation(),
-        passStatus: "bestanden mit Hinweis",
-        notes:
-          "mobile Chrome-Emulation in Chromium; kein echter iOS-Lauf, aber Pflichtpfade und Flows technisch grün",
-      },
-      {
-        slug: "android-chrome",
-        device: "Android",
-        browser: "Chrome",
-        kind: "mobile",
-        contextOptions: androidChromeEmulation(),
-        passStatus: "bestanden mit Hinweis",
-        notes:
-          "mobile Chrome-Emulation in Chromium; Pflichtpfade und Flows technisch grün",
-      },
-      {
-        slug: "desktop-chrome",
-        device: "Desktop",
-        browser: "Chrome",
-        kind: "desktop",
-        contextOptions: chromeContextOptions(),
-        passStatus: "bestanden",
-        notes: "Playwright-Lauf gegen Production mit System-Chrome/Chromium",
-      },
-    ]) {
-      profiles.push(await runProfile(browser, profile));
-    }
+  profiles.push(
+    ...(await runProfileBatch({
+      engine: "firefox",
+      profiles: [
+        {
+          slug: "desktop-firefox",
+          device: "Desktop",
+          browser: "Firefox",
+          kind: "desktop",
+          contextOptions: desktopFirefoxContextOptions(),
+          passStatus: "bestanden",
+          notes: "Playwright-Firefox-Lauf gegen Production",
+        },
+      ],
+      unavailableNotes: (_profile, error) =>
+        `offen – Firefox nicht verfügbar: ${normalizeError(error)}`,
+    }))
+  );
 
-    profiles.push(
-      unavailableProfile({
-        device: "Desktop",
-        browser: "Firefox",
-        notes:
-          "offen – Firefox ist auf diesem Rechner nicht installiert; Installation wurde in diesem Lauf bewusst nicht vorausgesetzt",
-      })
-    );
-
-    profiles.push(
-      unavailableProfile({
-        device: "optional macOS",
-        browser: "Safari",
-        optional: true,
-        notes: "optional – in diesem Lauf nicht automatisiert abgedeckt",
-      })
-    );
-
-    const hasHardFailure = profiles.some(
-      profile => profile.status === "nicht bestanden"
-    );
+  const hasHardFailure = profiles.some(
+    profile => profile.status === "nicht bestanden" && !profile.optional
+  );
     const hasMandatoryOpen =
       profiles.some(
         profile =>
-          !profile.browser.startsWith("Safari") && profile.status === "offen"
+          !profile.optional && profile.status === "offen"
       ) ||
       profiles.some(
         profile =>
@@ -531,34 +654,31 @@ async function main() {
           profile.status === "offen"
       );
 
-    const report = {
-      label: runLabel(),
-      createdAt: nowIso(),
-      baseUrl: BASE_URL,
-      gitHead: await gitHead(),
-      profiles,
-      releaseDecision:
-        hasHardFailure || hasMandatoryOpen ? "blocked" : "green-with-notes",
-    };
+  const report = {
+    label: runLabel(),
+    createdAt: nowIso(),
+    baseUrl: BASE_URL,
+    gitHead: await gitHead(),
+    profiles,
+    releaseDecision:
+      hasHardFailure || hasMandatoryOpen ? "blocked" : "green-with-notes",
+  };
 
-    const markdown = markdownReport(report);
+  const markdown = markdownReport(report);
 
-    if (write) {
-      await writeJson(REPORT_NAME, report);
+  if (write) {
+    await writeJson(REPORT_NAME, report);
 
-      const matrixPath = path.resolve(qaPath("release-browser-matrix.md"));
-      const original = await fs.readFile(matrixPath, "utf8");
-      const marker = "\n## Letzter Lauf\n";
-      const nextContent = original.includes(marker)
-        ? `${original.split(marker)[0]}${marker}\n${markdown}`
-        : `${original.trimEnd()}\n\n## Letzter Lauf\n\n${markdown}`;
-      await fs.writeFile(matrixPath, `${nextContent.trimEnd()}\n`);
-    }
-
-    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
-  } finally {
-    await browser.close();
+    const matrixPath = path.resolve(qaPath("release-browser-matrix.md"));
+    const original = await fs.readFile(matrixPath, "utf8");
+    const marker = "\n## Letzter Lauf\n";
+    const nextContent = original.includes(marker)
+      ? `${original.split(marker)[0]}${marker}\n${markdown}`
+      : `${original.trimEnd()}\n\n## Letzter Lauf\n\n${markdown}`;
+    await fs.writeFile(matrixPath, `${nextContent.trimEnd()}\n`);
   }
+
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
 }
 
 await main();


### PR DESCRIPTION
## Summary
- run the release browser matrix against real Playwright WebKit and Firefox profiles
- treat inline PDF handling as valid across browsers when the response is a correct PDF even if the engine downloads instead of previewing
- refresh the checked-in production matrix report to the new browser coverage state

## Verification
- pnpm audit:browser-matrix
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
