### PR TITLE
Consolidate editorial navigation styling

### DIFF
--- a/client/src/components/UnterstuetzenSubNav.tsx
+++ b/client/src/components/UnterstuetzenSubNav.tsx
@@ -1,11 +1,10 @@
 import { Link, useLocation } from "wouter";
-import { LayoutGrid, Calendar, AlertTriangle, Brain } from "lucide-react";
 
 const tabs = [
-  { href: "/unterstuetzen/uebersicht", label: "Übersicht", icon: LayoutGrid },
-  { href: "/unterstuetzen/alltag", label: "Im Alltag", icon: Calendar },
-  { href: "/unterstuetzen/krise", label: "In der Krise", icon: AlertTriangle },
-  { href: "/unterstuetzen/therapie", label: "Therapie", icon: Brain },
+  { href: "/unterstuetzen/uebersicht", label: "Übersicht" },
+  { href: "/unterstuetzen/alltag", label: "Im Alltag" },
+  { href: "/unterstuetzen/krise", label: "In der Krise" },
+  { href: "/unterstuetzen/therapie", label: "Therapie" },
 ];
 
 export default function UnterstuetzenSubNav() {
@@ -14,25 +13,24 @@ export default function UnterstuetzenSubNav() {
   return (
     <nav
       aria-label="Unterstützen – Unterseiten"
-      className="border-b border-border/50 bg-background"
+      className="border-b border-border/45 bg-background/92"
     >
       <div className="container">
-        <div className="flex overflow-x-auto -mb-px">
-          {tabs.map(({ href, label, icon: Icon }) => {
+        <div className="scrollbar-none flex overflow-x-auto -mb-px gap-1">
+          {tabs.map(({ href, label }) => {
             const isActive = location === href;
             return (
               <Link
                 key={href}
                 href={href}
                 className={[
-                  "flex items-center gap-2 px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors",
+                  "flex items-center px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors",
                   isActive
-                    ? "border-sage-dark text-sage-dark"
-                    : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+                    ? "border-[color:var(--accent-primary)] text-foreground"
+                    : "border-transparent text-muted-foreground hover:text-foreground hover:border-border/70",
                 ].join(" ")}
                 aria-current={isActive ? "page" : undefined}
               >
-                <Icon className="w-4 h-4 shrink-0" />
                 {label}
               </Link>
             );

--- a/client/src/components/layout/Breadcrumbs.tsx
+++ b/client/src/components/layout/Breadcrumbs.tsx
@@ -85,29 +85,26 @@ export function Breadcrumbs() {
   const backLabel = parent?.label || "Startseite";
 
   return (
-    <div className="border-b border-border/40 bg-[linear-gradient(180deg,rgba(250,250,247,0.82),rgba(248,250,249,0.92))]">
-      <nav className="container py-3 md:py-4" aria-label="Breadcrumb">
-        <div className="flex items-center justify-between gap-3">
+    <div className="border-b border-border/40 bg-background/92">
+      <nav className="container py-3 md:py-3.5" aria-label="Breadcrumb">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
           <Link
             href={backHref}
-            className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium shadow-sm shadow-black/5 transition-colors group sm:hidden ${accent.breadcrumbBack}`}
+            className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium transition-colors group sm:hidden ${accent.breadcrumbBack}`}
           >
             <ArrowLeft className="w-4 h-4" />
             <span>{backLabel}</span>
           </Link>
 
-          <span
-            className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium sm:hidden ${accent.breadcrumbChip}`}
-          >
-            <span className={`h-2 w-2 rounded-full ${accent.dot}`} />
+          <p className={`text-sm font-medium sm:hidden ${accent.textAccent}`}>
             {pageName}
-          </span>
+          </p>
 
-          <ol className="hidden sm:flex items-center gap-2 rounded-full border border-border/60 bg-white/88 px-3 py-2 text-sm text-muted-foreground shadow-sm shadow-black/5 backdrop-blur-sm">
+          <ol className="hidden sm:flex flex-wrap items-center gap-x-2 gap-y-1 text-sm text-muted-foreground">
             <li>
               <Link
                 href="/"
-                className="flex items-center gap-1.5 rounded-full px-2 py-1 transition-colors hover:bg-muted/60 hover:text-foreground"
+                className="flex items-center gap-1.5 transition-colors hover:text-foreground"
               >
                 <Home className="w-4 h-4" />
                 <span>Startseite</span>
@@ -132,10 +129,7 @@ export function Breadcrumbs() {
                 className="w-4 h-4 text-muted-foreground/50"
                 aria-hidden="true"
               />
-              <span
-                className={`inline-flex items-center gap-2 rounded-full border px-3 py-1 font-medium ${accent.breadcrumbChip}`}
-              >
-                <span className={`h-2 w-2 rounded-full ${accent.dot}`} />
+              <span className={`font-medium ${accent.textAccent}`}>
                 {pageName}
               </span>
             </li>

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -59,7 +59,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
   }, [mobileMenuOpen]);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/60 bg-background/88 backdrop-blur-xl shadow-[0_10px_34px_-28px_rgba(15,23,42,0.45)]">
+    <header className="sticky top-0 z-50 border-b border-border/55 bg-background/94 backdrop-blur-md">
       <div className="container">
         <div className="flex min-h-16 items-center justify-between gap-2 py-2 md:min-h-20 md:gap-4 md:py-3">
           <AppLink href="/" className="flex items-center gap-3 group shrink-0">
@@ -68,7 +68,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               iconClassName="md:h-[22px] md:w-[22px]"
             />
             <span className="hidden xl:flex flex-col leading-tight">
-              <span className="text-sm font-medium text-foreground transition-colors group-hover:text-sage-darker whitespace-nowrap">
+              <span className="text-sm font-medium text-foreground transition-colors group-hover:text-[color:var(--accent-primary)] whitespace-nowrap">
                 Borderline · Hilfe für Angehörige
               </span>
               <span className="text-[11px] text-muted-foreground whitespace-nowrap">
@@ -78,7 +78,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
           </AppLink>
 
           <nav
-            className="hidden lg:flex items-center gap-0.5 rounded-full border border-border/70 bg-white/82 px-2 py-1 shadow-[0_18px_34px_-30px_rgba(15,23,42,0.55)] backdrop-blur-sm shrink-0"
+            className="hidden lg:flex items-center gap-0.5 rounded-full border border-border/60 bg-white/78 px-2 py-1 shrink-0"
             aria-label="Hauptnavigation"
           >
             {navItems.map(item => {
@@ -111,7 +111,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             <button
               type="button"
               onClick={onSearchOpen}
-              className="hidden sm:flex h-10 items-center gap-2 rounded-full border border-border/70 bg-white/82 px-4 text-sm text-muted-foreground shadow-sm shadow-black/5 transition-colors hover:border-border hover:text-foreground"
+              className="hidden sm:flex h-10 items-center gap-2 rounded-full border border-border/60 bg-white/78 px-4 text-sm text-muted-foreground transition-colors hover:border-border hover:text-foreground"
               aria-label="Suchen"
             >
               <SearchIcon className="w-4 h-4" />
@@ -121,7 +121,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             <button
               type="button"
               onClick={onSearchOpen}
-              className="sm:hidden inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-white/82 text-muted-foreground shadow-sm shadow-black/5 transition-all hover:text-foreground hover:bg-muted"
+              className="sm:hidden inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/60 bg-white/78 text-muted-foreground transition-all hover:text-foreground hover:bg-muted"
               aria-label="Suche öffnen"
             >
               <SearchIcon className="w-5 h-5" />
@@ -154,7 +154,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               ref={menuButtonRef}
               type="button"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className={`lg:hidden inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-white/82 shadow-sm shadow-black/5 transition-colors ${
+              className={`lg:hidden inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/60 bg-white/78 transition-colors ${
                 mobileMenuOpen ? currentAccent.surfaceActive : "hover:bg-muted"
               }`}
               aria-controls="mobile-navigation-dialog"

--- a/client/src/components/layout/RessourcenMenu.tsx
+++ b/client/src/components/layout/RessourcenMenu.tsx
@@ -104,7 +104,7 @@ export function RessourcenMenu({
       {isOpen && (
         <div
           onKeyDown={handleMenuKeyDown}
-          className="absolute right-0 top-full z-50 mt-2 w-[min(680px,calc(100vw-2rem))] rounded-[1.4rem] border border-border/65 bg-white/92 shadow-[0_34px_64px_-34px_rgba(15,23,42,0.55)] backdrop-blur-md"
+          className="absolute right-0 top-full z-50 mt-2 w-[min(680px,calc(100vw-2rem))] rounded-[1.25rem] border border-border/65 bg-white/96 shadow-[0_24px_48px_-36px_rgba(15,23,42,0.38)]"
           {...menuA11yProps}
         >
           <div className="grid grid-cols-3 gap-0 p-3">
@@ -115,8 +115,7 @@ export function RessourcenMenu({
                   groupIdx > 0 ? "border-l border-border/40 pl-3" : undefined
                 }
               >
-                <div className="flex items-center gap-2.5 px-3 pt-2 pb-2.5">
-                  <span className={`w-5 h-px ${currentAccent.dot}`} />
+                <div className="px-3 pt-2 pb-2.5">
                   <span
                     className={`text-[11px] font-semibold tracking-[0.08em] uppercase whitespace-nowrap ${currentAccent.groupLabel}`}
                   >

--- a/client/src/components/layout/routeAccent.ts
+++ b/client/src/components/layout/routeAccent.ts
@@ -4,91 +4,29 @@ export interface RouteAccent {
   breadcrumbChip: string;
   breadcrumbBack: string;
   textAccent: string;
-  dot: string;
   groupLabel: string;
 }
 
-const accents = {
-  sage: {
-    navActive:
-      "bg-sage-dark text-white shadow-[0_16px_30px_-18px_rgba(31,101,109,0.9)]",
-    surfaceActive: "border-sage-light/70 bg-sage-wash text-sage-darker",
-    breadcrumbChip: "border-sage-light/70 bg-sage-wash/95 text-sage-darker",
-    breadcrumbBack:
-      "border-sage-light/60 bg-white/90 text-sage-darker hover:bg-sage-wash/80",
-    textAccent: "text-sage-darker",
-    dot: "bg-sage-dark",
-    groupLabel: "text-sage-dark/85",
-  },
-  terracotta: {
-    navActive:
-      "bg-terracotta text-white shadow-[0_16px_30px_-18px_rgba(165,97,55,0.9)]",
-    surfaceActive:
-      "border-terracotta-light/80 bg-terracotta-wash text-terracotta-darker",
-    breadcrumbChip:
-      "border-terracotta-light/80 bg-terracotta-wash/95 text-terracotta-darker",
-    breadcrumbBack:
-      "border-terracotta-light/70 bg-white/90 text-terracotta-darker hover:bg-terracotta-wash/85",
-    textAccent: "text-terracotta-darker",
-    dot: "bg-terracotta",
-    groupLabel: "text-terracotta-dark/85",
-  },
-  slate: {
-    navActive:
-      "bg-slate-dark text-white shadow-[0_16px_30px_-18px_rgba(82,109,158,0.85)]",
-    surfaceActive: "border-slate-light/85 bg-slate-wash text-slate-dark",
-    breadcrumbChip: "border-slate-light/85 bg-slate-wash/95 text-slate-dark",
-    breadcrumbBack:
-      "border-slate-light/80 bg-white/90 text-slate-dark hover:bg-slate-wash/85",
-    textAccent: "text-slate-dark",
-    dot: "bg-slate-blue",
-    groupLabel: "text-slate-dark/85",
-  },
-  sand: {
-    navActive:
-      "bg-sand-warm text-white shadow-[0_16px_30px_-18px_rgba(161,126,56,0.88)]",
-    surfaceActive: "border-sand-border/85 bg-sand-muted text-sand-warm",
-    breadcrumbChip: "border-sand-border/85 bg-sand-muted/95 text-sand-warm",
-    breadcrumbBack:
-      "border-sand-border/80 bg-white/90 text-sand-warm hover:bg-sand-muted/90",
-    textAccent: "text-sand-warm",
-    dot: "bg-sand-accent",
-    groupLabel: "text-sand-warm/85",
-  },
-  selfCare: {
-    navActive:
-      "bg-sage-mid text-white shadow-[0_16px_30px_-18px_rgba(59,127,117,0.88)]",
-    surfaceActive: "border-sage-light/80 bg-sage-pale text-sage-darker",
-    breadcrumbChip: "border-sage-light/80 bg-sage-pale text-sage-darker",
-    breadcrumbBack:
-      "border-sage-light/70 bg-white/90 text-sage-darker hover:bg-sage-pale",
-    textAccent: "text-sage-darker",
-    dot: "bg-sage-mid",
-    groupLabel: "text-sage-darker/85",
-  },
-  alert: {
-    navActive:
-      "bg-alert text-white shadow-[0_16px_30px_-18px_rgba(197,95,61,0.9)]",
-    surfaceActive: "border-alert-light/85 bg-alert-wash text-alert-dark",
-    breadcrumbChip: "border-alert-light/85 bg-alert-wash/95 text-alert-dark",
-    breadcrumbBack:
-      "border-alert-light/80 bg-white/90 text-alert-dark hover:bg-alert-wash/85",
-    textAccent: "text-alert-dark",
-    dot: "bg-alert",
-    groupLabel: "text-alert-dark/85",
-  },
-  navy: {
-    navActive:
-      "bg-navy text-white shadow-[0_16px_30px_-18px_rgba(34,52,85,0.88)]",
-    surfaceActive: "border-slate-light/85 bg-slate-pale text-navy",
-    breadcrumbChip: "border-slate-light/85 bg-slate-pale text-navy",
-    breadcrumbBack:
-      "border-slate-light/80 bg-white/90 text-navy hover:bg-slate-pale/90",
-    textAccent: "text-navy",
-    dot: "bg-navy-light",
-    groupLabel: "text-navy/80",
-  },
-} satisfies Record<string, RouteAccent>;
+const editorialAccent: RouteAccent = {
+  navActive: "border-border/80 bg-white text-foreground shadow-none",
+  surfaceActive: "border-border/75 bg-white text-foreground",
+  breadcrumbChip: "border-border/70 bg-white/95 text-foreground",
+  breadcrumbBack:
+    "border-border/55 bg-transparent text-muted-foreground hover:bg-white/70 hover:text-foreground",
+  textAccent: "text-[color:var(--accent-primary)]",
+  groupLabel: "text-[color:var(--accent-label)]",
+};
+
+const alertAccent: RouteAccent = {
+  navActive:
+    "bg-alert text-white shadow-[0_16px_30px_-18px_rgba(197,95,61,0.9)]",
+  surfaceActive: "border-alert-light/85 bg-alert-wash text-alert-dark",
+  breadcrumbChip: "border-alert-light/85 bg-alert-wash/95 text-alert-dark",
+  breadcrumbBack:
+    "border-alert-light/80 bg-white/90 text-alert-dark hover:bg-alert-wash/85",
+  textAccent: "text-alert-dark",
+  groupLabel: "text-alert-dark/85",
+};
 
 function normalizePath(path: string) {
   return path.split("#")[0];
@@ -107,38 +45,8 @@ export function getRouteAccent(pathOrHref: string): RouteAccent {
     matches(path, ["/soforthilfe", "/notfallkarte"]) ||
     path === "/unterstuetzen/krise"
   ) {
-    return accents.alert;
+    return alertAccent;
   }
 
-  if (matches(path, ["/kommunizieren", "/uebungen", "/genesung"])) {
-    return accents.slate;
-  }
-
-  if (matches(path, ["/grenzen"])) {
-    return accents.sand;
-  }
-
-  if (matches(path, ["/selbstfuersorge", "/selbsttest"])) {
-    return accents.selfCare;
-  }
-
-  if (matches(path, ["/unterstuetzen", "/beratung", "/selbsthilfegruppen"])) {
-    return accents.terracotta;
-  }
-
-  if (
-    matches(path, [
-      "/verstehen",
-      "/materialien",
-      "/wegweiser",
-      "/faq",
-      "/glossar",
-      "/buchempfehlungen",
-      "/quellen",
-    ])
-  ) {
-    return accents.sage;
-  }
-
-  return accents.navy;
+  return editorialAccent;
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,7 +5,9 @@
 @import "tailwindcss/preflight.css" layer(base);
 
 :root {
-  /* Sanctuary Calm - Warm, therapeutic palette */
+  /* Legacy Sanctuary Calm bridge.
+     Editorial tokens below are the primary design source.
+     Legacy tokens remain for migration and functional crisis UI. */
   --primary: oklch(
     0.55 0.15 55
   ); /* Terracotta – WCAG AA: weiss auf primary ≥4.5:1 (Phase 1 fix, war 0.65 0.12 55) */
@@ -59,12 +61,10 @@
   --sidebar-ring: oklch(0.55 0.15 55); /* Terracotta (angepasst mit primary) */
 
   /* ════════════════════════════════════════════════════════════════════════
-     Editorial Redesign — Phase 1 Tokens (Brief 27.04.2026)
-     Parallel zu bestehenden Sanctuary-Calm-Tokens. Phase-2-Primitive
-     referenzieren ausschliesslich diese neuen Tokens. Bestehende Tokens
-     werden in Phase 7 entfernt.
-     Nicht in der neuen Palette: Soforthilfe-Tokens (--color-sos-*) und
-     Alert-Tokens (--color-alert*) bleiben funktional unverändert.
+     Editorial tokens — primäre Designquelle
+     Neue Layout- und Inhaltsseiten sollen bevorzugt diese Tokens nutzen.
+     Funktionale Krisenfarben (--color-sos-* / --color-alert*) bleiben
+     davon ausgenommen.
      ════════════════════════════════════════════════════════════════════════ */
 
   /* — Farben — */
@@ -313,8 +313,7 @@
     max-width: 44ch;
   }
 
-  /* ── Pull-Quote (Phase 4) ── */
-  /* Zitat-Hervorhebung in Prosa-Abschnitten: linker Akzentbalken, italic, etwas grösser */
+  /* Pull-Quote — sparsame Zitat-Hervorhebung fuer Lesestrecken */
   .pull-quote {
     border-left: 3px solid var(--color-sage, oklch(0.72 0.08 150));
     padding-left: 1.25rem;
@@ -337,27 +336,7 @@
     letter-spacing: 0.02em;
   }
 
-  .home-hero-surface {
-    background: linear-gradient(
-      to bottom right,
-      var(--color-navy),
-      var(--color-home-hero-mid),
-      var(--color-home-hero-end)
-    );
-  }
-
-  .home-orbit-glow {
-    background: radial-gradient(
-      circle,
-      var(--color-home-orbit-inner),
-      var(--color-home-orbit-outer)
-    );
-  }
-
-  /* ── Editorial Redesign — Phase 2 Primitives (Brief 27.04.2026) ──
-     CSS-Pendant zu den React-Primitiven in client/src/components/editorial/.
-     Diese Klassen werden von EditorialProse genutzt; .editorial-link ist
-     eine eigenständige Inline-Anchor-Utility. */
+  /* Editorial primitives fuer React-Komponenten und Inline-Links */
 
   .editorial-prose {
     font-size: var(
@@ -394,15 +373,13 @@
     font-style: italic;
   }
 
-  /* Brief 2.3: <strong> NICHT bold sondern in Aubergine, normal weight —
-     subtile Hervorhebung statt visueller Lärm */
+  /* <strong> bleibt bewusst ruhig statt fett und werblich */
   .editorial-prose strong {
     color: var(--accent-primary);
     font-weight: var(--weight-body);
   }
 
-  /* Drop-Cap auf erstem Buchstaben des ersten Absatzes
-     (nur wenn .editorial-prose-dropcap als Modifier-Klasse gesetzt) */
+  /* Drop-Cap auf dem ersten Buchstaben des ersten Absatzes */
   .editorial-prose-dropcap > p:first-child::first-letter {
     font-family: var(--font-display);
     float: left;
@@ -415,14 +392,13 @@
     font-weight: var(--weight-display);
   }
 
-  /* Brief Anhang C: Mobile-Sicherung gegen Layout-Bruch bei sehr schmalen Viewports */
   @media (max-width: 380px) {
     .editorial-prose-dropcap > p:first-child::first-letter {
-      font-size: 3.2rem; /* Proportional reduziert */
+      font-size: 3.2rem;
     }
   }
 
-  /* .editorial-link — eigenständige Inline-Anchor-Utility (Brief 2.6) */
+  /* Eigenstaendige Inline-Link-Utility */
   .editorial-link {
     color: var(--accent-primary);
     text-decoration: underline;

--- a/client/src/styles/tailwind-theme.css
+++ b/client/src/styles/tailwind-theme.css
@@ -1,6 +1,8 @@
 @custom-variant dark (&:is(.dark *));
 
-/* Sanctuary Calm Design System */
+/* Legacy Sanctuary Calm token bridge.
+   Editorial tokens in :root are the primary design source for current pages.
+   These legacy families stay available for migration and functional crisis UI. */
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
@@ -40,9 +42,10 @@
   --color-sidebar-ring: var(--sidebar-ring);
 
   /* =============================================
-     SANCTUARY CALM – Design Token Palette
-     Alle Farben zentral definiert. Keine hard-coded
-     oklch/hex-Werte in Komponenten verwenden!
+     LEGACY TOKEN FAMILIES
+     Fuer migrierte Editorial-Seiten moeglichst keine
+     neuen Abhaengigkeiten mehr aufbauen. Beibehalten
+     fuer funktionale Krisenfaelle und Restmigration.
      ============================================= */
 
   /* --- Warm Family (Hue 55/85) --- */
@@ -142,13 +145,6 @@
   --color-sos-amber-wash: oklch(0.97 0.03 85); /* ~amber-50 – Warn-BG */
   --color-sos-amber-border: oklch(0.85 0.06 85); /* ~amber-200 – Warn-Border */
   --color-sos-amber-dark: oklch(0.35 0.06 85); /* ~amber-900 – Warn-Text */
-
-  /* --- Home decorative surfaces --- */
-  --color-home-hero-mid: oklch(0.28 0.05 220);
-  --color-home-hero-end: oklch(0.35 0.03 250 / 0.8);
-  --color-home-divider: oklch(0.93 0.02 190 / 0.3);
-  --color-home-orbit-inner: oklch(0.95 0.02 190 / 0.7);
-  --color-home-orbit-outer: oklch(0.88 0.04 190 / 0.25);
 
   /* Typography
      --font-body: Inter (alle Body-/UI-Texte)


### PR DESCRIPTION
## Summary
- reduce route-level color fragmentation across navigation chrome
- simplify breadcrumbs, resources menu, and Unterstuetzen subnav toward the editorial system
- clarify editorial tokens as the primary design source and remove unused home decorative styles

## Testing
- pnpm lint
- pnpm check
- pnpm test
- pnpm build