### PR TITLE
Clarify notfallkarte privacy and local storage

### DIFF
--- a/client/src/__tests__/datenschutz.test.tsx
+++ b/client/src/__tests__/datenschutz.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ElementType, HTMLAttributes, ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import Datenschutz from "@/pages/Datenschutz";
+
+const MOTION_PROPS = new Set([
+  "animate",
+  "exit",
+  "initial",
+  "layout",
+  "layoutId",
+  "onAnimationComplete",
+  "onUpdate",
+  "transition",
+  "variants",
+  "viewport",
+  "whileHover",
+  "whileInView",
+  "whileTap",
+]);
+
+function stripMotionProps(props: Record<string, unknown>) {
+  return Object.fromEntries(
+    Object.entries(props).filter(([key]) => !MOTION_PROPS.has(key))
+  );
+}
+
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get:
+        (_target, tag: string) =>
+        ({
+          children,
+          ...props
+        }: HTMLAttributes<HTMLElement> & {
+          children?: ReactNode;
+        }) => {
+          const Tag = tag as ElementType;
+          return (
+            <Tag {...stripMotionProps(props as Record<string, unknown>)}>
+              {children}
+            </Tag>
+          );
+        },
+    }
+  ),
+  AnimatePresence: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe("Datenschutz", () => {
+  it("explains local browser storage for the personal notfallkarte", () => {
+    render(<Datenschutz />);
+
+    const sectionToggle = screen.getByRole("button", {
+      name: /Persönliche Notfallkarte und lokale Speicherung/i,
+    });
+    expect(sectionToggle).toBeInTheDocument();
+    fireEvent.click(sectionToggle);
+    expect(document.body).toHaveTextContent(
+      /lokal im Browser auf Ihrem Gerät/i
+    );
+    expect(document.body).toHaveTextContent(
+      /nicht an einen Server dieser Website übertragen/i
+    );
+    expect(
+      screen.getByText(/gemeinsam genutzten Geräten/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/«Daten löschen»/i)).toBeInTheDocument();
+
+    const cookiesToggle = screen.getByRole("button", {
+      name: /Cookies/i,
+    });
+    fireEvent.click(cookiesToggle);
+    expect(document.body).toHaveTextContent(
+      /verwendet für ihre eigenen Einträge kein Cookie/i
+    );
+  });
+});

