### PR TITLE
Editorialize shell and meta elements

### DIFF
--- a/client/src/components/Layout.tsx
+++ b/client/src/components/Layout.tsx
@@ -49,18 +49,20 @@ export default function Layout({ children }: LayoutProps) {
 
       <aside
         aria-label="Notfallhinweis"
-        className="border-b border-border/40 bg-sage-wash/40"
+        className="border-b border-border/50 bg-background"
       >
-        <div className="container py-1.5 text-sm md:text-xs text-muted-foreground flex flex-wrap items-center gap-x-3 gap-y-1">
-          <span className="font-medium text-foreground">
-            Notfallkontakte: Schweiz (Kanton Zürich)
+        <div className="container flex flex-wrap items-center gap-x-3 gap-y-1 py-2 text-[13px] text-muted-foreground">
+          <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]">
+            Notfallkontakte
           </span>
           <span className="hidden sm:inline">•</span>
+          <span className="text-foreground/90">Schweiz · Kanton Zürich</span>
+          <span className="hidden md:inline">•</span>
           <span>Für andere Regionen bitte lokale Notrufnummern nutzen.</span>
           {showInlineSoforthilfeLink && (
             <AppLink
               href="/soforthilfe"
-              className="sm:hidden inline-flex min-h-9 items-center rounded-full border border-alert/25 bg-alert/10 px-3 py-1 text-sm font-medium text-alert transition-colors hover:bg-alert/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-alert/40 focus-visible:ring-offset-2"
+              className="sm:hidden inline-flex min-h-9 items-center rounded-full border border-border/70 bg-background px-3 py-1 text-sm font-medium text-[color:var(--accent-primary)] transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)]/30 focus-visible:ring-offset-2"
             >
               Zur Soforthilfe
             </AppLink>
@@ -77,18 +79,21 @@ export default function Layout({ children }: LayoutProps) {
       </main>
 
       {/* Footer */}
-      <footer className="bg-navy text-white border-t border-navy-light/20 mt-auto">
+      <footer
+        className="mt-auto border-t bg-background"
+        style={{ borderColor: "var(--rule-color)" }}
+      >
         <div className="container py-8 md:py-12">
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-12">
             {/* Brand + Absender */}
             <div className="lg:col-span-1">
               <AppLink href="/" className="flex items-center gap-2 mb-4">
-                <BrandMark variant="dark" />
-                <span className="font-medium text-base text-white">
+                <BrandMark variant="light" />
+                <span className="font-medium text-base text-foreground">
                   Borderline · Hilfe für Angehörige
                 </span>
               </AppLink>
-              <p className="text-white/90 text-sm leading-relaxed">
+              <p className="text-muted-foreground text-sm leading-relaxed">
                 Psychoedukatives Informationsangebot für Angehörige von Menschen
                 mit Borderline-Muster.
               </p>
@@ -96,15 +101,15 @@ export default function Layout({ children }: LayoutProps) {
 
             {/* Navigation */}
             <div>
-              <h3 className="font-semibold text-white mb-4 text-base">
+              <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]">
                 Themen
-              </h3>
+              </p>
               <ul className="space-y-1">
                 {navItems.map(item => (
                   <li key={item.href}>
                     <AppLink
                       href={item.href}
-                      className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
+                      className="inline-flex items-center py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
                     >
                       {item.label}
                     </AppLink>
@@ -115,15 +120,15 @@ export default function Layout({ children }: LayoutProps) {
 
             {/* Resources */}
             <div>
-              <h3 className="font-semibold text-white mb-4 text-base">
+              <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]">
                 Ressourcen
-              </h3>
+              </p>
               <ul className="space-y-1">
                 {ressourcenItems.map(item => (
                   <li key={item.href}>
                     <AppLink
                       href={item.href}
-                      className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center py-1.5"
+                      className="inline-flex items-center py-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
                     >
                       {item.label}
                     </AppLink>
@@ -134,10 +139,10 @@ export default function Layout({ children }: LayoutProps) {
 
             {/* Hinweis */}
             <div>
-              <h3 className="font-semibold text-white mb-4 text-base">
+              <p className="mb-4 text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]">
                 Hinweis
-              </h3>
-              <p className="text-white/90 text-sm leading-relaxed">
+              </p>
+              <p className="text-sm leading-relaxed text-muted-foreground">
                 Diese Website ersetzt keine professionelle Beratung oder
                 Therapie. Bei akuten Krisen wenden Sie sich bitte an die
                 Notfallnummern.
@@ -146,55 +151,61 @@ export default function Layout({ children }: LayoutProps) {
           </div>
 
           {/* Absender-Einordnung */}
-          <div className="border-t border-white/10 mt-8 pt-8">
-            <p className="text-sm text-white leading-relaxed">
+          <div
+            className="mt-8 border-t pt-8"
+            style={{ borderColor: "var(--rule-color)" }}
+          >
+            <p className="text-sm leading-relaxed text-foreground">
               Herausgegeben von der Fachstelle Angehörigenarbeit der
               Psychiatrischen Universitätsklinik Zürich (PUK).
             </p>
-            <p className="text-xs text-white/90 mt-1 leading-relaxed">
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
               Redaktionell eigenständiges Informationsangebot der Fachstelle
               Angehörigenarbeit innerhalb der PUK Zürich.
             </p>
           </div>
 
-          <div className="border-t border-white/10 mt-6 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
-            <p className="text-white/90 text-sm">
+          <div
+            className="mt-6 flex flex-col items-start justify-between gap-4 border-t pt-6 sm:flex-row sm:items-center"
+            style={{ borderColor: "var(--rule-color)" }}
+          >
+            <p className="text-sm text-muted-foreground">
               © 2026 Borderline · Hilfe für Angehörige. Alle Rechte vorbehalten.
             </p>
             <div className="flex flex-wrap gap-x-4 gap-y-1">
               <AppLink
                 href="/fachstelle"
-                className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="inline-flex min-h-[44px] items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 Fachstelle
               </AppLink>
               <AppLink
                 href="/ueber-uns"
-                className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="inline-flex min-h-[44px] items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 Über uns
               </AppLink>
               <AppLink
                 href="/impressum"
-                className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="inline-flex min-h-[44px] items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 Impressum
               </AppLink>
               <AppLink
                 href="/datenschutz"
-                className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="inline-flex min-h-[44px] items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 Datenschutz
               </AppLink>
               <AppLink
                 href="/barrierefreiheit"
-                className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="inline-flex min-h-[44px] items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 Barrierefreiheit
               </AppLink>
               <AppLink
                 href="/feedback"
-                className="text-white/90 hover:text-white text-sm transition-colors inline-flex items-center min-h-[44px]"
+                className="inline-flex min-h-[44px] items-center text-sm text-muted-foreground transition-colors hover:text-foreground"
               >
                 Feedback
               </AppLink>

--- a/client/src/components/ReviewBadge.tsx
+++ b/client/src/components/ReviewBadge.tsx
@@ -23,10 +23,11 @@ export default function ReviewBadge({ path }: { path: string }) {
 
   return (
     <aside
-      className="mt-4 rounded-xl border border-border/60 bg-white/70 px-4 py-3 text-sm text-muted-foreground shadow-sm"
+      className="mt-6 border-t pt-4 text-sm text-muted-foreground"
       aria-label="Review-Informationen"
+      style={{ borderColor: "var(--rule-color)" }}
     >
-      <p className="mb-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/90">
+      <p className="mb-3 text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]">
         Review & Governance
       </p>
 

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -331,7 +331,7 @@ export function TableOfContents() {
 
   // Aktiver Eintrag Styling
   const activeClass =
-    "bg-sage-wash text-sage-darker font-semibold border-l-2 border-l-sage-dark";
+    "border-l border-[color:var(--rule-color-strong)] bg-background text-foreground font-semibold";
   const inactiveClass =
     "text-muted-foreground hover:text-foreground hover:bg-muted/60";
 
@@ -341,7 +341,7 @@ export function TableOfContents() {
       {floatingMode === "content" && showFloatingButton && (
         <motion.button
           onClick={() => setIsOpen(true)}
-          className="min-[1800px]:hidden fixed right-4 bottom-[calc(7.5rem+env(safe-area-inset-bottom,0px))] z-40 h-11 px-4 rounded-full bg-background border border-border shadow-lg flex items-center gap-2 text-sm font-medium text-foreground"
+          className="min-[1800px]:hidden fixed right-4 bottom-[calc(7.5rem+env(safe-area-inset-bottom,0px))] z-40 flex h-11 items-center gap-2 rounded-full border border-border/70 bg-background/95 px-4 text-sm font-medium text-foreground shadow-[0_18px_40px_-34px_rgba(15,23,42,0.55)] backdrop-blur-sm"
           aria-label="Inhaltsverzeichnis öffnen"
         >
           <List className="w-4 h-4" />
@@ -356,7 +356,7 @@ export function TableOfContents() {
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
-            className="min-[1800px]:hidden fixed inset-0 bg-black/30 z-40"
+            className="min-[1800px]:hidden fixed inset-0 z-40 bg-black/20"
             onClick={() => setIsOpen(false)}
           />
         )}
@@ -370,7 +370,7 @@ export function TableOfContents() {
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="min-[1800px]:hidden fixed left-0 right-0 bottom-0 max-h-[70vh] bg-background z-50 rounded-t-2xl shadow-2xl overflow-hidden flex flex-col pb-[env(safe-area-inset-bottom,0px)]"
+            className="min-[1800px]:hidden fixed bottom-0 left-0 right-0 z-50 flex max-h-[70vh] flex-col overflow-hidden rounded-t-[1.75rem] border-t border-border/60 bg-background shadow-[0_-24px_48px_-36px_rgba(15,23,42,0.45)] pb-[env(safe-area-inset-bottom,0px)]"
           >
             {/* Drawer Handle */}
             <div className="flex justify-center pt-3 pb-1">
@@ -378,9 +378,9 @@ export function TableOfContents() {
             </div>
 
             {/* Drawer Header */}
-            <div className="flex items-center justify-between px-5 py-3 border-b border-border">
+            <div className="flex items-center justify-between border-b border-border/60 px-5 py-3">
               <span
-                className="font-semibold text-foreground text-base"
+                className="text-base font-semibold text-foreground"
                 role="heading"
                 aria-level={2}
               >
@@ -422,18 +422,15 @@ export function TableOfContents() {
       {/* ─── Desktop: Sticky Sidebar in der linken Gutter-Zone ─── */}
       {/* left = 50vw - halbe Content-Breite (304px) - Abstand (2rem) - Sidebar-Breite (15rem) */}
       <div className="hidden min-[1800px]:block fixed left-[calc(50vw-304px-17rem)] top-[calc(8rem+env(safe-area-inset-top,0px))] z-30 max-h-[calc(100vh-9.5rem)] w-60">
-        <div className="flex max-h-full flex-col overflow-hidden rounded-[1.4rem] border border-border/60 bg-background/92 shadow-[0_28px_52px_-36px_rgba(15,23,42,0.45)] backdrop-blur-md">
-          <div className="px-4 pt-4 pb-2">
-            <div className="flex items-center gap-2.5 rounded-full border border-sage-light/60 bg-sage-wash/80 px-3 py-2">
-              <span className="h-2 w-2 rounded-full bg-sage-dark" />
-              <span
-                className="text-sm font-semibold text-sage-darker"
-                role="heading"
-                aria-level={2}
-              >
-                Auf dieser Seite
-              </span>
-            </div>
+        <div className="flex max-h-full flex-col overflow-hidden rounded-[1.4rem] border border-border/60 bg-background/92 shadow-[0_28px_52px_-40px_rgba(15,23,42,0.28)] backdrop-blur-md">
+          <div className="border-b border-border/60 px-4 pt-4 pb-3">
+            <span
+              className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]"
+              role="heading"
+              aria-level={2}
+            >
+              Auf dieser Seite
+            </span>
           </div>
           <nav className="overflow-y-auto overscroll-contain px-2 pb-3 flex-1">
             <ul className="space-y-0.5">
@@ -444,7 +441,7 @@ export function TableOfContents() {
                     ref={activeId === id ? activeNavRef : null}
                     onClick={() => scrollToHeading(id)}
                     aria-label={`Zum Abschnitt: ${text}`}
-                    className={`w-full text-left px-3 py-2 rounded-xl text-xs transition-colors line-clamp-2 focus-visible:ring-2 focus-visible:ring-sage-dark/40 focus-visible:ring-offset-1 ${
+                    className={`w-full line-clamp-2 rounded-lg px-3 py-2 text-left text-xs transition-colors focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)]/30 focus-visible:ring-offset-1 ${
                       level === 3 ? "pl-5" : ""
                     } ${activeId === id ? activeClass : inactiveClass}`}
                   >

--- a/client/src/components/layout/ScrollToTopButton.tsx
+++ b/client/src/components/layout/ScrollToTopButton.tsx
@@ -29,7 +29,7 @@ export function ScrollToTopButton() {
           behavior: "smooth",
         })
       }
-      className={`fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy hover:bg-navy-light text-white shadow-lg items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
+      className={`fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-40 flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-background/95 text-[color:var(--accent-primary)] shadow-[0_18px_40px_-34px_rgba(15,23,42,0.55)] backdrop-blur-sm transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)]/30 focus-visible:ring-offset-2 sm:h-12 sm:w-12 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
       aria-label="Nach oben scrollen"
     >
       <ChevronUp className="w-6 h-6" />

--- a/client/src/pages/NotFound.tsx
+++ b/client/src/pages/NotFound.tsx
@@ -1,17 +1,9 @@
 import SEO from "@/components/SEO";
 import Layout from "@/components/Layout";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { useLocation } from "wouter";
+import AppLink from "@/components/AppLink";
 import { AlertCircle, Home } from "@/icons/root-icons";
 
 export default function NotFound() {
-  const [, setLocation] = useLocation();
-
-  const handleGoHome = () => {
-    setLocation("/");
-  };
-
   return (
     <Layout>
       <SEO
@@ -20,39 +12,49 @@ export default function NotFound() {
         path="/404"
         robots="noindex, nofollow"
       />
-      <div className="min-h-[70vh] w-full flex items-center justify-center">
-        <Card className="w-full max-w-lg mx-4 shadow-lg border-0 bg-white/80 backdrop-blur-sm">
-          <CardContent className="pt-8 pb-8 text-center">
-            <div className="flex justify-center mb-6">
-              <div className="relative">
-                <div className="absolute inset-0 bg-sage-lighter rounded-full animate-pulse" />
-                <AlertCircle className="relative h-16 w-16 text-sage-mid" />
-              </div>
+      <div className="container flex min-h-[70vh] items-center justify-center py-16">
+        <section
+          className="w-full max-w-[38rem] border-t pt-8"
+          style={{ borderColor: "var(--rule-color)" }}
+        >
+          <div className="flex justify-center sm:justify-start">
+            <div className="flex h-16 w-16 items-center justify-center rounded-full border border-border/60 bg-background">
+              <AlertCircle className="h-8 w-8 text-[color:var(--accent-primary)]" />
             </div>
+          </div>
 
-            <h1 className="text-4xl font-bold text-foreground mb-2">404</h1>
+          <p className="mt-6 text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]">
+            404
+          </p>
 
-            <h2 className="text-xl font-normal text-foreground mb-4">
-              Seite nicht gefunden
-            </h2>
+          <h1
+            className="mt-3 font-display text-4xl text-foreground sm:text-5xl"
+            style={{ fontWeight: "var(--weight-display)" }}
+          >
+            Seite nicht gefunden
+          </h1>
 
-            <p className="text-muted-foreground mb-8 leading-relaxed">
-              Die gesuchte Seite existiert leider nicht.
-              <br />
-              Sie wurde möglicherweise verschoben oder gelöscht.
-            </p>
+          <p className="mt-4 max-w-[32rem] text-base leading-relaxed text-muted-foreground sm:text-lg">
+            Die gesuchte Seite existiert leider nicht. Sie wurde möglicherweise
+            verschoben oder gelöscht.
+          </p>
 
-            <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Button
-                onClick={handleGoHome}
-                className="bg-sage-mid hover:bg-sage-dark text-white px-6 py-2.5 rounded-lg transition-all duration-400 shadow-md hover:shadow-lg"
-              >
-                <Home className="w-4 h-4 mr-2" />
-                Zur Startseite
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+          <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <AppLink
+              href="/"
+              className="inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-border/70 bg-background px-5 py-2.5 text-sm font-medium text-foreground transition-colors hover:bg-muted/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)]/30 focus-visible:ring-offset-2"
+            >
+              <Home className="h-4 w-4" />
+              Zur Startseite
+            </AppLink>
+            <AppLink
+              href="/wegweiser"
+              className="editorial-link inline-flex min-h-11 items-center justify-center"
+            >
+              Zum Wegweiser
+            </AppLink>
+          </div>
+        </section>
       </div>
     </Layout>
   );


### PR DESCRIPTION
## Summary
- calm the shell layer around the content with a quieter footer and flatter emergency hint
- lighten floating controls and table-of-contents chrome while keeping behavior intact
- move review metadata and the 404 page onto the same editorial pattern

## Testing
- pnpm lint
- pnpm check
- pnpm test
- pnpm build