### PR TITLE
Editorialize handout text and self-care sections

### DIFF
--- a/client/src/pages/HandoutTextPage.tsx
+++ b/client/src/pages/HandoutTextPage.tsx
@@ -1,6 +1,12 @@
 import { useEffect, useState } from "react";
 import AppLink from "@/components/AppLink";
+import {
+  EditorialLayout,
+  EditorialProse,
+  EditorialSection,
+} from "@/components/editorial";
 import Layout from "@/components/Layout";
+import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import SEO, { MedicalPageSchema } from "@/components/SEO";
 import {
   getHandoutDownloadHref,
@@ -17,18 +23,10 @@ import type {
   HandoutTextVersion,
 } from "@/content/handoutTextVersionTypes";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
 import { Spinner } from "@/components/ui/spinner";
 import NotFound from "@/pages/NotFound";
 import type { RouteComponentProps } from "wouter";
-import {
-  ArrowLeft,
-  BookOpen,
-  Download,
-  ExternalLink,
-  FileText,
-  Library,
-} from "lucide-react";
+import { Download, ExternalLink } from "lucide-react";
 
 type HandoutTextPageParams = {
   handoutId?: string;
@@ -102,6 +100,30 @@ export default function HandoutTextPage({
   const openHref = getHandoutOpenHref(pdfSourceUrl) ?? pdfSourceUrl;
   const downloadHref = getHandoutDownloadHref(pdfSourceUrl) ?? pdfSourceUrl;
   const textVersionPreferred = prefersHandoutTextVersion(pdfSourceUrl);
+  const pageKicker = handout?.kicker ?? "Textversion";
+
+  const leadStyle = {
+    fontSize: "var(--text-lg)",
+    lineHeight: "var(--lh-snug)",
+    color: "var(--fg-secondary)",
+  };
+
+  const bodyStyle = {
+    fontSize: "var(--text-sm)",
+    lineHeight: "var(--lh-relaxed)",
+    color: "var(--fg-secondary)",
+  };
+
+  const metaStyle = {
+    fontSize: "var(--text-sm)",
+    color: "var(--fg-tertiary)",
+  };
+
+  const sectionCardTitleStyle = {
+    fontSize: "var(--text-md)",
+    fontWeight: 600,
+    color: "var(--fg-primary)",
+  };
 
   return (
     <Layout>
@@ -116,210 +138,213 @@ export default function HandoutTextPage({
         path={handoutMeta.path}
       />
 
-      <section className="py-12 md:py-16 bg-gradient-to-b from-sage-wash/50 via-background to-background">
-        <div className="container">
-          <div className="max-w-6xl mx-auto grid gap-8 lg:grid-cols-[1.25fr_0.95fr] items-start">
-            <div>
-              <div className="flex flex-wrap items-center gap-3 mb-4">
-                <span className="inline-flex items-center rounded-full bg-sage-dark px-4 py-1.5 text-sm font-medium text-white">
-                  {handout?.kicker ?? "Textversion"}
-                </span>
-                <span className="inline-flex items-center gap-2 rounded-full border border-border bg-white/90 px-4 py-1.5 text-sm text-muted-foreground">
-                  <Library className="w-4 h-4 text-sage-dark" />
-                  {pageTopicLabel}
-                </span>
-                <span className="inline-flex items-center gap-2 rounded-full border border-border bg-white/90 px-4 py-1.5 text-sm text-muted-foreground">
-                  <FileText className="w-4 h-4 text-sage-dark" />
-                  {pageKind}
-                </span>
-              </div>
+      <EditorialLayout width="wide">
+        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
+          <p
+            className="text-xs uppercase"
+            style={{
+              color: "var(--accent-label)",
+              letterSpacing: "var(--tracking-caps)",
+              fontWeight: 500,
+            }}
+          >
+            {pageKicker}
+          </p>
+          <p className="mt-4" style={metaStyle}>
+            {pageTopicLabel} · {pageKind}
+          </p>
+          <h1
+            className="mt-8 font-display text-[var(--text-3xl)] md:text-[var(--text-4xl)]"
+            style={{
+              lineHeight: "var(--lh-tight)",
+              letterSpacing: "var(--tracking-tight)",
+              color: "var(--fg-primary)",
+              fontWeight: "var(--weight-display)",
+            }}
+          >
+            {pageTitle}
+          </h1>
+          <p className="mt-6" style={leadStyle}>
+            {pageSummary}
+          </p>
 
-              <h1 className="text-3xl md:text-4xl lg:text-5xl font-normal text-foreground leading-tight mb-5">
-                {pageTitle}
-              </h1>
-
-              <p className="text-lg md:text-xl text-muted-foreground leading-relaxed mb-6 max-w-3xl">
-                {pageSummary}
-              </p>
-
-              <div className="flex flex-wrap gap-3 mb-5">
-                <Button
-                  asChild
-                  className="bg-sage-dark hover:bg-sage-mid text-white"
-                >
-                  <a href={openHref} target="_blank" rel="noopener noreferrer">
-                    <ExternalLink className="w-4 h-4" />
-                    PDF öffnen
-                  </a>
-                </Button>
-                <Button asChild variant="outline">
-                  <a href={downloadHref} download="">
-                    <Download className="w-4 h-4" />
-                    PDF herunterladen
-                  </a>
-                </Button>
-                <Button asChild variant="outline">
-                  <AppLink href="/materialien">
-                    <ArrowLeft className="w-4 h-4" />
-                    Zur Materialsammlung
-                  </AppLink>
-                </Button>
-              </div>
-
-              {textVersionPreferred ? (
-                <p className="mb-5 text-sm text-muted-foreground leading-relaxed max-w-3xl">
-                  Diese Textversion ist die empfohlene Lesefassung. Das PDF
-                  bleibt als Druck- und Layoutversion verfügbar.
-                </p>
-              ) : null}
-
-              <div className="flex flex-wrap gap-x-5 gap-y-2 text-sm text-muted-foreground">
-                <AppLink
-                  href={pageTopicHref}
-                  className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
-                >
-                  <BookOpen className="w-4 h-4 text-sage-dark" />
-                  Zum Themenbereich {pageTopicLabel}
-                </AppLink>
-                <AppLink
-                  href="/barrierefreiheit"
-                  className="inline-flex items-center gap-2 hover:text-foreground transition-colors"
-                >
-                  <FileText className="w-4 h-4 text-sage-dark" />
-                  Warum diese Textversion hilfreich ist
-                </AppLink>
-              </div>
-            </div>
-
-            <Card className="overflow-hidden border-border/60 bg-white/90 shadow-sm">
-              <img
-                src={pagePreviewImageUrl}
-                alt={`Vorschau des Handouts ${pageTitle}`}
-                className="w-full h-auto object-cover object-top"
-                loading="eager"
-                width={720}
-                height={900}
-                decoding="async"
-              />
-            </Card>
+          <div className="mt-8 flex flex-wrap gap-3">
+            <Button
+              asChild
+              className="bg-sage-dark hover:bg-sage-mid text-white"
+            >
+              <a href={openHref} target="_blank" rel="noopener noreferrer">
+                <ExternalLink className="w-4 h-4" />
+                PDF öffnen
+              </a>
+            </Button>
+            <Button asChild variant="outline">
+              <a href={downloadHref} download="">
+                <Download className="w-4 h-4" />
+                PDF herunterladen
+              </a>
+            </Button>
           </div>
-        </div>
-      </section>
 
-      <section className="py-8">
-        <div className="container">
-          <div className="max-w-6xl mx-auto">
-            <Card className="border-sage-light bg-sage-wash/70">
-              <CardContent className="p-6">
-                <h2 className="text-lg font-semibold text-foreground mb-3">
-                  Worum es in diesem Handout geht
-                </h2>
-                {handout ? (
-                  <div className="space-y-3 text-muted-foreground leading-relaxed">
-                    {handout.intro.map(text => (
-                      <p key={text}>{text}</p>
+          <div
+            className="mt-5 flex flex-wrap gap-x-5 gap-y-2"
+            style={bodyStyle}
+          >
+            <AppLink href={pageTopicHref} className="editorial-link">
+              Zum Themenbereich {pageTopicLabel}
+            </AppLink>
+            <AppLink href="/materialien" className="editorial-link">
+              Zur Materialsammlung
+            </AppLink>
+            <AppLink href="/barrierefreiheit" className="editorial-link">
+              Warum diese Textversion hilfreich ist
+            </AppLink>
+          </div>
+
+          {textVersionPreferred ? (
+            <p
+              className="mt-8 border-t pt-4"
+              style={{
+                ...bodyStyle,
+                borderColor: "var(--rule-color)",
+              }}
+            >
+              Diese Textversion ist die empfohlene Lesefassung. Das PDF bleibt
+              als Druck- und Layoutversion verfügbar.
+            </p>
+          ) : null}
+
+          <figure
+            className="mt-10 border-t pt-5"
+            style={{ borderColor: "var(--rule-color)" }}
+          >
+            <img
+              src={pagePreviewImageUrl}
+              alt={`Vorschau des Handouts ${pageTitle}`}
+              className="w-full h-auto border object-cover object-top"
+              style={{ borderColor: "var(--rule-color)" }}
+              loading="eager"
+              width={720}
+              height={900}
+              decoding="async"
+            />
+            <figcaption className="mt-3" style={metaStyle}>
+              Vorschau der Druckversion. Für ruhiges Lesen ist diese Textfassung
+              gedacht.
+            </figcaption>
+          </figure>
+        </header>
+
+        <EditorialSection
+          label="Überblick"
+          title="Worum es in diesem Handout geht"
+        >
+          {handout ? (
+            <EditorialProse>
+              {handout.intro.map(text => (
+                <p key={text}>{text}</p>
+              ))}
+            </EditorialProse>
+          ) : (
+            <div className="flex items-center gap-3" style={bodyStyle}>
+              <Spinner className="size-5 text-sage-dark" />
+              <p>Die ausführliche Textversion wird geladen.</p>
+            </div>
+          )}
+        </EditorialSection>
+
+        {handout ? (
+          <>
+            {handout.sections.map(section => (
+              <EditorialSection key={section.title} title={section.title} rule>
+                {section.intro ? (
+                  <EditorialProse>
+                    <p>{section.intro}</p>
+                  </EditorialProse>
+                ) : null}
+
+                {section.calloutTitle && section.calloutText ? (
+                  <div
+                    className="mt-6 border-l pl-4"
+                    style={{ borderColor: "var(--accent-label)" }}
+                  >
+                    <h3 style={sectionCardTitleStyle}>
+                      {section.calloutTitle}
+                    </h3>
+                    <p className="mt-2" style={bodyStyle}>
+                      {section.calloutText}
+                    </p>
+                  </div>
+                ) : null}
+
+                {section.cards?.length ? (
+                  <div className={`mt-6 ${getCardGridClass(section.cards)}`}>
+                    {section.cards.map(card => (
+                      <article
+                        key={`${section.title}-${card.title}`}
+                        className="border-t pt-4"
+                        style={{ borderColor: "var(--rule-color)" }}
+                      >
+                        <h3 style={sectionCardTitleStyle}>{card.title}</h3>
+                        <p className="mt-2" style={bodyStyle}>
+                          {card.text}
+                        </p>
+                      </article>
                     ))}
                   </div>
-                ) : (
-                  <div className="flex items-center gap-3 text-muted-foreground">
-                    <Spinner className="size-5 text-sage-dark" />
-                    <p>Die ausführliche Textversion wird geladen.</p>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          </div>
-        </div>
-      </section>
+                ) : null}
 
-      <section className="pb-14 md:pb-16">
-        <div className="container">
-          <div className="max-w-6xl mx-auto grid gap-6">
-            {handout ? (
-              <>
-                {handout.sections.map(section => (
-                  <Card
-                    key={section.title}
-                    className="border-border/60 shadow-sm"
-                  >
-                    <CardContent className="p-6 md:p-7">
-                      <h2 className="text-2xl font-semibold text-foreground mb-3">
-                        {section.title}
-                      </h2>
+                {section.bullets?.length ? (
+                  <ul className="mt-6 space-y-3 pl-5 list-disc marker:text-[color:var(--accent-label)]">
+                    {section.bullets.map(item => (
+                      <li key={item} style={bodyStyle}>
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+              </EditorialSection>
+            ))}
 
-                      {section.intro ? (
-                        <p className="text-muted-foreground leading-relaxed mb-5">
-                          {section.intro}
-                        </p>
-                      ) : null}
+            <EditorialSection label="Quelle & Stand" rule>
+              <p style={bodyStyle}>{handout.sourceLine}</p>
+              <p className="mt-2" style={bodyStyle}>
+                {handout.standLine}
+              </p>
+            </EditorialSection>
+          </>
+        ) : (
+          <EditorialSection title="Textversion lädt" rule>
+            <div className="flex items-center gap-3" style={bodyStyle}>
+              <Spinner className="size-5 text-sage-dark" />
+              <p>Die Abschnitte dieser Textversion werden geladen.</p>
+            </div>
+          </EditorialSection>
+        )}
 
-                      {section.calloutTitle && section.calloutText ? (
-                        <div className="rounded-xl border border-sage-light/80 bg-sage-wash/50 p-5 mb-5">
-                          <h3 className="font-semibold text-foreground mb-2">
-                            {section.calloutTitle}
-                          </h3>
-                          <p className="text-base leading-relaxed text-foreground">
-                            {section.calloutText}
-                          </p>
-                        </div>
-                      ) : null}
-
-                      {section.cards?.length ? (
-                        <div className={getCardGridClass(section.cards)}>
-                          {section.cards.map(card => (
-                            <div
-                              key={`${section.title}-${card.title}`}
-                              className="rounded-xl border border-border/60 bg-background p-5"
-                            >
-                              <h3 className="font-semibold text-foreground mb-2">
-                                {card.title}
-                              </h3>
-                              <p className="text-sm md:text-base leading-relaxed text-muted-foreground">
-                                {card.text}
-                              </p>
-                            </div>
-                          ))}
-                        </div>
-                      ) : null}
-
-                      {section.bullets?.length ? (
-                        <ul className="grid gap-3">
-                          {section.bullets.map(item => (
-                            <li
-                              key={item}
-                              className="rounded-xl border border-border/60 bg-background px-4 py-3 text-sm md:text-base text-muted-foreground"
-                            >
-                              {item}
-                            </li>
-                          ))}
-                        </ul>
-                      ) : null}
-                    </CardContent>
-                  </Card>
-                ))}
-
-                <Card className="border-border/60 bg-muted/20">
-                  <CardContent className="p-6">
-                    <p className="text-sm text-muted-foreground mb-2">
-                      {handout.sourceLine}
-                    </p>
-                    <p className="text-sm text-muted-foreground">
-                      {handout.standLine}
-                    </p>
-                  </CardContent>
-                </Card>
-              </>
-            ) : (
-              <Card className="border-border/60 bg-muted/20">
-                <CardContent className="p-6 flex items-center gap-3 text-muted-foreground">
-                  <Spinner className="size-5 text-sage-dark" />
-                  <p>Die Abschnitte dieser Textversion werden geladen.</p>
-                </CardContent>
-              </Card>
-            )}
-          </div>
-        </div>
-      </section>
+        <RelatedLinksEditorial
+          links={[
+            {
+              href: pageTopicHref,
+              title: `${pageTopicLabel} vertiefen`,
+              description:
+                "Zur vertiefenden Themenseite mit Kontext, Einordnung und weiterführenden Hinweisen.",
+            },
+            {
+              href: "/materialien",
+              title: "Weitere Materialien",
+              description:
+                "Weitere Handouts, PDFs und lesbare Textversionen nach Themenbereich durchsuchen.",
+            },
+            {
+              href: "/barrierefreiheit",
+              title: "Barrierefreiheit & Lesbarkeit",
+              description:
+                "Einordnung zur Lesbarkeit, Nutzung mit Assistenztechnologien und Grenzen bildbasierter PDFs.",
+            },
+          ]}
+        />
+      </EditorialLayout>
     </Layout>
   );
 }

--- a/client/src/sections/SelbstfuersorgeExercisesSection.tsx
+++ b/client/src/sections/SelbstfuersorgeExercisesSection.tsx
@@ -75,7 +75,7 @@ function AtemuebungCard() {
   };
 
   return (
-    <Card className="bg-gradient-to-br from-sage-lighter/30 to-sage-wash/20 border-sage-mid">
+    <Card className="border-border/60 bg-background shadow-none">
       <CardContent className="p-6">
         <div className="flex items-center gap-3 mb-4">
           <Wind className="w-6 h-6 text-sage-mid" />
@@ -137,43 +137,42 @@ function AtemuebungCard() {
 
 function StrategyIcon({
   icon,
+  className,
 }: {
   icon: "clock" | "heart" | "users" | "shield";
+  className?: string;
 }) {
-  if (icon === "clock") return <Clock className="w-5 h-5 text-white" />;
-  if (icon === "heart") return <Heart className="w-5 h-5 text-white" />;
-  if (icon === "users") return <Users className="w-5 h-5 text-white" />;
-  return <Shield className="w-5 h-5 text-white" />;
+  if (icon === "clock") return <Clock className={className} />;
+  if (icon === "heart") return <Heart className={className} />;
+  if (icon === "users") return <Users className={className} />;
+  return <Shield className={className} />;
 }
 
 function UebungAkkordeon({
   title,
   icon,
-  color,
   children,
 }: {
   title: string;
   icon: "clock" | "heart" | "users" | "shield";
-  color: string;
   children: React.ReactNode;
 }) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <Card className="border-border/50 overflow-hidden">
+    <div className="border-t" style={{ borderColor: "var(--rule-color)" }}>
       <button
         type="button"
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full p-5 flex items-center justify-between text-left hover:bg-muted/30 transition-colors"
+        className="flex w-full items-center justify-between gap-3 py-5 text-left transition-opacity hover:opacity-80"
         aria-expanded={isOpen}
         aria-label={`${title} ${isOpen ? "zuklappen" : "aufklappen"}`}
       >
         <div className="flex items-center gap-3">
-          <div
-            className={`w-10 h-10 rounded-lg ${color} flex items-center justify-center`}
-          >
-            <StrategyIcon icon={icon} />
-          </div>
+          <StrategyIcon
+            icon={icon}
+            className="h-4 w-4 text-[color:var(--accent-label)]"
+          />
           <span className="font-semibold text-foreground">{title}</span>
         </div>
         {isOpen ? (
@@ -182,128 +181,134 @@ function UebungAkkordeon({
           <ChevronDown className="w-5 h-5 text-muted-foreground" />
         )}
       </button>
-      {isOpen && (
-        <CardContent className="pt-0 pb-5 px-5">{children}</CardContent>
-      )}
-    </Card>
+      {isOpen && <div className="pb-5">{children}</div>}
+    </div>
   );
 }
 
 export function SelbstfuersorgeExercisesSection() {
+  const bodyStyle = {
+    fontSize: "var(--text-sm)",
+    lineHeight: "var(--lh-relaxed)",
+    color: "var(--fg-secondary)",
+  };
+
+  const titleStyle = {
+    fontSize: "var(--text-md)",
+    fontWeight: 600,
+    color: "var(--fg-primary)",
+  };
+
   return (
     <>
       <ContentSection
+        variant="editorial"
         title="Sofort-Übungen für akute Belastung"
-        icon={<Clock className="w-6 h-6 text-sage-mid" />}
         id="sofort-uebungen"
         preview="Atemübung, 5-4-3-2-1 Grounding und STOPP-Technik – jederzeit anwendbar."
       >
-        <p className="text-muted-foreground leading-relaxed mb-6">
+        <p className="mb-6" style={bodyStyle}>
           Diese Übungen können Sie jederzeit anwenden, wenn Sie merken, dass der
           Stress überhand nimmt:
         </p>
 
-        <div className="grid md:grid-cols-[7fr_5fr] gap-4 mb-6">
+        <div className="grid gap-6 md:grid-cols-[7fr_5fr]">
           <AtemuebungCard />
           <GroundingTimer />
         </div>
 
-        <Card className="border-border/50">
-          <CardContent className="p-5">
-            <h3 className="font-semibold text-foreground mb-3">
-              STOPP-Technik
-            </h3>
-            <p className="text-muted-foreground text-sm mb-4">
-              Wenn Sie merken, dass Sie in einen Strudel aus Sorgen oder Ärger
-              geraten:
-            </p>
-            <div className="grid sm:grid-cols-2 gap-3">
-              {[
-                { letter: "S", text: "Stopp – Innehalten" },
-                { letter: "T", text: "Tief durchatmen" },
-                { letter: "O", text: "Orientieren – Was passiert gerade?" },
-                { letter: "P", text: "Planen – Was ist jetzt hilfreich?" },
-                { letter: "P", text: "Praktizieren – Einen Schritt tun" },
-              ].map(item => (
-                <div
-                  key={`${item.letter}-${item.text}`}
-                  className="flex items-center gap-3"
-                >
-                  <span className="w-8 h-8 rounded-lg bg-terracotta/20 flex items-center justify-center font-bold text-terracotta-mid">
-                    {item.letter}
-                  </span>
-                  <span className="text-sm text-muted-foreground">
-                    {item.text}
-                  </span>
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+        <div
+          className="mt-8 border-t pt-5"
+          style={{ borderColor: "var(--rule-color)" }}
+        >
+          <h3 style={titleStyle}>STOPP-Technik</h3>
+          <p className="mt-3" style={bodyStyle}>
+            Wenn Sie merken, dass Sie in einen Strudel aus Sorgen oder Ärger
+            geraten:
+          </p>
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            {[
+              { letter: "S", text: "Stopp – Innehalten" },
+              { letter: "T", text: "Tief durchatmen" },
+              { letter: "O", text: "Orientieren – Was passiert gerade?" },
+              { letter: "P", text: "Planen – Was ist jetzt hilfreich?" },
+              { letter: "P", text: "Praktizieren – Einen Schritt tun" },
+            ].map(item => (
+              <div
+                key={`${item.letter}-${item.text}`}
+                className="flex items-start gap-3 border-t pt-3"
+                style={{ borderColor: "var(--rule-color)" }}
+              >
+                <span className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-full border border-border/60 text-xs font-semibold text-foreground">
+                  {item.letter}
+                </span>
+                <span style={bodyStyle}>{item.text}</span>
+              </div>
+            ))}
+          </div>
+        </div>
       </ContentSection>
 
       <ContentSection
+        variant="editorial"
         title="Langfristige Selbstfürsorge-Strategien"
-        icon={<Heart className="w-6 h-6 text-terracotta" />}
         id="langfristige-strategien"
         preview="Tägliche Mini-Auszeiten, Bewegung, soziale Kontakte und professionelle Unterstützung."
       >
-        <p className="text-muted-foreground leading-relaxed mb-6">
+        <p className="mb-6" style={bodyStyle}>
           Neben den Sofort-Übungen brauchen Sie auch langfristige Strategien, um
           Ihre Gesundheit zu erhalten:
         </p>
 
-        <div className="space-y-3">
+        <div>
           {longTermStrategies.map(strategy => (
             <UebungAkkordeon
               key={strategy.title}
               title={strategy.title}
               icon={strategy.icon}
-              color={strategy.colorClass}
             >
               <div className="space-y-4 pt-4">
-                <p className="text-muted-foreground text-sm">
-                  {strategy.intro}
-                </p>
+                <p style={bodyStyle}>{strategy.intro}</p>
 
                 {strategy.checklist && (
-                  <div className="grid sm:grid-cols-2 gap-2">
+                  <div className="grid gap-3 sm:grid-cols-2">
                     {strategy.checklist.map(item => (
-                      <div
-                        key={item}
-                        className="flex items-start gap-2 text-sm text-muted-foreground"
-                      >
-                        <CheckCircle2 className="w-4 h-4 flex-shrink-0 mt-0.5" />
-                        {item}
+                      <div key={item} className="flex items-start gap-2">
+                        <CheckCircle2 className="mt-0.5 h-4 w-4 flex-shrink-0 text-[color:var(--accent-label)]" />
+                        <span style={bodyStyle}>{item}</span>
                       </div>
                     ))}
                   </div>
                 )}
 
                 {strategy.noteTitle && strategy.noteText && (
-                  <Card className="bg-muted/30 border-transparent">
-                    <CardContent className="p-4">
-                      <p className="text-sm text-foreground">
-                        <strong>{strategy.noteTitle}</strong>{" "}
-                        {strategy.noteText}
-                      </p>
-                    </CardContent>
-                  </Card>
+                  <p
+                    className="border-l pl-4"
+                    style={{
+                      ...bodyStyle,
+                      borderColor: "var(--accent-label)",
+                    }}
+                  >
+                    <strong style={{ color: "var(--fg-primary)" }}>
+                      {strategy.noteTitle}
+                    </strong>{" "}
+                    {strategy.noteText}
+                  </p>
                 )}
 
                 {strategy.cards && (
-                  <div className="space-y-3">
+                  <div className="space-y-4">
                     {strategy.cards.map(card => (
-                      <Card key={card.title} className="border-border/30">
-                        <CardContent className="p-4">
-                          <h4 className="font-medium text-foreground mb-2">
-                            {card.title}
-                          </h4>
-                          <p className="text-sm text-muted-foreground">
-                            {card.text}
-                          </p>
-                        </CardContent>
-                      </Card>
+                      <article
+                        key={card.title}
+                        className="border-t pt-4"
+                        style={{ borderColor: "var(--rule-color)" }}
+                      >
+                        <h4 style={titleStyle}>{card.title}</h4>
+                        <p className="mt-2" style={bodyStyle}>
+                          {card.text}
+                        </p>
+                      </article>
                     ))}
                   </div>
                 )}

--- a/client/src/sections/SelbstfuersorgeRoleNotesSection.tsx
+++ b/client/src/sections/SelbstfuersorgeRoleNotesSection.tsx
@@ -1,5 +1,4 @@
 import { Heart, UserCircle, Users } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
 import ContentSection from "@/components/ContentSection";
 import { roleNotes } from "@/content/selbstfuersorge-page";
 
@@ -16,57 +15,46 @@ function RoleNoteIcon({
 }
 
 export function SelbstfuersorgeRoleNotesSection() {
+  const bodyStyle = {
+    fontSize: "var(--text-sm)",
+    lineHeight: "var(--lh-relaxed)",
+    color: "var(--fg-secondary)",
+  };
+
+  const titleStyle = {
+    fontSize: "var(--text-md)",
+    fontWeight: 600,
+    color: "var(--fg-primary)",
+  };
+
   return (
     <ContentSection
+      variant="editorial"
       title="Hinweise für Ihre Situation"
-      icon={<UserCircle className="w-6 h-6 text-slate-mid" />}
       id="ihre-situation"
       preview="Spezifische Hinweise für Partner/innen, Elternteile und erwachsene Kinder."
     >
-      <div className="space-y-4">
+      <div>
         {roleNotes.map(note => {
-          const cardClass =
-            note.tone === "terracotta"
-              ? "border-l-4 border-l-terracotta-mid bg-terracotta-wash"
-              : note.tone === "slate"
-                ? "border-l-4 border-l-slate-mid bg-slate-pale"
-                : "border-l-4 border-l-sage-mid bg-sage-pale";
-          const iconWrapperClass =
-            note.tone === "terracotta"
-              ? "bg-terracotta-lighter"
-              : note.tone === "slate"
-                ? "bg-slate-lighter"
-                : "bg-sage-lighter";
-          const iconClass =
-            note.tone === "terracotta"
-              ? "text-terracotta-mid"
-              : note.tone === "slate"
-                ? "text-slate-mid"
-                : "text-sage-mid";
-
           return (
-            <Card key={note.title} className={cardClass}>
-              <CardContent className="p-5">
-                <div className="flex items-start gap-3">
-                  <div
-                    className={`w-10 h-10 rounded-lg ${iconWrapperClass} flex items-center justify-center flex-shrink-0`}
-                  >
-                    <RoleNoteIcon
-                      icon={note.icon}
-                      className={`w-5 h-5 ${iconClass}`}
-                    />
-                  </div>
-                  <div>
-                    <h3 className="font-semibold text-foreground mb-2">
-                      {note.title}
-                    </h3>
-                    <p className="text-sm text-muted-foreground leading-relaxed">
-                      {note.text}
-                    </p>
-                  </div>
+            <article
+              key={note.title}
+              className="border-t pt-4"
+              style={{ borderColor: "var(--rule-color)" }}
+            >
+              <div className="flex items-start gap-3">
+                <RoleNoteIcon
+                  icon={note.icon}
+                  className="mt-0.5 h-5 w-5 flex-shrink-0 text-[color:var(--accent-label)]"
+                />
+                <div>
+                  <h3 style={titleStyle}>{note.title}</h3>
+                  <p className="mt-2" style={bodyStyle}>
+                    {note.text}
+                  </p>
                 </div>
-              </CardContent>
-            </Card>
+              </div>
+            </article>
           );
         })}
       </div>


### PR DESCRIPTION
## Summary
- convert the handout text page to the editorial reading pattern with calmer meta/link treatment
- reduce card overhang in handout sections and self-care reading flows while keeping interactive exercises intact
- keep PDF actions functional and preserve the existing test expectations around text versions

## Verification
- pnpm lint
- pnpm check
- pnpm test
- pnpm build