--- a/client/src/__tests__/notfallkarte-storage.test.tsx
+++ b/client/src/__tests__/notfallkarte-storage.test.tsx
@@ -80,7 +80,7 @@ function renderPage() {
 }
 
 describe("Notfallkarte storage fallbacks", () => {
-  it("does not report a successful save when browser storage is blocked", () => {
+  it("shows a clear alert when browser storage is blocked", () => {
     vi.spyOn(Storage.prototype, "getItem").mockReturnValue(null);
     vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
       throw new DOMException("Storage blocked", "QuotaExceededError");
@@ -89,15 +89,11 @@ describe("Notfallkarte storage fallbacks", () => {
 
     renderPage();
 
-    const saveButton = screen.getByRole("button", {
-      name: /im browser speichern/i,
-    });
-    fireEvent.click(saveButton);
-
-    expect(saveButton).toHaveTextContent("Im Browser speichern");
-    expect(screen.queryByText(/gespeichert ✓/i)).not.toBeInTheDocument();
     expect(screen.getByRole("alert")).toHaveTextContent(
       /speichern nicht möglich/i
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /eingaben bleiben dann möglicherweise nicht auf diesem gerät erhalten/i
     );
   });
 
@@ -123,5 +119,23 @@ describe("Notfallkarte storage fallbacks", () => {
       expect.objectContaining({ type: "notfallkarte-print-data" }),
       window.location.origin
     );
+  });
+
+  it("tells people that entries are saved automatically in the browser", () => {
+    renderPage();
+
+    expect(
+      screen.getByText(/Änderungen werden automatisch lokal gespeichert\./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /werden nicht an einen Server dieser Website übertragen/i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /lokale notfallkarten-daten löschen/i,
+      })
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/pages/Datenschutz.tsx
+++ b/client/src/pages/Datenschutz.tsx
@@ -212,6 +212,47 @@ export default function Datenschutz() {
               </Card>
             </ContentSection>
 
+            <ContentSection
+              title="Persönliche Notfallkarte und lokale Speicherung"
+              icon={<Lock className="w-7 h-7 text-sage-dark" />}
+              id="notfallkarte-lokal"
+              preview="Persönliche Einträge der Notfallkarte bleiben lokal im Browser und werden nicht an den Server dieser Website übertragen."
+            >
+              <Card className="border-border/50">
+                <CardContent className="p-6">
+                  <div className="text-muted-foreground leading-relaxed space-y-4">
+                    <p>
+                      Die persönliche Notfallkarte kann{" "}
+                      <strong>personenbezogene Angaben</strong> enthalten, zum
+                      Beispiel Namen, Telefonnummern, Beziehungen,
+                      Beruhigungsstrategien oder freie Notizen.
+                    </p>
+                    <p>
+                      Diese Angaben werden{" "}
+                      <strong>lokal im Browser auf Ihrem Gerät</strong>{" "}
+                      gespeichert, damit die Notfallkarte zwischen Ihren
+                      Besuchen erhalten bleibt. Die Daten werden dabei{" "}
+                      <strong>nicht an einen Server dieser Website</strong>{" "}
+                      übertragen.
+                    </p>
+                    <p>
+                      Wichtig: Auf <strong>gemeinsam genutzten Geräten</strong>{" "}
+                      können andere Personen diese Einträge sehen, wenn sie
+                      denselben Browser verwenden. Wenn die Angaben nicht auf
+                      dem Gerät bleiben sollen, können Sie sie in der
+                      Notfallkarte über <strong>«Daten löschen»</strong>{" "}
+                      entfernen.
+                    </p>
+                    <p className="text-sm">
+                      Für die Druckansicht wird zusätzlich kurzfristig ein
+                      lokaler Zwischenspeicher im Browser verwendet. Auch diese
+                      Daten werden nicht an unsere Server übertragen.
+                    </p>
+                  </div>
+                </CardContent>
+              </Card>
+            </ContentSection>
+
             {/* Cookies */}
             <ContentSection
               title="Cookies"
@@ -240,6 +281,12 @@ export default function Datenschutz() {
                         Informationen.
                       </p>
                     </div>
+                    <p className="text-sm">
+                      Die persönliche Notfallkarte verwendet für ihre eigenen
+                      Einträge <strong>kein Cookie</strong>, sondern den lokalen
+                      Browser-Speicher (`localStorage`). Dieser unterscheidet
+                      sich von Cookies und wird nur auf Ihrem Gerät abgelegt.
+                    </p>
                     <p className="text-sm">
                       Sie können Ihren Browser so einstellen, dass Sie über das
                       Setzen von Cookies informiert werden und Cookies nur im
@@ -312,8 +359,8 @@ export default function Datenschutz() {
                     Die auf dieser Website angebotenen Infografiken und Handouts
                     können heruntergeladen werden. Beim Download werden keine
                     personenbezogenen Daten erfasst oder gespeichert. Die
-                    Materialien werden über einen Content Delivery Network (CDN)
-                    bereitgestellt.
+                    Materialien werden über die Website und ihren
+                    Hosting-Anbieter bereitgestellt.
                   </p>
                 </CardContent>
               </Card>
@@ -366,9 +413,12 @@ export default function Datenschutz() {
                       </li>
                     </ul>
                     <p className="text-sm">
-                      Da wir jedoch keine personenbezogenen Daten speichern
-                      (ausser den anonymisierten Server-Logfiles), sind diese
-                      Rechte in der Praxis selten relevant.
+                      Auf unseren Servern speichern wir grundsätzlich keine
+                      persönlichen Inhalte aus der Notfallkarte. Wenn Sie die
+                      persönliche Notfallkarte verwenden, können solche Angaben
+                      jedoch lokal in Ihrem Browser gespeichert sein. In diesem
+                      Fall können Sie die Einträge direkt auf Ihrem Gerät über
+                      «Daten löschen» entfernen.
                     </p>
                   </div>
                 </CardContent>

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -5,7 +5,7 @@
  * Brief: docs/redesign/phase-5-tier2-master-brief.md, Abschnitt
  * «Page 9 — Notfallkarte».
  */
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { EditorialPillButton } from "@/components/ui/EditorialPillButton";
 import {
   EditorialLayout,
@@ -263,36 +263,14 @@ function PersonalContactRow({
 
 export default function Notfallkarte() {
   const [data, setData] = useState<NotfallkarteData>(loadData);
-  const [saved, setSaved] = useState(false);
   const [storageError, setStorageError] = useState(false);
   const [announcement, setAnnouncement] = useState("");
-  const savedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     if (!isStorageAvailable()) setStorageError(true);
   }, []);
   useEffect(() => {
     if (!saveData(data)) setStorageError(true);
-  }, [data]);
-  useEffect(
-    () => () => {
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
-    },
-    []
-  );
-
-  const handleSave = useCallback(() => {
-    if (!saveData(data)) {
-      setStorageError(true);
-      setSaved(false);
-      setAnnouncement("Speichern nicht möglich");
-      return;
-    }
-
-    setSaved(true);
-    setAnnouncement("Im Browser gespeichert");
-    if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
-    savedTimerRef.current = setTimeout(() => setSaved(false), 2000);
   }, [data]);
 
   const handleDeleteData = useCallback(() => {
@@ -303,10 +281,8 @@ export default function Notfallkarte() {
     if (!confirmed) return;
 
     if (deleteStoredData()) {
-      if (savedTimerRef.current) clearTimeout(savedTimerRef.current);
       setData(EMPTY_DATA);
       setAnnouncement("Lokale Notfallkarten-Daten wurden gelöscht.");
-      setSaved(false);
     } else {
       setStorageError(true);
       setAnnouncement("Daten konnten nicht gelöscht werden.");
@@ -450,7 +426,8 @@ export default function Notfallkarte() {
             }}
           >
             <strong>Speichern nicht möglich</strong> – privater Modus oder
-            gesperrter Speicher. Bitte{" "}
+            gesperrter Speicher. Ihre Eingaben bleiben dann möglicherweise nicht
+            auf diesem Gerät erhalten. Bitte{" "}
             <button
               type="button"
               onClick={handlePrint}
@@ -727,12 +704,6 @@ export default function Notfallkarte() {
         <div className="mt-12 flex flex-wrap items-center justify-center gap-3 print:hidden">
           <PrimaryButton onClick={handlePrint}>Drucken / Als PDF</PrimaryButton>
           <SecondaryButton
-            onClick={handleSave}
-            ariaLabel="Im Browser speichern"
-          >
-            {saved ? "Gespeichert ✓" : "Im Browser speichern"}
-          </SecondaryButton>
-          <SecondaryButton
             onClick={handleDeleteData}
             ariaLabel="Lokale Notfallkarten-Daten löschen"
           >
@@ -742,9 +713,10 @@ export default function Notfallkarte() {
         <EditorialSection rule>
           <EditorialProse>
             <p>
-              <strong>Ihre Daten bleiben auf diesem Gerät.</strong> Alle Angaben
-              werden nur lokal in Ihrem Browser gespeichert und verlassen Ihr
-              Gerät nicht. Auf gemeinsam genutzten Geräten können andere
+              <strong>Änderungen werden automatisch lokal gespeichert.</strong>{" "}
+              Die Notfallkarte nutzt dafür den Speicher Ihres Browsers auf
+              diesem Gerät. Die Angaben werden nicht an einen Server dieser
+              Website übertragen. Auf gemeinsam genutzten Geräten können andere
               Personen diese Einträge sehen. Nutzen Sie «Daten löschen», wenn
               die Notfallkarte nicht auf diesem Gerät bleiben soll. Beim Drucken
               oder PDF-Export werden Ihre persönlichen Einträge mit ausgegeben.

--- a/docs/governance/notfallkarte-privacy-fix.md
+++ b/docs/governance/notfallkarte-privacy-fix.md
@@ -6,11 +6,13 @@ Status: als Umsetzungsanleitung für `client/src/pages/Notfallkarte.tsx` dokumen
 
 Die Notfallkarte speichert persönliche Einträge lokal im Browser. Für gemeinsam genutzte Geräte braucht es:
 
+- einen sichtbaren Hinweis auf automatische lokale Speicherung
 - einen sichtbaren Button `Daten löschen`
 - Löschung von `localStorage` und des temporären Print-Transfers
 - Rücksetzen auf leere Standarddaten
 - Screenreader-Statusmeldung
 - geschärften Hinweis auf gemeinsam genutzte Geräte
+- eine präzise Erklärung auf der Datenschutzseite
 
 ## Code-Bausteine
 
@@ -57,5 +59,19 @@ const handleDeleteData = useCallback(() => {
 ## Hinweistext
 
 ```txt
-Ihre Daten bleiben auf diesem Gerät. Alle Angaben werden nur lokal in Ihrem Browser gespeichert und verlassen Ihr Gerät nicht. Auf gemeinsam genutzten Geräten können andere Personen diese Einträge sehen. Nutzen Sie «Daten löschen», wenn die Notfallkarte nicht auf diesem Gerät bleiben soll.
+Änderungen werden automatisch lokal gespeichert. Die Notfallkarte nutzt dafür den Speicher Ihres Browsers auf diesem Gerät. Die Angaben werden nicht an einen Server dieser Website übertragen. Auf gemeinsam genutzten Geräten können andere Personen diese Einträge sehen. Nutzen Sie «Daten löschen», wenn die Notfallkarte nicht auf diesem Gerät bleiben soll.
 ```
+
+## Datenschutzseite
+
+Die Datenschutzerklärung soll einen eigenen Abschnitt
+`Persönliche Notfallkarte und lokale Speicherung` enthalten und sauber
+zwischen drei Dingen unterscheiden:
+
+- Cookies
+- lokalem Browser-Speicher (`localStorage`)
+- technisch notwendigen Server-Logfiles
+
+Wichtig: keine überzogenen Zusicherungen formulieren. Korrekt ist:
+persönliche Notfallkarten-Daten bleiben lokal im Browser und werden nicht
+an einen Server der Website übertragen.


### PR DESCRIPTION
## Summary
- clarify that the personal notfallkarte is stored locally in the browser and not sent to the website server
- remove misleading manual-save wording in favor of explicit automatic local-save messaging
- add and update privacy/storage regression tests

## Testing
- pnpm test
- pnpm check
- pnpm lint
- pnpm build