### PR TITLE
Strengthen inline source links

### DIFF
--- a/client/src/__tests__/quellen-links.test.tsx
+++ b/client/src/__tests__/quellen-links.test.tsx
@@ -1,0 +1,17 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { quellenLinks } from "@/content/quellenLinks";
+import Quellen from "@/pages/Quellen";
+
+describe("quellenLinks", () => {
+  it("points only to anchor ids that exist on /quellen", () => {
+    render(<Quellen />);
+
+    for (const href of Object.values(quellenLinks)) {
+      const anchorId = href.split("#")[1];
+
+      expect(anchorId).toBeTruthy();
+      expect(document.getElementById(anchorId!)).not.toBeNull();
+    }
+  });
+});

--- a/client/src/content/quellenLinks.ts
+++ b/client/src/content/quellenLinks.ts
@@ -1,0 +1,23 @@
+export const quellenLinks = {
+  apa2022: "/quellen#src-american-psychiatric-association-2022",
+  apa2024: "/quellen#src-american-psychiatric-association-keepers-2024",
+  batemanFonagy2009: "/quellen#src-bateman-fonagy-2009",
+  first2017: "/quellen#src-first-williamsw-benjamin-spitzer-2017",
+  fruzzetti2006: "/quellen#src-fruzzetti-2006",
+  gunderson1997: "/quellen#src-gunderson-berkowitz-ruiz-sancho-1997",
+  gunderson2011: "/quellen#src-gunderson-2011",
+  hoffman2005: "/quellen#src-hoffman-2005",
+  icd11: "/quellen#src-world-health-organization-2019",
+  ipde1999: "/quellen#src-loranger-1999",
+  linehan1993: "/quellen#src-linehan-1993",
+  linehan2015: "/quellen#src-linehan-2015",
+  projectAir: "/quellen#src-project-air-strategy-laufend",
+  storebo2020: "/quellen#src-storeb-2020",
+  zanarini1998:
+    "/quellen#src-zanarini-frankenburg-dubo-sickel-trikha-levin-reynolds-1998",
+  zanarini2004: "/quellen#src-zanarini-frankenburg-hennen-reich-silk-2004",
+  zanarini2010: "/quellen#src-zanarini-2010",
+  zanarini2012: "/quellen#src-zanarini-2012",
+} as const;
+
+export type QuellenLinkKey = keyof typeof quellenLinks;

--- a/client/src/pages/Begleiterkrankungen.tsx
+++ b/client/src/pages/Begleiterkrankungen.tsx
@@ -33,6 +33,7 @@ import ReviewBadge from "@/components/ReviewBadge";
 import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import AppLink from "@/components/AppLink";
+import { quellenLinks } from "@/content/quellenLinks";
 import { emailByIdStrict, kontaktByIdStrict } from "@/data/kontakte";
 import { Link } from "wouter";
 
@@ -306,13 +307,13 @@ export default function Begleiterkrankungen() {
               {
                 label:
                   "Zanarini et al. (1998), Axis I comorbidity of borderline personality disorder",
-                href: "https://pubmed.ncbi.nlm.nih.gov/9842784/",
+                href: quellenLinks.zanarini1998,
                 type: "wissenschaft",
               },
               {
                 label:
                   "Zanarini et al. (2004), Axis I comorbidity in patients with BPD: 6-year follow-up",
-                href: "https://pubmed.ncbi.nlm.nih.gov/15514413/",
+                href: quellenLinks.zanarini2004,
                 type: "wissenschaft",
               },
             ]}
