### PR TITLE
Editorialize secondary information pages

### DIFF
--- a/client/src/__tests__/datenschutz.test.tsx
+++ b/client/src/__tests__/datenschutz.test.tsx
@@ -74,7 +74,7 @@ describe("Datenschutz", () => {
     });
     fireEvent.click(cookiesToggle);
     expect(document.body).toHaveTextContent(
-      /verwendet für ihre eigenen Einträge kein Cookie/i
+      /verwendet für ihre Einträge kein Cookie/i
     );
   });
 });

--- a/client/src/pages/Datenschutz.tsx
+++ b/client/src/pages/Datenschutz.tsx
@@ -1,22 +1,21 @@
-import SEO from "@/components/SEO";
-import Layout from "@/components/Layout";
 import ContentSection from "@/components/ContentSection";
-import ReviewBadge from "@/components/ReviewBadge";
-import { Card, CardContent } from "@/components/ui/card";
-import { motion } from "framer-motion";
 import {
-  Shield,
-  Cookie,
-  Server,
-  Eye,
-  Lock,
-  ExternalLink,
-  Download,
-  Scale,
-  FileText,
-} from "lucide-react";
+  EditorialLayout,
+  EditorialProse,
+  EditorialSection,
+} from "@/components/editorial";
+import Layout from "@/components/Layout";
+import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
+import ReviewBadge from "@/components/ReviewBadge";
+import SEO from "@/components/SEO";
 
 export default function Datenschutz() {
+  const bodyStyle = {
+    fontSize: "var(--text-sm)",
+    lineHeight: "var(--lh-relaxed)",
+    color: "var(--fg-secondary)",
+  };
+
   return (
     <Layout>
       <SEO
@@ -24,440 +23,355 @@ export default function Datenschutz() {
         description="Datenschutzerklärung: Wie diese Website mit Daten umgeht, welche Cookies gesetzt werden und welche Rechte Sie haben."
         path="/datenschutz"
       />
-      {/* Hero */}
-      <section className="py-10 md:py-14 bg-gradient-to-b from-sage-wash/60 to-background">
-        <div className="container">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="max-w-3xl"
+
+      <EditorialLayout width="narrow">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
+          <p
+            className="text-xs uppercase"
+            style={{
+              color: "var(--accent-label)",
+              letterSpacing: "var(--tracking-caps)",
+              fontWeight: 500,
+            }}
           >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-light flex items-center justify-center">
-                <Shield className="w-6 h-6 text-sage-darker" />
-              </div>
-            </div>
-
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-normal text-foreground mb-6">
-              Datenschutzerklärung
-            </h1>
-
-            <p className="text-lg text-muted-foreground leading-relaxed">
-              Der Schutz Ihrer Privatsphäre ist uns wichtig. Diese
-              Datenschutzerklärung informiert Sie über die Verarbeitung
-              personenbezogener Daten auf dieser Website.
-            </p>
+            Datenschutz
+          </p>
+          <h1
+            className="mt-8 font-display text-[var(--text-3xl)] md:text-[var(--text-4xl)]"
+            style={{
+              lineHeight: "var(--lh-tight)",
+              letterSpacing: "var(--tracking-tight)",
+              color: "var(--fg-primary)",
+              fontWeight: "var(--weight-display)",
+            }}
+          >
+            Wie diese Website mit <em>Daten</em> umgeht
+          </h1>
+          <p
+            className="mt-6"
+            style={{
+              fontSize: "var(--text-lg)",
+              lineHeight: "var(--lh-snug)",
+              color: "var(--fg-secondary)",
+            }}
+          >
+            Der Schutz Ihrer Privatsphäre ist uns wichtig. Diese Erklärung
+            beschreibt, welche Daten technisch anfallen, welche lokal im Browser
+            bleiben und welche Rechte Sie haben.
+          </p>
+          <div className="mt-6">
             <ReviewBadge path="/datenschutz" />
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Content */}
-      <section className="py-8 md:py-12">
-        <div className="container">
-          <div className="max-w-3xl mx-auto">
-            {/* Rechtsgrundlage */}
-            <ContentSection
-              title="Rechtsgrundlage"
-              icon={<Scale className="w-7 h-7 text-sage-dark" />}
-              id="rechtsgrundlage"
-              defaultOpen={true}
-              preview="Diese Website unterliegt dem Schweizer Datenschutzgesetz (DSG) und der EU-Datenschutz-Grundverordnung (DSGVO)."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-4">
-                    <p>
-                      Diese Website unterliegt dem{" "}
-                      <strong>
-                        Bundesgesetz über den Datenschutz (DSG, SR 235.1)
-                      </strong>{" "}
-                      der Schweiz in der revidierten Fassung vom 1. September
-                      2023. Soweit die Website auch von Personen aus dem
-                      Europäischen Wirtschaftsraum (EWR) genutzt wird, gilt
-                      ergänzend die{" "}
-                      <strong>
-                        EU-Datenschutz-Grundverordnung (DSGVO/GDPR, Verordnung
-                        (EU) 2016/679)
-                      </strong>
-                      .
-                    </p>
-                    <p>
-                      Die Verarbeitung von Daten erfolgt auf Grundlage
-                      berechtigter Interessen (Art. 31 Abs. 1 DSG bzw. Art. 6
-                      Abs. 1 lit. f DSGVO) zur Bereitstellung und Sicherung
-                      dieser Website.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Drittanbieter und Hosting */}
-            <ContentSection
-              title="Hosting und Drittanbieter"
-              icon={<Server className="w-7 h-7 text-sage-mid" />}
-              id="hosting"
-              preview="Hosting über Netlify (USA) – Datenverarbeitung gemäss Standardvertragsklauseln."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-4">
-                    <p>
-                      Diese Website wird über <strong>Netlify, Inc.</strong>{" "}
-                      (San Francisco, USA) gehostet. Beim Aufruf der Website
-                      werden technisch notwendige Daten (siehe Server-Logfiles)
-                      an Server von Netlify übertragen. Die Datenverarbeitung
-                      erfolgt auf Grundlage von EU-Standardvertragsklauseln
-                      (SCC).
-                    </p>
-                    <p>
-                      Darüber hinaus werden{" "}
-                      <strong>keine weiteren Drittanbieter-Dienste</strong>{" "}
-                      eingesetzt — kein Analytics, kein CDN für externe
-                      Schriften, keine eingebetteten Inhalte von Drittseiten.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Grundsatz – immer offen */}
-            <ContentSection
-              title="Unser Grundsatz"
-              icon={<Lock className="w-7 h-7 text-sage-mid" />}
-              id="grundsatz"
-              defaultOpen={true}
-              preview="Möglichst wenige personenbezogene Daten – kein Tracking, keine Werbung, keine Social-Media-Plugins."
-            >
-              <Card className="border-sage/30 bg-sage-light/20">
-                <CardContent className="p-6">
-                  <p className="text-muted-foreground leading-relaxed">
-                    Diese Website wurde mit dem Ziel entwickelt, möglichst
-                    wenige personenbezogene Daten zu erheben. Wir verzichten
-                    bewusst auf Tracking-Tools, Werbung und
-                    Social-Media-Plugins. Ihre Privatsphäre hat Priorität.
-                  </p>
-                </CardContent>
-              </Card>
-
-              <Card className="border-border/50 mt-4">
-                <CardContent className="p-6">
-                  <h3 className="text-lg font-semibold text-foreground mb-4">
-                    Verantwortliche Stelle
-                  </h3>
-                  <div className="text-muted-foreground leading-relaxed">
-                    <p className="font-medium text-foreground">Christa Egger</p>
-                    <p>Angehörigenberaterin</p>
-                    <p className="mt-4 text-sm">
-                      Bei Fragen zum Datenschutz können Sie sich an die oben
-                      genannte Person wenden.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Datenerhebung */}
-            <ContentSection
-              title="Erhebung und Verarbeitung von Daten"
-              icon={<Server className="w-7 h-7 text-slate-blue" />}
-              id="datenerhebung"
-              preview="Server-Logfiles mit anonymisierten IP-Adressen – keine Zusammenführung mit anderen Datenquellen."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <h3 className="font-medium text-foreground mb-3">
-                    Server-Logfiles
-                  </h3>
-                  <p className="text-muted-foreground leading-relaxed mb-3">
-                    Bei jedem Zugriff auf diese Website werden automatisch
-                    Informationen in sogenannten Server-Logfiles gespeichert,
-                    die Ihr Browser automatisch übermittelt. Dies sind:
-                  </p>
-                  <ul className="space-y-1 text-sm text-muted-foreground">
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Browsertyp und Browserversion
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Verwendetes Betriebssystem
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Referrer URL (die zuvor besuchte Seite)
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Hostname des zugreifenden Rechners
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Uhrzeit der Serveranfrage
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      IP-Adresse (anonymisiert)
-                    </li>
-                  </ul>
-                  <p className="mt-3 text-sm text-muted-foreground">
-                    Diese Daten werden ausschliesslich zur Gewährleistung eines
-                    störungsfreien Betriebs der Website und zur Verbesserung
-                    unseres Angebots ausgewertet. Eine Zusammenführung dieser
-                    Daten mit anderen Datenquellen wird nicht vorgenommen.
-                  </p>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            <ContentSection
-              title="Persönliche Notfallkarte und lokale Speicherung"
-              icon={<Lock className="w-7 h-7 text-sage-dark" />}
-              id="notfallkarte-lokal"
-              preview="Persönliche Einträge der Notfallkarte bleiben lokal im Browser und werden nicht an den Server dieser Website übertragen."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-4">
-                    <p>
-                      Die persönliche Notfallkarte kann{" "}
-                      <strong>personenbezogene Angaben</strong> enthalten, zum
-                      Beispiel Namen, Telefonnummern, Beziehungen,
-                      Beruhigungsstrategien oder freie Notizen.
-                    </p>
-                    <p>
-                      Diese Angaben werden{" "}
-                      <strong>lokal im Browser auf Ihrem Gerät</strong>{" "}
-                      gespeichert, damit die Notfallkarte zwischen Ihren
-                      Besuchen erhalten bleibt. Die Daten werden dabei{" "}
-                      <strong>nicht an einen Server dieser Website</strong>{" "}
-                      übertragen.
-                    </p>
-                    <p>
-                      Wichtig: Auf <strong>gemeinsam genutzten Geräten</strong>{" "}
-                      können andere Personen diese Einträge sehen, wenn sie
-                      denselben Browser verwenden. Wenn die Angaben nicht auf
-                      dem Gerät bleiben sollen, können Sie sie in der
-                      Notfallkarte über <strong>«Daten löschen»</strong>{" "}
-                      entfernen.
-                    </p>
-                    <p className="text-sm">
-                      Für die Druckansicht wird zusätzlich kurzfristig ein
-                      lokaler Zwischenspeicher im Browser verwendet. Auch diese
-                      Daten werden nicht an unsere Server übertragen.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Cookies */}
-            <ContentSection
-              title="Cookies"
-              icon={<Cookie className="w-7 h-7 text-sage-dark" />}
-              id="cookies"
-              preview="Nur technisch notwendige Cookies – keine Tracking-Cookies, keine Werbung."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-4">
-                    <p>
-                      Diese Website verwendet ausschliesslich technisch
-                      notwendige Cookies, die für den Betrieb der Website
-                      erforderlich sind. Es werden{" "}
-                      <strong>keine Tracking-Cookies</strong> oder Cookies zu
-                      Werbezwecken eingesetzt.
-                    </p>
-                    <div className="bg-muted/30 rounded-lg p-4">
-                      <h3 className="font-medium text-foreground mb-2">
-                        Technisch notwendige Cookies
-                      </h3>
-                      <p className="text-sm">
-                        Diese Cookies sind für die Grundfunktionen der Website
-                        erforderlich und können nicht deaktiviert werden. Sie
-                        speichern keine persönlich identifizierbaren
-                        Informationen.
-                      </p>
-                    </div>
-                    <p className="text-sm">
-                      Die persönliche Notfallkarte verwendet für ihre eigenen
-                      Einträge <strong>kein Cookie</strong>, sondern den lokalen
-                      Browser-Speicher (`localStorage`). Dieser unterscheidet
-                      sich von Cookies und wird nur auf Ihrem Gerät abgelegt.
-                    </p>
-                    <p className="text-sm">
-                      Sie können Ihren Browser so einstellen, dass Sie über das
-                      Setzen von Cookies informiert werden und Cookies nur im
-                      Einzelfall erlauben. Bei der Deaktivierung von Cookies
-                      kann die Funktionalität dieser Website eingeschränkt sein.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Analyse-Tools */}
-            <ContentSection
-              title="Analyse- und Tracking-Tools"
-              icon={<Eye className="w-7 h-7 text-sage-dark" />}
-              id="tracking"
-              preview="Keine Analyse- oder Tracking-Tools, keine Social-Media-Plugins."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-4">
-                    <p>
-                      Diese Website verwendet{" "}
-                      <strong>keine Analyse- oder Tracking-Tools</strong> wie
-                      Google Analytics, Facebook Pixel oder ähnliche Dienste.
-                      Wir erfassen keine Nutzungsprofile und geben keine Daten
-                      an Dritte weiter.
-                    </p>
-                    <p>
-                      Es werden auch <strong>keine Social-Media-Plugins</strong>{" "}
-                      eingebunden, die Daten an soziale Netzwerke übertragen
-                      könnten.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Externe Links */}
-            <ContentSection
-              title="Externe Links"
-              icon={<ExternalLink className="w-7 h-7 text-sage-mid" />}
-              id="externe-links"
-              preview="Für verlinkte externe Websites gelten deren eigene Datenschutzerklärungen."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <p className="text-muted-foreground leading-relaxed">
-                    Diese Website enthält Links zu externen Websites Dritter
-                    (z.B. Notfallressourcen, Selbsthilfegruppen). Auf deren
-                    Inhalte haben wir keinen Einfluss. Für die Inhalte der
-                    verlinkten Seiten ist stets der jeweilige Anbieter oder
-                    Betreiber verantwortlich. Bitte beachten Sie die
-                    Datenschutzerklärungen der jeweiligen externen Websites.
-                  </p>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Downloads */}
-            <ContentSection
-              title="Downloads und Materialien"
-              icon={<Download className="w-7 h-7 text-sage-mid" />}
-              id="downloads"
-              preview="Beim Download werden keine personenbezogenen Daten erfasst."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <p className="text-muted-foreground leading-relaxed">
-                    Die auf dieser Website angebotenen Infografiken und Handouts
-                    können heruntergeladen werden. Beim Download werden keine
-                    personenbezogenen Daten erfasst oder gespeichert. Die
-                    Materialien werden über die Website und ihren
-                    Hosting-Anbieter bereitgestellt.
-                  </p>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Ihre Rechte */}
-            <ContentSection
-              title="Ihre Rechte"
-              icon={<Scale className="w-7 h-7 text-slate-blue" />}
-              id="rechte"
-              preview="Auskunft, Berichtigung, Löschung und Widerspruch gemäss DSG und DSGVO."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-4">
-                    <p>
-                      Gemäss dem schweizerischen Datenschutzgesetz (DSG) und der
-                      EU-Datenschutz-Grundverordnung (DSGVO) haben Sie folgende
-                      Rechte:
-                    </p>
-                    <ul className="space-y-2">
-                      <li className="flex items-start gap-2">
-                        <span className="text-sage-mid">•</span>
-                        <span>
-                          <strong>Auskunftsrecht:</strong> Sie können Auskunft
-                          über Ihre gespeicherten personenbezogenen Daten
-                          verlangen.
-                        </span>
-                      </li>
-                      <li className="flex items-start gap-2">
-                        <span className="text-sage-mid">•</span>
-                        <span>
-                          <strong>Berichtigungsrecht:</strong> Sie können die
-                          Berichtigung unrichtiger Daten verlangen.
-                        </span>
-                      </li>
-                      <li className="flex items-start gap-2">
-                        <span className="text-sage-mid">•</span>
-                        <span>
-                          <strong>Löschungsrecht:</strong> Sie können die
-                          Löschung Ihrer Daten verlangen.
-                        </span>
-                      </li>
-                      <li className="flex items-start gap-2">
-                        <span className="text-sage-mid">•</span>
-                        <span>
-                          <strong>Widerspruchsrecht:</strong> Sie können der
-                          Verarbeitung Ihrer Daten widersprechen.
-                        </span>
-                      </li>
-                    </ul>
-                    <p className="text-sm">
-                      Auf unseren Servern speichern wir grundsätzlich keine
-                      persönlichen Inhalte aus der Notfallkarte. Wenn Sie die
-                      persönliche Notfallkarte verwenden, können solche Angaben
-                      jedoch lokal in Ihrem Browser gespeichert sein. In diesem
-                      Fall können Sie die Einträge direkt auf Ihrem Gerät über
-                      «Daten löschen» entfernen.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Änderungen */}
-            <ContentSection
-              title="Änderungen dieser Datenschutzerklärung"
-              icon={<FileText className="w-7 h-7 text-sage-dark" />}
-              id="aenderungen"
-              preview="Anpassungen bei geänderten rechtlichen Anforderungen."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <p className="text-muted-foreground leading-relaxed">
-                    Wir behalten uns vor, diese Datenschutzerklärung anzupassen,
-                    damit sie stets den aktuellen rechtlichen Anforderungen
-                    entspricht oder um Änderungen unserer Leistungen in der
-                    Datenschutzerklärung umzusetzen. Für Ihren erneuten Besuch
-                    gilt dann die neue Datenschutzerklärung.
-                  </p>
-                </CardContent>
-              </Card>
-            </ContentSection>
-
-            {/* Stand */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-            >
-              <p className="text-center text-sm text-muted-foreground">
-                Stand: Februar 2026
-              </p>
-            </motion.div>
           </div>
-        </div>
-      </section>
+        </header>
+
+        <ContentSection
+          variant="editorial"
+          title="Rechtsgrundlage"
+          id="rechtsgrundlage"
+          defaultOpen={true}
+          preview="Schweizer DSG, ergänzend DSGVO für Nutzer:innen aus dem EWR."
+        >
+          <EditorialProse>
+            <p>
+              Diese Website unterliegt dem{" "}
+              <strong>Bundesgesetz über den Datenschutz (DSG, SR 235.1)</strong>{" "}
+              der Schweiz in der revidierten Fassung vom 1. September 2023.
+              Soweit die Website auch von Personen aus dem Europäischen
+              Wirtschaftsraum genutzt wird, gilt ergänzend die{" "}
+              <strong>
+                EU-Datenschutz-Grundverordnung (DSGVO/GDPR, Verordnung (EU)
+                2016/679)
+              </strong>
+              .
+            </p>
+            <p>
+              Die Verarbeitung technischer Daten erfolgt auf Grundlage
+              berechtigter Interessen zur Bereitstellung und Sicherung dieser
+              Website.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Hosting und Drittanbieter"
+          id="hosting"
+          preview="Hosting über Netlify; keine zusätzlichen Tracking- oder Werbedienste."
+        >
+          <EditorialProse>
+            <p>
+              Diese Website wird über <strong>Netlify, Inc.</strong> (San
+              Francisco, USA) gehostet. Beim Aufruf der Website werden technisch
+              notwendige Daten an Server von Netlify übertragen. Die
+              Datenverarbeitung erfolgt auf Grundlage von
+              Standardvertragsklauseln.
+            </p>
+            <p>
+              Darüber hinaus werden{" "}
+              <strong>keine weiteren Drittanbieter-Dienste</strong> eingesetzt:
+              kein Analytics, kein externes Schrift-CDN, keine eingebetteten
+              Social-Media-Plugins und keine Werbedienste.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Unser Grundsatz"
+          id="grundsatz"
+          defaultOpen={true}
+          preview="So wenige personenbezogene Daten wie möglich; kein Tracking, keine Werbung."
+        >
+          <EditorialProse>
+            <p>
+              Diese Website wurde mit dem Ziel entwickelt, möglichst wenige
+              personenbezogene Daten zu erheben. Wir verzichten bewusst auf
+              Tracking-Tools, Werbung und Social-Media-Plugins.
+            </p>
+            <p>
+              Verantwortliche Stelle ist <strong>Christa Egger</strong>,
+              Angehörigenberaterin. Bei Fragen zum Datenschutz können Sie sich
+              an die im Impressum genannte verantwortliche Person wenden.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Erhebung und Verarbeitung von Daten"
+          id="datenerhebung"
+          preview="Technisch notwendige Server-Logfiles ohne Zusammenführung mit anderen Datenquellen."
+        >
+          <EditorialProse>
+            <p>
+              Beim Zugriff auf diese Website werden automatisch Informationen in
+              sogenannten Server-Logfiles gespeichert, die Ihr Browser technisch
+              übermittelt.
+            </p>
+          </EditorialProse>
+
+          <ul className="mt-6 space-y-3 pl-5 marker:text-[color:var(--accent-label)]">
+            <li style={bodyStyle}>Browsertyp und Browserversion</li>
+            <li style={bodyStyle}>verwendetes Betriebssystem</li>
+            <li style={bodyStyle}>Referrer URL</li>
+            <li style={bodyStyle}>Hostname des zugreifenden Rechners</li>
+            <li style={bodyStyle}>Uhrzeit der Serveranfrage</li>
+            <li style={bodyStyle}>IP-Adresse in anonymisierter Form</li>
+          </ul>
+
+          <p className="mt-6" style={bodyStyle}>
+            Diese Daten werden ausschliesslich zur Gewährleistung eines
+            störungsfreien Betriebs und zur technischen Verbesserung des
+            Angebots ausgewertet. Eine Zusammenführung mit anderen Datenquellen
+            findet nicht statt.
+          </p>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Persönliche Notfallkarte und lokale Speicherung"
+          id="notfallkarte-lokal"
+          preview="Persönliche Einträge bleiben lokal im Browser und werden nicht an Server dieser Website übertragen."
+        >
+          <EditorialProse>
+            <p>
+              Die persönliche Notfallkarte kann personenbezogene Angaben
+              enthalten, zum Beispiel Namen, Telefonnummern, Beziehungen,
+              Beruhigungsstrategien oder freie Notizen.
+            </p>
+            <p>
+              Diese Angaben werden{" "}
+              <strong>lokal im Browser auf Ihrem Gerät</strong> gespeichert,
+              damit die Notfallkarte zwischen Ihren Besuchen erhalten bleibt.
+              Die Daten werden dabei{" "}
+              <strong>nicht an einen Server dieser Website übertragen</strong>.
+            </p>
+            <p>
+              Auf gemeinsam genutzten Geräten können andere Personen diese
+              Einträge sehen, wenn sie denselben Browser verwenden. Wenn die
+              Angaben nicht auf dem Gerät bleiben sollen, können Sie sie in der
+              Notfallkarte über <strong>«Daten löschen»</strong> entfernen.
+            </p>
+            <p>
+              Für die Druckansicht wird zusätzlich kurzfristig lokaler
+              Browser-Speicher verwendet. Auch diese Daten werden nicht an
+              unsere Server übertragen.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Cookies"
+          id="cookies"
+          preview="Nur technisch notwendige Cookies; Notfallkarten-Einträge liegen im localStorage, nicht im Cookie."
+        >
+          <EditorialProse>
+            <p>
+              Diese Website verwendet ausschliesslich technisch notwendige
+              Cookies, die für den Betrieb erforderlich sind. Es werden{" "}
+              <strong>keine Tracking-Cookies</strong> oder Cookies zu
+              Werbezwecken eingesetzt.
+            </p>
+            <p>
+              Die persönliche Notfallkarte verwendet für ihre Einträge{" "}
+              <strong>kein Cookie</strong>, sondern lokalen Browser-Speicher
+              (`localStorage`). Dieser unterscheidet sich von Cookies und wird
+              nur auf Ihrem Gerät abgelegt.
+            </p>
+            <p>
+              Sie können Ihren Browser so einstellen, dass Sie über das Setzen
+              von Cookies informiert werden und Cookies nur im Einzelfall
+              erlauben. Bei der Deaktivierung von Cookies kann die
+              Funktionalität dieser Website eingeschränkt sein.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Analyse- und Tracking-Tools"
+          id="tracking"
+          preview="Keine Analyse- oder Tracking-Tools, keine Social-Media-Plugins."
+        >
+          <EditorialProse>
+            <p>
+              Diese Website verwendet{" "}
+              <strong>keine Analyse- oder Tracking-Tools</strong> wie Google
+              Analytics, Facebook Pixel oder ähnliche Dienste. Wir erfassen
+              keine Nutzungsprofile und geben keine Daten an Dritte weiter.
+            </p>
+            <p>
+              Es werden auch <strong>keine Social-Media-Plugins</strong>{" "}
+              eingebunden, die Daten an soziale Netzwerke übertragen könnten.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Externe Links"
+          id="externe-links"
+          preview="Für externe Websites gelten deren eigene Datenschutzerklärungen."
+        >
+          <EditorialProse>
+            <p>
+              Diese Website enthält Links zu externen Websites Dritter, zum
+              Beispiel Notfallressourcen oder Selbsthilfeangeboten. Auf deren
+              Inhalte haben wir keinen Einfluss. Bitte beachten Sie die
+              Datenschutzerklärungen der jeweiligen externen Anbieter.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Downloads und Materialien"
+          id="downloads"
+          preview="Beim Download werden keine zusätzlichen personenbezogenen Inhalte aus Formularen übertragen."
+        >
+          <EditorialProse>
+            <p>
+              Die auf dieser Website angebotenen Infografiken und Handouts
+              können heruntergeladen werden. Beim Download werden keine
+              persönlichen Inhalte aus der Notfallkarte oder anderen lokalen
+              Eingaben an uns übertragen. Die Materialien werden über die
+              Website und ihren Hosting-Anbieter bereitgestellt.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Ihre Rechte"
+          id="rechte"
+          preview="Auskunft, Berichtigung, Löschung und Widerspruch nach DSG und DSGVO."
+        >
+          <EditorialProse>
+            <p>
+              Gemäss dem schweizerischen Datenschutzgesetz und der
+              EU-Datenschutz-Grundverordnung haben Sie insbesondere folgende
+              Rechte:
+            </p>
+          </EditorialProse>
+
+          <ul className="mt-6 space-y-4">
+            <li>
+              <p style={bodyStyle}>
+                <strong>Auskunftsrecht:</strong> Sie können Auskunft über
+                gespeicherte personenbezogene Daten verlangen.
+              </p>
+            </li>
+            <li>
+              <p style={bodyStyle}>
+                <strong>Berichtigungsrecht:</strong> Sie können die Berichtigung
+                unrichtiger Daten verlangen.
+              </p>
+            </li>
+            <li>
+              <p style={bodyStyle}>
+                <strong>Löschungsrecht:</strong> Sie können die Löschung Ihrer
+                Daten verlangen.
+              </p>
+            </li>
+            <li>
+              <p style={bodyStyle}>
+                <strong>Widerspruchsrecht:</strong> Sie können der Verarbeitung
+                Ihrer Daten widersprechen.
+              </p>
+            </li>
+          </ul>
+
+          <p className="mt-6" style={bodyStyle}>
+            Auf unseren Servern speichern wir grundsätzlich keine persönlichen
+            Inhalte aus der Notfallkarte. Falls Sie die persönliche Notfallkarte
+            verwenden, können solche Angaben lokal auf Ihrem Gerät gespeichert
+            sein. Diese Einträge können Sie direkt über{" "}
+            <strong>«Daten löschen»</strong> entfernen.
+          </p>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Änderungen dieser Datenschutzerklärung"
+          id="aenderungen"
+          preview="Anpassungen bei geänderten rechtlichen Anforderungen oder technischen Änderungen."
+        >
+          <EditorialProse>
+            <p>
+              Wir behalten uns vor, diese Datenschutzerklärung anzupassen, damit
+              sie stets den aktuellen rechtlichen Anforderungen entspricht oder
+              um Änderungen unserer Leistungen abzubilden. Für Ihren erneuten
+              Besuch gilt dann die jeweils aktuelle Fassung.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <EditorialSection label="Stand" title="Aktualität" rule>
+          <p style={bodyStyle}>Stand: Februar 2026</p>
+        </EditorialSection>
+
+        <RelatedLinksEditorial
+          links={[
+            {
+              href: "/impressum",
+              title: "Impressum",
+              description: "Verantwortung, Kontakt und rechtliche Hinweise.",
+            },
+            {
+              href: "/barrierefreiheit",
+              title: "Barrierefreiheit",
+              description: "Wie die Website zugänglich gestaltet wird.",
+            },
+            {
+              href: "/notfallkarte",
+              title: "Persönliche Notfallkarte",
+              description:
+                "Wie lokale Speicherung und Löschfunktion praktisch funktionieren.",
+            },
+          ]}
+        />
+      </EditorialLayout>
     </Layout>
   );
 }

