### PR TITLE
Prepare fachliche Freigabe sign-off draft

### DIFF
--- a/docs/governance/fachliche-freigabe-2026-05-02.md
+++ b/docs/governance/fachliche-freigabe-2026-05-02.md
@@ -10,7 +10,7 @@ fachlich verantwortliche Person erfolgen.
 ## Fachliche Freigabe
 
 - Release / PR: `main`
-- Commit / Deploy-Stand bei Vorbereitung: `eb4e07e`
+- Commit / Deploy-Stand bei Vorbereitung: `043a4ff`
 - Datum der technischen Vorbereitung: `2026-05-02`
 - Fachlich pruefende Person: ausstehend
 - Rolle / Funktion: ausstehend
@@ -35,8 +35,42 @@ fachlich verantwortliche Person erfolgen.
 - [x] SEO- / Metadaten-Audit
 - [x] Security- / Caching-Audit
 - [x] PDF- / Download-Audit fuer lokale und kanonische Materialien
-- [x] Browser-Matrix technisch soweit automatisiert dokumentiert unter
+- [x] Browser-Matrix technisch gruen mit Hinweisen dokumentiert unter
       `qa/release-browser-matrix.md`
+
+### Technischer Gate-Stand am Vorbereitungsdatum
+
+- [x] keine offenen technischen Release-Blocker im geprueften Scope
+- [x] Notfallkarten-Druckpfad auf Production verifiziert
+- [x] PDF- / Download-Pfade auf Production verifiziert
+- [x] Browser-Matrix Pflichtteil auf Production bestanden
+
+### Unterlagen fuer die fachliche Pruefung
+
+- `docs/governance/10-fachliche-freigabe-vorlage.md`
+- `qa/release-browser-matrix.md`
+- `qa/audit-pdf-handouts.md`
+- `client/src/data/kontakte.ts`
+
+### Empfohlene fachliche Pruefreihenfolge
+
+1. Akute Krisen- und Notfallinhalte:
+   `/soforthilfe`, `/notfallkarte`, lokale Notfall-PDFs
+2. Kontakt- und Beratungsinhalte:
+   `client/src/data/kontakte.ts`, `/beratung`, `/unterstuetzen/krise`
+3. Medizinisch / fachlich sensible Lesestrecken:
+   `/diagnostik`, `/begleiterkrankungen`, `/grenzen`, `/quellen`
+
+### Konkrete fachliche Fokusfragen
+
+- Stimmen Notfallnummern, PUK-Daten und Beratungsangaben in Website,
+  Notfallkarte und Kontaktregister inhaltlich ueberein?
+- Sind rechtliche und medizinische Begriffe fuer Angehoerige korrekt und
+  nicht missverstaendlich formuliert?
+- Passen Krisenhinweise, Eskalationslogik und lokale Einordnung fuer
+  Schweiz / Zuerich?
+- Sind Quellen- und Review-Hinweise fuer Hochrisiko-Seiten fachlich
+  plausibel und aktuell genug?
 
 ### Pruefgegenstaende
 
@@ -56,7 +90,8 @@ fachlich verantwortliche Person erfolgen.
 
 ### Hinweise / Auflagen
 
-- Die technische Release-Vorbereitung ist weitgehend gruen.
+- Die technische Release-Vorbereitung ist gruen mit dokumentierten
+  Resthinweisen aus der Browser-Matrix-Methodik.
 - Die letzte inhaltliche Freigabe fuer Hochrisiko-Seiten muss bewusst durch
   eine fachlich verantwortliche Person erfolgen.
 - Ohne dokumentiertes fachliches Sign-off soll das Release nicht als


### PR DESCRIPTION
## Summary
- update the fachliche Freigabe draft to the current deploy and audit state
- prefill the technical release status and review references for the fachlich verantwortliche Person
- keep the actual fachliche sign-off checkboxes intentionally open

## Verification
- documentation only