@@ -354,6 +355,24 @@ export default function Begleiterkrankungen() {
               </li>
             </ul>
           </EditorialProse>
+          <EvidenceNote
+            variant="editorial"
+            title="Quellen zu Krisenhinweisen und Angehörigen-Einordnung"
+            sources={[
+              {
+                label:
+                  "APA Practice Guideline (2024) zur klinischen Einordnung von Borderline und Krisenbehandlung",
+                href: quellenLinks.apa2024,
+                type: "wissenschaft",
+              },
+              {
+                label:
+                  "Project Air Strategy: Understanding Self-Harm & Suicidal Thinking for Families & Carers",
+                href: quellenLinks.projectAir,
+                type: "versorgung",
+              },
+            ]}
+          />
         </ContentSection>
 
         {/* ── 4: Was Sie als Angehörige wissen sollten ── */}

--- a/client/src/pages/Diagnostik.tsx
+++ b/client/src/pages/Diagnostik.tsx
@@ -32,6 +32,7 @@ import ReviewBadge from "@/components/ReviewBadge";
 import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
 import AppLink from "@/components/AppLink";
+import { quellenLinks } from "@/content/quellenLinks";
 import {
   emailByIdStrict,
   kontaktByIdStrict,
@@ -342,22 +343,25 @@ export default function Diagnostik() {
             sources={[
               {
                 label: "WHO ICD-11: Borderline pattern specifier (6D11.5)",
-                href: "https://icd.who.int/browse/2025-01/mms/en#2006821354",
+                href: quellenLinks.icd11,
                 type: "wissenschaft",
               },
               {
                 label:
                   "American Psychiatric Association (2022). DSM-5-TR — Diagnostic and Statistical Manual of Mental Disorders, Text Revision.",
+                href: quellenLinks.apa2022,
                 type: "wissenschaft",
               },
               {
                 label:
                   "First, Williams, Benjamin & Spitzer (2017). SCID-5-PD: Structured Clinical Interview for DSM-5 Personality Disorders. APA Publishing.",
+                href: quellenLinks.first2017,
                 type: "wissenschaft",
               },
               {
                 label:
                   "Loranger (1999). IPDE — International Personality Disorder Examination. WHO / Cambridge University Press.",
+                href: quellenLinks.ipde1999,
                 type: "wissenschaft",
               },
             ]}

--- a/client/src/pages/Genesung.tsx
+++ b/client/src/pages/Genesung.tsx
@@ -36,6 +36,7 @@ import { TableOfContents } from "@/components/UXEnhancements";
 import { genesungItems as genesungMaterialItems } from "@/content/genesung";
 import { getHandoutOpenHref } from "@/content/handouts";
 import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
+import { quellenLinks } from "@/content/quellenLinks";
 import { Link } from "wouter";
 
 /** Öffnet eine ContentSection via Custom Event und scrollt dorthin. */
@@ -302,17 +303,17 @@ export default function Genesung() {
                 {
                   label:
                     "Zanarini et al. (2010) – McLean Study of Adult Development",
-                  href: "https://pubmed.ncbi.nlm.nih.gov/20395399/",
+                  href: quellenLinks.zanarini2010,
                 },
                 {
                   label:
                     "Zanarini et al. (2012) – Sustained remission and recovery in BPD",
-                  href: "https://pubmed.ncbi.nlm.nih.gov/22737693/",
+                  href: quellenLinks.zanarini2012,
                 },
                 {
                   label:
                     "Gunderson et al. (2011) – Ten-year course of BPD (CLPS)",
-                  href: "https://pubmed.ncbi.nlm.nih.gov/21464343/",
+                  href: quellenLinks.gunderson2011,
                 },
               ]}
             />

--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -9,9 +9,8 @@
  * Optional Hinweis-Paragraph + PubMed/WHO-Link als editorial-link.
  *
  * Stabile id-Anker pro Eintrag (Schema `src-<author-slug>-<year>`),
- * damit Tier-1-Pages später per `EditorialFootnotes` mit href auf
- * konkrete Quellen verlinken können. Aktuell keine Cross-Page-Refs zu
- * /quellen#-Ankern im Repo.
+ * damit Inhaltsseiten gezielt auf einzelne Quellen unter `/quellen#...`
+ * verlinken können.
  */
 import {
   EditorialLayout,

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -25,6 +25,7 @@ import {
   EditorialPullQuote,
   EditorialSection,
 } from "@/components/editorial";
+import EvidenceNote from "@/components/EvidenceNote";
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
@@ -32,6 +33,7 @@ import SEO, { MedicalPageSchema } from "@/components/SEO";
 import UnterstuetzenSubNav from "@/components/UnterstuetzenSubNav";
 import { TableOfContents } from "@/components/UXEnhancements";
 import RollenOrbitVisualisierung from "@/components/visualizations/RollenOrbitVisualisierung";
+import { quellenLinks } from "@/content/quellenLinks";
 import {
   GELB,
   emailByIdStrict,
@@ -423,6 +425,35 @@ export default function UnterstuetzenTherapie() {
               kann.
             </EditorialPullQuote>
           </div>
+          <EvidenceNote
+            variant="editorial"
+            title="Quellen zu Therapieverfahren und Angehörigenprogrammen"
+            definition="DBT, MBT und andere BPS-spezifische Psychotherapien sind die am besten untersuchten Verfahren. Für Angehörige sind zusätzlich psychoedukative Programme wie Family Connections relevant."
+            sources={[
+              {
+                label:
+                  "Storebø et al. (2020) – Cochrane-Review zu psychologischen Therapien bei BPS",
+                href: quellenLinks.storebo2020,
+                type: "wissenschaft",
+              },
+              {
+                label:
+                  "Bateman & Fonagy (2009) – RCT zu mentalisierungsbasierter Therapie",
+                href: quellenLinks.batemanFonagy2009,
+                type: "wissenschaft",
+              },
+              {
+                label: "Linehan (2015) – DBT Skills Training Manual",
+                href: quellenLinks.linehan2015,
+                type: "wissenschaft",
+              },
+              {
+                label: "Hoffman et al. (2005) – Family Connections",
+                href: quellenLinks.hoffman2005,
+                type: "wissenschaft",
+              },
+            ]}
+          />
         </ContentSection>
 
         {/* ── ContentSection 4: unterstuetzen ── */}

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -38,6 +38,7 @@ import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
+import { quellenLinks } from "@/content/quellenLinks";
 import VerstehenMaterialsSection from "@/sections/VerstehenMaterialsSection";
 import {
   VerstehenDiagnosticSection,
@@ -278,18 +279,19 @@ export default function Verstehen() {
             sources={[
               {
                 label: "WHO ICD-11: Borderline pattern specifier (6D11.5)",
-                href: "https://icd.who.int/browse/2025-01/mms/en#2006821354",
+                href: quellenLinks.icd11,
                 type: "wissenschaft",
               },
               {
                 label:
                   "APA Practice Guideline for the Treatment of Patients With Borderline Personality Disorder (2024)",
-                href: "https://pubmed.ncbi.nlm.nih.gov/39482953/",
+                href: quellenLinks.apa2024,
                 type: "wissenschaft",
               },
               {
                 label:
                   "Linehan, Cognitive-Behavioral Treatment of Borderline Personality Disorder",
+                href: quellenLinks.linehan1993,
                 type: "wissenschaft",
                 note: "Grundlagenwerk zu Emotionsregulation und Bindungsstress",
               },

--- a/client/src/sections/VerstehenSupportSections.tsx
+++ b/client/src/sections/VerstehenSupportSections.tsx
@@ -7,6 +7,7 @@ import {
   meaningForRelativesCards,
   relationshipPatterns,
 } from "@/content/verstehen";
+import { quellenLinks } from "@/content/quellenLinks";
 import EvidenceNote from "@/components/EvidenceNote";
 
 export function VerstehenRelationshipSection() {
@@ -54,15 +55,20 @@ export function VerstehenRelationshipSection() {
           reviewDate="24.03.2026"
           sources={[
             {
-              label:
-                "Fruzzetti, The High-Conflict Couple / DBT-informed family work",
+              label: "Fruzzetti (2006) zur DBT-informierten Angehörigenarbeit",
+              href: quellenLinks.fruzzetti2006,
               type: "wissenschaft",
             },
             {
-              label: "NEA-BPD / Family Connections",
-              href: "https://www.borderlinepersonalitydisorder.org/family-connections/",
-              type: "versorgung",
-              note: "Angehörigenprogramm mit DBT-bezogener Vermittlung",
+              label: "Hoffman et al. (2005) zu Family Connections",
+              href: quellenLinks.hoffman2005,
+              type: "wissenschaft",
+            },
+            {
+              label:
+                "Gunderson, Berkowitz & Ruiz-Sancho (1997) zur psychoedukativen Familienarbeit",
+              href: quellenLinks.gunderson1997,
+              type: "wissenschaft",
             },
           ]}
           className="mt-4"


### PR DESCRIPTION
## Summary
- route existing evidence notes on core content pages to stable /quellen anchors
- add a focused evidence block on the therapy page and a crisis-oriented source note on begleiterkrankungen
- add a regression test to ensure all internal quellen anchors exist

## Testing
- pnpm test
- pnpm check
- pnpm lint
- pnpm build