--- a/client/src/pages/Feedback.tsx
+++ b/client/src/pages/Feedback.tsx
@@ -1,13 +1,28 @@
-import SEO from "@/components/SEO";
+import {
+  EditorialLayout,
+  EditorialProse,
+  EditorialSection,
+} from "@/components/editorial";
 import Layout from "@/components/Layout";
-import { Card, CardContent } from "@/components/ui/card";
-import { motion } from "framer-motion";
-import { MessageSquare, Mail, Heart, ExternalLink } from "lucide-react";
+import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
+import SEO from "@/components/SEO";
 import { emailByIdStrict } from "@/data/kontakte";
 
 const emailAngehoerigen = emailByIdStrict("EMAIL_ANGEHOERIGEN");
 
 export default function Feedback() {
+  const bodyStyle = {
+    fontSize: "var(--text-sm)",
+    lineHeight: "var(--lh-relaxed)",
+    color: "var(--fg-secondary)",
+  };
+
+  const stepStyle = {
+    fontSize: "var(--text-md)",
+    fontWeight: 600,
+    color: "var(--fg-primary)",
+  };
+
   return (
     <Layout>
       <SEO
@@ -15,159 +30,123 @@ export default function Feedback() {
         description="Rückmeldungen zur Website nehmen wir per E-Mail entgegen."
         path="/feedback"
       />
-      {/* Hero */}
-      <section className="py-10 md:py-14 bg-gradient-to-b from-sage-wash/60 to-background">
-        <div className="container">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="max-w-3xl"
+
+      <EditorialLayout width="narrow">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
+          <p
+            className="text-xs uppercase"
+            style={{
+              color: "var(--accent-label)",
+              letterSpacing: "var(--tracking-caps)",
+              fontWeight: 500,
+            }}
           >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-wash flex items-center justify-center">
-                <MessageSquare className="w-6 h-6 text-slate-dark" />
-              </div>
-              <span className="text-sm font-medium text-sage-dark">
-                Ihre Meinung zählt
-              </span>
-            </div>
+            Feedback
+          </p>
+          <h1
+            className="mt-8 font-display text-[var(--text-3xl)] md:text-[var(--text-4xl)]"
+            style={{
+              lineHeight: "var(--lh-tight)",
+              letterSpacing: "var(--tracking-tight)",
+              color: "var(--fg-primary)",
+              fontWeight: "var(--weight-display)",
+            }}
+          >
+            Rückmeldung <em>geben</em>
+          </h1>
+          <p
+            className="mt-6"
+            style={{
+              fontSize: "var(--text-lg)",
+              lineHeight: "var(--lh-snug)",
+              color: "var(--fg-secondary)",
+            }}
+          >
+            Ihre Erfahrungen und Anregungen helfen uns, diese Website für andere
+            Angehörige noch hilfreicher zu gestalten.
+          </p>
+        </header>
 
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-normal text-foreground mb-6">
-              Rückmeldung geben
-            </h1>
-
-            <p className="text-lg md:text-xl text-muted-foreground leading-relaxed">
-              Ihre Erfahrungen und Anregungen helfen uns, diese Website für
-              andere Angehörige noch hilfreicher zu gestalten.
+        <EditorialSection label="Kontakt" title="Schreiben Sie uns">
+          <EditorialProse>
+            <p>
+              Rückmeldungen nehmen wir aktuell per E-Mail entgegen – ob Lob,
+              Verbesserungsvorschläge oder Hinweise auf Fehler.
             </p>
-          </motion.div>
-        </div>
-      </section>
-
-      {/* Kontakt per E-Mail */}
-      <section className="py-8 md:py-12">
-        <div className="container">
-          <div className="max-w-2xl mx-auto space-y-8">
-            {/* Hauptkarte: E-Mail-Kontakt */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-            >
-              <Card className="bg-sage-light/30 border-sage/30">
-                <CardContent className="p-8 text-center">
-                  <div className="w-16 h-16 rounded-full bg-sage-light flex items-center justify-center mx-auto mb-6">
-                    <Mail className="w-8 h-8 text-sage-dark" />
-                  </div>
-                  <h2 className="text-2xl font-normal text-foreground mb-4">
-                    Schreiben Sie uns
-                  </h2>
-                  <p className="text-muted-foreground mb-6 leading-relaxed max-w-md mx-auto">
-                    Rückmeldungen nehmen wir aktuell per E-Mail entgegen – ob
-                    Lob, Verbesserungsvorschläge oder Fehlermeldungen.
-                  </p>
-                  <a
-                    href={`mailto:${emailAngehoerigen.adresse}?subject=Feedback zur Website «Borderline – Hilfe für Angehörige»`}
-                    className="inline-flex items-center gap-3 px-6 py-3 rounded-lg bg-sage-mid hover:bg-sage-dark text-white font-medium transition-colors"
-                  >
-                    <Mail className="w-5 h-5" />
-                    E-Mail schreiben
-                    <ExternalLink className="w-4 h-4 opacity-60" />
-                  </a>
-                  <p className="text-sm text-muted-foreground mt-4">
-                    {emailAngehoerigen.adresse}
-                  </p>
-                </CardContent>
-              </Card>
-            </motion.div>
-
-            {/* Anregungen */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-            >
-              <Card>
-                <CardContent className="p-6">
-                  <h3 className="text-lg font-semibold text-foreground mb-4">
-                    Worüber wir uns besonders freuen
-                  </h3>
-                  <ul className="space-y-3 text-muted-foreground">
-                    <li className="flex items-start gap-3">
-                      <span className="w-6 h-6 rounded-full bg-sage-lighter flex items-center justify-center flex-shrink-0 mt-0.5">
-                        <span className="text-sage-dark text-sm">1</span>
-                      </span>
-                      <span>Welche Inhalte Ihnen besonders geholfen haben</span>
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="w-6 h-6 rounded-full bg-sage-lighter flex items-center justify-center flex-shrink-0 mt-0.5">
-                        <span className="text-sage-dark text-sm">2</span>
-                      </span>
-                      <span>Was Sie sich zusätzlich wünschen würden</span>
-                    </li>
-                    <li className="flex items-start gap-3">
-                      <span className="w-6 h-6 rounded-full bg-sage-lighter flex items-center justify-center flex-shrink-0 mt-0.5">
-                        <span className="text-sage-dark text-sm">3</span>
-                      </span>
-                      <span>
-                        Hinweise auf Fehler oder Verbesserungsmöglichkeiten
-                      </span>
-                    </li>
-                  </ul>
-                </CardContent>
-              </Card>
-            </motion.div>
-
-            {/* Ermutigende Karte */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-            >
-              <Card className="bg-sand border-sand-subtle">
-                <CardContent className="p-6 text-center">
-                  <Heart className="w-8 h-8 text-sage-dark mx-auto mb-3" />
-                  <p className="text-foreground leading-relaxed">
-                    Denken Sie daran: Sie sind nicht allein. Viele Angehörige
-                    gehen einen ähnlichen Weg – und Ihr Engagement zeigt, dass
-                    Ihnen die Beziehung wichtig ist.
-                  </p>
-                </CardContent>
-              </Card>
-            </motion.div>
-
-            {/* Weiterführende Links */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-              className="flex flex-wrap gap-3 justify-center pt-2"
-            >
+            <p>
               <a
-                href="/"
-                className="inline-flex items-center gap-2 text-sm text-sage-dark hover:underline underline-offset-2"
+                href={`mailto:${emailAngehoerigen.adresse}?subject=Feedback zur Website «Borderline – Hilfe für Angehörige»`}
+                className="editorial-link"
+                style={{ fontSize: "var(--text-lg)" }}
               >
-                ← Zur Startseite
+                {emailAngehoerigen.adresse}
               </a>
-              <span className="text-muted-foreground">·</span>
-              <a
-                href="/beratung"
-                className="inline-flex items-center gap-2 text-sm text-sage-dark hover:underline underline-offset-2"
-              >
-                Beratung &amp; Selbsthilfe
-              </a>
-              <span className="text-muted-foreground">·</span>
-              <a
-                href="/selbstfuersorge"
-                className="inline-flex items-center gap-2 text-sm text-sage-dark hover:underline underline-offset-2"
-              >
-                Selbstfürsorge
-              </a>
-            </motion.div>
-          </div>
-        </div>
-      </section>
+            </p>
+            <p>Wir freuen uns über eine kurze Schilderung Ihres Anliegens.</p>
+          </EditorialProse>
+        </EditorialSection>
+
+        <EditorialSection
+          label="Hilfreich"
+          title="Worüber wir uns besonders freuen"
+          rule
+        >
+          <ol className="space-y-6">
+            <li>
+              <h3 style={stepStyle}>1. Was Ihnen besonders geholfen hat</h3>
+              <p className="mt-1" style={bodyStyle}>
+                Welche Inhalte, Formulierungen oder Materialien für Sie
+                hilfreich oder entlastend waren.
+              </p>
+            </li>
+            <li>
+              <h3 style={stepStyle}>2. Was Sie zusätzlich vermissen</h3>
+              <p className="mt-1" style={bodyStyle}>
+                Welche Fragen offen geblieben sind oder welche Inhalte Sie sich
+                ergänzend wünschen würden.
+              </p>
+            </li>
+            <li>
+              <h3 style={stepStyle}>3. Hinweise auf Fehler</h3>
+              <p className="mt-1" style={bodyStyle}>
+                Hinweise auf technische Probleme, unklare Stellen oder
+                fehlerhafte Angaben helfen uns besonders weiter.
+              </p>
+            </li>
+          </ol>
+        </EditorialSection>
+
+        <EditorialSection label="Zum Schluss" title="Ein Gedanke" rule>
+          <EditorialProse>
+            <p>
+              Viele Angehörige gehen einen ähnlichen Weg. Ihr Engagement zeigt,
+              dass Ihnen die Beziehung wichtig ist. Danke, dass Sie sich die
+              Zeit nehmen, diese Website mit Ihrer Rückmeldung besser zu machen.
+            </p>
+          </EditorialProse>
+        </EditorialSection>
+
+        <RelatedLinksEditorial
+          links={[
+            {
+              href: "/beratung",
+              title: "Beratung & Netzwerke",
+              description: "Anlaufstellen und Unterstützung im Raum Zürich.",
+            },
+            {
+              href: "/selbstfuersorge",
+              title: "Selbstfürsorge",
+              description:
+                "Eigene Belastung ernst nehmen und Grenzen schützen.",
+            },
+            {
+              href: "/",
+              title: "Startseite",
+              description: "Zurück zum Überblick der Website.",
+            },
+          ]}
+        />
+      </EditorialLayout>
     </Layout>
   );
 }

--- a/client/src/pages/Impressum.tsx
+++ b/client/src/pages/Impressum.tsx
@@ -1,19 +1,14 @@
-import SEO from "@/components/SEO";
-import Layout from "@/components/Layout";
 import ContentSection from "@/components/ContentSection";
-import { Card, CardContent } from "@/components/ui/card";
-import { motion } from "framer-motion";
 import {
-  FileText,
-  BookOpen,
-  Phone,
-  Mail,
-  Shield,
-  Target,
-  Copyright,
-} from "lucide-react";
-import { Link } from "wouter";
-import { kontaktByIdStrict, emailByIdStrict } from "@/data/kontakte";
+  EditorialLayout,
+  EditorialProse,
+  EditorialSection,
+} from "@/components/editorial";
+import Layout from "@/components/Layout";
+import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
+import SEO from "@/components/SEO";
+import AppLink from "@/components/AppLink";
+import { emailByIdStrict, kontaktByIdStrict } from "@/data/kontakte";
 
 const fachstelle = kontaktByIdStrict("INFO_FACHSTELLE");
 const emailAngehoerigen = emailByIdStrict("EMAIL_ANGEHOERIGEN");
@@ -22,6 +17,25 @@ const rot117 = kontaktByIdStrict("ROT_117");
 const gruen143 = kontaktByIdStrict("GRUEN_143");
 
 export default function Impressum() {
+  const subheadingStyle = {
+    fontSize: "var(--text-md)",
+    fontWeight: 600,
+    color: "var(--fg-primary)",
+  };
+
+  const bodyStyle = {
+    fontSize: "var(--text-sm)",
+    lineHeight: "var(--lh-relaxed)",
+    color: "var(--fg-secondary)",
+  };
+
+  const labelStyle = {
+    fontSize: "var(--text-xs)",
+    letterSpacing: "var(--tracking-caps)",
+    color: "var(--fg-tertiary)",
+    fontWeight: 500,
+  } as const;
+
   return (
     <Layout>
       <SEO
@@ -29,305 +43,272 @@ export default function Impressum() {
         description="Impressum und rechtliche Informationen."
         path="/impressum"
       />
-      {/* Hero */}
-      <section className="py-10 md:py-14 bg-gradient-to-b from-sage-wash/60 to-background">
-        <div className="container">
-          <motion.div
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            transition={{ duration: 0.6, ease: "easeOut" }}
-            className="max-w-3xl"
+
+      <EditorialLayout width="narrow">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
+          <p
+            className="text-xs uppercase"
+            style={{
+              color: "var(--accent-label)",
+              letterSpacing: "var(--tracking-caps)",
+              fontWeight: 500,
+            }}
           >
-            <div className="flex items-center gap-3 mb-6">
-              <div className="w-12 h-12 rounded-xl bg-sage-wash flex items-center justify-center">
-                <FileText className="w-6 h-6 text-sage-darker" />
-              </div>
-            </div>
+            Impressum
+          </p>
+          <h1
+            className="mt-8 font-display text-[var(--text-3xl)] md:text-[var(--text-4xl)]"
+            style={{
+              lineHeight: "var(--lh-tight)",
+              letterSpacing: "var(--tracking-tight)",
+              color: "var(--fg-primary)",
+              fontWeight: "var(--weight-display)",
+            }}
+          >
+            Verantwortung und <em>rechtliche Hinweise</em>
+          </h1>
+          <p
+            className="mt-6"
+            style={{
+              fontSize: "var(--text-lg)",
+              lineHeight: "var(--lh-snug)",
+              color: "var(--fg-secondary)",
+            }}
+          >
+            Wer hinter diesem Informationsangebot steht, wie Sie die Fachstelle
+            erreichen und welche rechtlichen Hinweise für Inhalte, Links und
+            Materialien gelten.
+          </p>
+        </header>
 
-            <h1 className="text-2xl md:text-3xl lg:text-4xl font-normal text-foreground mb-6">
-              Impressum
-            </h1>
-          </motion.div>
-        </div>
-      </section>
+        <ContentSection
+          variant="editorial"
+          title="Verantwortlich für den Inhalt"
+          id="verantwortlich"
+          defaultOpen={true}
+          preview="Christa Egger, Fachstelle Angehörigenarbeit der PUK Zürich."
+        >
+          <EditorialProse>
+            <p>
+              Verantwortlich für die Inhalte dieser Website ist{" "}
+              <strong>Christa Egger</strong>, Angehörigenberaterin der
+              Fachstelle Angehörigenarbeit.
+            </p>
+            <p>
+              Erstellt von Ch. Egger innerhalb der Fachstelle Angehörigenarbeit
+              der PUK Zürich. Die inhaltliche Verantwortung liegt bei der
+              Fachstelle Angehörigenarbeit. Das Informationsdesign ist
+              eigenständig und folgt nicht der PUK-CI.
+            </p>
+            <p>
+              Die Website ist ein unabhängiges Informationsangebot der
+              Fachstelle Angehörigenarbeit und kein offizieller
+              Kommunikationskanal der PUK Zürich.
+            </p>
+          </EditorialProse>
 
-      {/* Content */}
-      <section className="py-8 md:py-12">
-        <div className="container">
-          <div className="max-w-3xl mx-auto">
-            {/* Verantwortlich + Kontakt – immer offen */}
-            <ContentSection
-              title="Verantwortlich für den Inhalt"
-              icon={<Mail className="w-7 h-7 text-sage-mid" />}
-              id="verantwortlich"
-              defaultOpen={true}
-              preview="Christa Egger, Angehörigenberaterin – Fachstelle Angehörigenarbeit PUK Zürich."
-            >
-              <Card className="border-border/50 mb-4">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-2">
-                    <p className="font-medium text-foreground">Christa Egger</p>
-                    <p>Angehörigenberaterin</p>
-                    <p className="mt-4 text-sm">
-                      Erstellt von Ch. Egger, Fachstelle Angehörigenarbeit (PUK
-                      Zürich). Inhaltliche Verantwortung: Fachstelle
-                      Angehörigenarbeit. Gestaltung folgt einem eigenständigen
-                      Informationsdesign (nicht PUK-CI).
-                    </p>
-                    <p className="mt-2 text-sm text-muted-foreground/80">
-                      Unabhängiges Informationsangebot der Fachstelle
-                      Angehörigenarbeit. Nicht offizieller Kommunikationskanal
-                      der PUK Zürich.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
+          <dl className="mt-8 grid gap-y-6 sm:grid-cols-[max-content_1fr] sm:gap-x-10">
+            <dt className="uppercase" style={labelStyle}>
+              Funktion
+            </dt>
+            <dd style={bodyStyle}>Angehörigenberaterin</dd>
 
-              <Card className="border-sage-mid/30 bg-sage-wash/30">
-                <CardContent className="p-6">
-                  <h3 className="text-lg font-semibold text-foreground mb-4">
-                    Beratung für Angehörige
-                  </h3>
-                  <p className="text-muted-foreground leading-relaxed mb-4">
-                    Die <strong>Fachstelle Angehörigenarbeit</strong> an der
-                    Psychiatrischen Universitätsklinik Zürich (PUK) bietet
-                    Unterstützung und Beratung für Angehörige von psychisch
-                    erkrankten Menschen.
-                  </p>
-                  <div className="space-y-3">
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 rounded-lg bg-sage-light flex items-center justify-center flex-shrink-0">
-                        <Phone className="w-5 h-5 text-sage-dark" />
-                      </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">Telefon</p>
-                        <a
-                          href={`tel:${fachstelle.tel}`}
-                          className="font-medium text-foreground hover:text-sage-mid transition-colors"
-                        >
-                          {fachstelle.nummer}
-                        </a>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-3">
-                      <div className="w-10 h-10 rounded-lg bg-sage-light flex items-center justify-center flex-shrink-0">
-                        <Mail className="w-5 h-5 text-sage-dark" />
-                      </div>
-                      <div>
-                        <p className="text-sm text-muted-foreground">E-Mail</p>
-                        <a
-                          href={`mailto:${emailAngehoerigen.adresse}`}
-                          className="font-medium text-foreground hover:text-sage-mid transition-colors"
-                        >
-                          {emailAngehoerigen.adresse}
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                  <div className="mt-4 pt-4 border-t border-border/50">
-                    <p className="text-sm text-muted-foreground">
-                      Die Beratung ist <strong>kostenlos</strong> und steht
-                      allen Angehörigen von psychisch kranken Menschen im Kanton
-                      Zürich vertraulich zur Verfügung.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
+            <dt className="uppercase" style={labelStyle}>
+              Telefon
+            </dt>
+            <dd>
+              <a
+                href={`tel:${fachstelle.tel}`}
+                className="editorial-link"
+                style={{ fontSize: "var(--text-md)" }}
+              >
+                {fachstelle.nummer}
+              </a>
+            </dd>
 
-            {/* Hinweis + Zweck */}
-            <ContentSection
-              title="Zweck der Website"
-              icon={<Target className="w-7 h-7 text-sage-dark" />}
-              id="zweck"
-              preview="Evidenzbasierte Informationen, praktische Strategien und Ressourcen zur Selbstfürsorge."
-            >
-              <Card className="border-sage/30 bg-sage-wash/30 mb-4">
-                <CardContent className="p-6">
-                  <h3 className="font-semibold text-foreground mb-3">
-                    Wichtiger Hinweis
-                  </h3>
-                  <p className="text-muted-foreground leading-relaxed">
-                    Unabhängiges Informationsangebot der Fachstelle
-                    Angehörigenarbeit. Nicht offizieller Kommunikationskanal der
-                    PUK Zürich. Die Website stellt eine eigenständige
-                    Informationsressource dar, die auf Basis evidenzbasierter
-                    Fachliteratur und praktischer Erfahrung in der
-                    Angehörigenberatung erstellt wurde.
-                  </p>
-                </CardContent>
-              </Card>
+            <dt className="uppercase" style={labelStyle}>
+              E-Mail
+            </dt>
+            <dd>
+              <a
+                href={`mailto:${emailAngehoerigen.adresse}`}
+                className="editorial-link"
+                style={{ fontSize: "var(--text-md)" }}
+              >
+                {emailAngehoerigen.adresse}
+              </a>
+            </dd>
+          </dl>
 
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <p className="text-muted-foreground leading-relaxed mb-4">
-                    Diese Website bietet Angehörigen von Menschen mit
-                    Borderline-Persönlichkeitsstörung:
-                  </p>
-                  <ul className="space-y-2 text-muted-foreground">
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-dark">•</span>
-                      Evidenzbasierte Informationen zum Verständnis der Störung
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Praktische Strategien für den Alltag und Krisensituationen
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Kommunikationstechniken für schwierige Gespräche
-                    </li>
-                    <li className="flex items-start gap-2">
-                      <span className="text-sage-mid">•</span>
-                      Ressourcen zur Selbstfürsorge und Burnout-Prävention
-                    </li>
-                  </ul>
-                </CardContent>
-              </Card>
-            </ContentSection>
+          <p className="mt-6" style={bodyStyle}>
+            Die Beratung für Angehörige ist kostenlos und steht Angehörigen von
+            psychisch kranken Menschen im Kanton Zürich vertraulich zur
+            Verfügung.
+          </p>
+        </ContentSection>
 
-            {/* Haftungsausschluss */}
-            <ContentSection
-              title="Haftungsausschluss"
-              icon={<Shield className="w-7 h-7 text-slate-blue" />}
-              id="haftung"
-              preview="Keine Gewähr für Richtigkeit – ersetzt keine professionelle Beratung, Diagnose oder Behandlung."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <div className="text-muted-foreground leading-relaxed space-y-4">
-                    <p>
-                      Die Inhalte dieser Website wurden mit grösster Sorgfalt
-                      erstellt. Für die Richtigkeit, Vollständigkeit und
-                      Aktualität der Inhalte kann jedoch keine Gewähr übernommen
-                      werden.
-                    </p>
-                    <p>
-                      <strong>
-                        Diese Website ersetzt keine professionelle Beratung,
-                        Diagnose oder Behandlung.
-                      </strong>{" "}
-                      Bei psychischen Krisen oder Notfällen wenden Sie sich
-                      bitte umgehend an die entsprechenden Notfallnummern (
-                      {rot144.nummer} / {rot117.nummer}) oder den
-                      psychiatrischen Notdienst. Zur Entlastung:{" "}
-                      {gruen143.label} ({gruen143.nummer}).
-                    </p>
-                    <p>
-                      Für externe Links wird keine Haftung übernommen. Für den
-                      Inhalt der verlinkten Seiten sind ausschliesslich deren
-                      Betreiber verantwortlich.
-                    </p>
-                  </div>
-                </CardContent>
-              </Card>
-            </ContentSection>
+        <ContentSection
+          variant="editorial"
+          title="Zweck der Website"
+          id="zweck"
+          preview="Evidenzbasierte Orientierung, praktische Strategien und Materialien für Angehörige."
+        >
+          <EditorialProse>
+            <p>
+              Diese Website bietet Angehörigen von Menschen mit
+              Borderline-Persönlichkeitsstörung evidenzbasierte Informationen,
+              Orientierung für schwierige Alltagssituationen und Materialien zur
+              Selbstfürsorge.
+            </p>
+            <p>
+              Sie verbindet wissenschaftliche Quellen, klinische Erfahrung aus
+              der Angehörigenarbeit und praktische Hilfen für Gesprächs-,
+              Krisen- und Belastungssituationen.
+            </p>
+          </EditorialProse>
 
-            {/* Quellenangaben */}
-            <ContentSection
-              title="Quellenangaben"
-              icon={<BookOpen className="w-7 h-7 text-sage-mid" />}
-              id="impressum-quellen"
-              preview="Fachliteratur von Mason/Kreger, Linehan, Fruzzetti und Gunderson/Hoffman."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <p className="text-muted-foreground leading-relaxed mb-4">
-                    Die Inhalte dieser Website stützen sich auf anerkannte
-                    Fachliteratur, wissenschaftliche Quellen für medizinische
-                    und therapeutische Aussagen sowie auf klinische Erfahrung in
-                    der Angehörigenarbeit, insbesondere:
-                  </p>
-                  <p className="text-sm text-sage-dark mb-4">
-                    <Link
-                      href="/quellen"
-                      className="underline hover:no-underline"
-                    >
-                      → Vollständige Literaturliste mit PubMed-Links
-                    </Link>
-                  </p>
-                  <ul className="space-y-3 text-muted-foreground">
-                    <li className="border-l-2 border-sage pl-4">
-                      <p className="font-medium text-foreground">
-                        Mason, P. T. & Kreger, R.
-                      </p>
-                      <p className="text-sm">
-                        Schluss mit dem Eiertanz: Für Angehörige von Menschen
-                        mit Borderline. Balance Buch + Medien Verlag.
-                      </p>
-                    </li>
-                    <li className="border-l-2 border-sage pl-4">
-                      <p className="font-medium text-foreground">
-                        Linehan, M. M.
-                      </p>
-                      <p className="text-sm">
-                        Dialektisch-Behaviorale Therapie der
-                        Borderline-Persönlichkeitsstörung. CIP-Medien.
-                      </p>
-                    </li>
-                    <li className="border-l-2 border-sage pl-4">
-                      <p className="font-medium text-foreground">
-                        Fruzzetti, A. E.
-                      </p>
-                      <p className="text-sm">
-                        The High-Conflict Couple: A Dialectical Behavior Therapy
-                        Guide. New Harbinger Publications.
-                      </p>
-                    </li>
-                    <li className="border-l-2 border-sage pl-4">
-                      <p className="font-medium text-foreground">
-                        Gunderson, J. G. & Hoffman, P. D.
-                      </p>
-                      <p className="text-sm">
-                        Understanding and Treating Borderline Personality
-                        Disorder. American Psychiatric Publishing.
-                      </p>
-                    </li>
-                  </ul>
-                </CardContent>
-              </Card>
-            </ContentSection>
+          <ul className="mt-6 space-y-3 pl-5 marker:text-[color:var(--accent-label)]">
+            <li style={bodyStyle}>Informationen zum Verständnis der Störung</li>
+            <li style={bodyStyle}>
+              Strategien für Alltag und Krisensituationen
+            </li>
+            <li style={bodyStyle}>
+              Kommunikationstechniken für schwierige Gespräche
+            </li>
+            <li style={bodyStyle}>
+              Ressourcen zur Selbstfürsorge und Burnout-Prävention
+            </li>
+          </ul>
+        </ContentSection>
 
-            {/* Urheberrecht */}
-            <ContentSection
-              title="Urheberrecht"
-              icon={<Copyright className="w-7 h-7 text-sage-mid" />}
-              id="urheberrecht"
-              preview="Schweizerisches Urheberrecht – Materialien für persönlichen Gebrauch und Angehörigenberatung."
-            >
-              <Card className="border-border/50">
-                <CardContent className="p-6">
-                  <p className="text-muted-foreground leading-relaxed">
-                    Die Inhalte und Werke auf dieser Website unterliegen dem
-                    schweizerischen Urheberrecht. Die Vervielfältigung,
-                    Bearbeitung, Verbreitung und jede Art der Verwertung
-                    ausserhalb der Grenzen des Urheberrechts bedürfen der
-                    schriftlichen Zustimmung. Downloads und Kopien dieser Seite
-                    sind nur für den privaten, nicht kommerziellen Gebrauch
-                    gestattet.
-                  </p>
-                  <p className="text-muted-foreground leading-relaxed mt-4">
-                    Die Infografiken und Handouts dürfen im Rahmen der
-                    Angehörigenberatung und für den persönlichen Gebrauch
-                    verwendet werden.
-                  </p>
-                </CardContent>
-              </Card>
-            </ContentSection>
+        <ContentSection
+          variant="editorial"
+          title="Haftungsausschluss"
+          id="haftung"
+          preview="Die Website ersetzt keine professionelle Beratung, Diagnose oder Behandlung."
+        >
+          <EditorialProse>
+            <p>
+              Die Inhalte dieser Website wurden mit grösster Sorgfalt erstellt.
+              Für die Richtigkeit, Vollständigkeit und Aktualität der Inhalte
+              kann dennoch keine Gewähr übernommen werden.
+            </p>
+            <p>
+              <strong>
+                Diese Website ersetzt keine professionelle Beratung, Diagnose
+                oder Behandlung.
+              </strong>{" "}
+              Bei psychischen Krisen oder Notfällen wenden Sie sich bitte
+              umgehend an die entsprechenden Notfallnummern ({rot144.nummer} /{" "}
+              {rot117.nummer}) oder den psychiatrischen Notdienst. Zur
+              Entlastung: {gruen143.label} ({gruen143.nummer}).
+            </p>
+            <p>
+              Für externe Links wird keine Haftung übernommen. Für den Inhalt
+              der verlinkten Seiten sind ausschliesslich deren Betreiber
+              verantwortlich.
+            </p>
+          </EditorialProse>
+        </ContentSection>
 
-            {/* Stand */}
-            <motion.div
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
-              viewport={{ once: true }}
-            >
-              <p className="text-center text-sm text-muted-foreground">
-                Stand: Februar 2026
+        <ContentSection
+          variant="editorial"
+          title="Quellenangaben"
+          id="impressum-quellen"
+          preview="Fachliteratur von Mason/Kreger, Linehan, Fruzzetti und Gunderson/Hoffman."
+        >
+          <EditorialProse>
+            <p>
+              Die Inhalte dieser Website stützen sich auf anerkannte
+              Fachliteratur, wissenschaftliche Quellen für medizinische und
+              therapeutische Aussagen sowie auf klinische Erfahrung in der
+              Angehörigenarbeit.
+            </p>
+            <p>
+              Eine vollständige Literaturliste finden Sie auf der{" "}
+              <AppLink href="/quellen" className="editorial-link">
+                Seite Quellen &amp; Literatur
+              </AppLink>
+              .
+            </p>
+          </EditorialProse>
+
+          <ul className="mt-6 space-y-6">
+            <li>
+              <h3 style={subheadingStyle}>Mason, P. T. &amp; Kreger, R.</h3>
+              <p className="mt-1" style={bodyStyle}>
+                Schluss mit dem Eiertanz: Für Angehörige von Menschen mit
+                Borderline. Balance Buch + Medien Verlag.
               </p>
-            </motion.div>
-          </div>
-        </div>
-      </section>
+            </li>
+            <li>
+              <h3 style={subheadingStyle}>Linehan, M. M.</h3>
+              <p className="mt-1" style={bodyStyle}>
+                Dialektisch-Behaviorale Therapie der
+                Borderline-Persönlichkeitsstörung. CIP-Medien.
+              </p>
+            </li>
+            <li>
+              <h3 style={subheadingStyle}>Fruzzetti, A. E.</h3>
+              <p className="mt-1" style={bodyStyle}>
+                The High-Conflict Couple: A Dialectical Behavior Therapy Guide.
+                New Harbinger Publications.
+              </p>
+            </li>
+            <li>
+              <h3 style={subheadingStyle}>
+                Gunderson, J. G. &amp; Hoffman, P. D.
+              </h3>
+              <p className="mt-1" style={bodyStyle}>
+                Understanding and Treating Borderline Personality Disorder.
+                American Psychiatric Publishing.
+              </p>
+            </li>
+          </ul>
+        </ContentSection>
+
+        <ContentSection
+          variant="editorial"
+          title="Urheberrecht"
+          id="urheberrecht"
+          preview="Schweizerisches Urheberrecht – Materialien für persönlichen Gebrauch und Angehörigenberatung."
+        >
+          <EditorialProse>
+            <p>
+              Die Inhalte und Werke auf dieser Website unterliegen dem
+              schweizerischen Urheberrecht. Die Vervielfältigung, Bearbeitung,
+              Verbreitung und jede Art der Verwertung ausserhalb der Grenzen des
+              Urheberrechts bedürfen der schriftlichen Zustimmung.
+            </p>
+            <p>
+              Downloads und Kopien dieser Seite sind nur für den privaten, nicht
+              kommerziellen Gebrauch gestattet. Die Infografiken und Handouts
+              dürfen im Rahmen der Angehörigenberatung und für den persönlichen
+              Gebrauch verwendet werden.
+            </p>
+          </EditorialProse>
+        </ContentSection>
+
+        <EditorialSection label="Stand" title="Aktualität" rule>
+          <p style={bodyStyle}>Stand: Februar 2026</p>
+        </EditorialSection>
+
+        <RelatedLinksEditorial
+          links={[
+            {
+              href: "/datenschutz",
+              title: "Datenschutz",
+              description: "Wie diese Website mit Daten umgeht.",
+            },
+            {
+              href: "/fachstelle",
+              title: "Fachstelle Angehörigenarbeit",
+              description:
+                "Kontakt und Einordnung der verantwortlichen Stelle.",
+            },
+          ]}
+        />
+      </EditorialLayout>
     </Layout>
   );
 }


### PR DESCRIPTION
## Summary
- move Impressum, Datenschutz, and Feedback onto the calmer editorial page pattern
- remove legacy gradient hero and card-heavy treatment from those secondary pages
- update the Datenschutz test to match the clarified copy

## Testing
- pnpm lint
- pnpm check
- pnpm test
- pnpm build