### PR TITLE
[codex] Lock editorial shared components

### DIFF
--- a/client/src/__tests__/evidence-note.test.tsx
+++ b/client/src/__tests__/evidence-note.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import EvidenceNote from "@/components/EvidenceNote";
 
 describe("EvidenceNote", () => {
-  it("groups scientific and service sources and renders the review date", () => {
+  it("renders the editorial evidence note by default", () => {
     render(
       <EvidenceNote
         title="Quellenhinweis"
@@ -24,7 +24,8 @@ describe("EvidenceNote", () => {
       />
     );
 
-    expect(screen.getByText("Wissenschaftliche Evidenz")).toBeInTheDocument();
+    expect(screen.getByText("Quellenhinweis")).toBeInTheDocument();
+    expect(screen.getByText("APA Practice Guideline")).toBeInTheDocument();
     expect(screen.getByText("Versorgung / Hilfe")).toBeInTheDocument();
     expect(
       screen.getByText(/Zuletzt redaktionell geprüft: 24\.03\.2026/)

--- a/client/src/components/ContentSection.tsx
+++ b/client/src/components/ContentSection.tsx
@@ -5,8 +5,6 @@ import { ChevronDown } from "lucide-react";
 interface ContentSectionProps {
   /** Überschrift des Abschnitts */
   title: string;
-  /** Icon-Komponente (Lucide). Im editorial-Variante ignoriert. */
-  icon?: React.ReactNode;
   /** HTML-ID für Ankerlinks und Inhaltsverzeichnis */
   id?: string;
   /** Ob der Abschnitt initial geöffnet ist */
@@ -15,13 +13,8 @@ interface ContentSectionProps {
   children: React.ReactNode;
   /** Kurze Vorschau, die im geschlossenen Zustand sichtbar bleibt */
   preview?: React.ReactNode;
-  /**
-   * "card" (Default): bestehendes Sanctuary-Calm-Layout (weisser Karten-BG,
-   * sage-Akzent-Border, rounded-md, Icon im Header).
-   * "editorial": Phase-4-Editorial-Pattern — kein Icon, kein Karten-BG,
-   * hairline-Trenner zwischen Items, Display-Serif-Title, kantiger Radius.
-   */
-  variant?: "card" | "editorial";
+  /** Kompatibilitäts-Prop für bestehende Callsites; nur editorial wird unterstützt. */
+  variant?: "editorial";
 }
 
 /**
@@ -31,14 +24,12 @@ interface ContentSectionProps {
  */
 export default function ContentSection({
   title,
-  icon,
   id,
   defaultOpen = false,
   children,
   preview,
-  variant = "card",
+  variant: _variant = "editorial",
 }: ContentSectionProps) {
-  const isEditorial = variant === "editorial";
   const [isOpen, setIsOpen] = useState(defaultOpen);
   const sectionRef = useRef<HTMLDivElement>(null);
   const pendingScrollRef = useRef(false);
@@ -90,104 +81,52 @@ export default function ContentSection({
     }
   }, [isOpen]);
 
-  if (isEditorial) {
-    return (
-      <div
-        ref={sectionRef}
-        id={id}
-        className="border-t"
-        style={{ borderColor: "var(--rule-color)" }}
-      >
-        <button
-          type="button"
-          onClick={() => setIsOpen(open => !open)}
-          className="group flex w-full items-center justify-between gap-3 py-5 text-left transition-opacity hover:opacity-80 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]"
-          aria-expanded={isOpen}
-          aria-controls={id ? `section-content-${id}` : undefined}
-          aria-label={`Abschnitt ${title} ${isOpen ? "zuklappen" : "aufklappen"}`}
-        >
-          <h2
-            className="font-display"
-            style={{
-              fontSize: "var(--text-xl)",
-              lineHeight: "var(--lh-snug)",
-              color: "var(--fg-primary)",
-              fontWeight: "var(--weight-display)",
-            }}
-          >
-            {title}
-          </h2>
-          <ChevronDown
-            className={`h-5 w-5 flex-shrink-0 transition-transform duration-200 ${
-              isOpen ? "rotate-180" : ""
-            }`}
-            style={{ color: "var(--fg-tertiary)" }}
-            aria-hidden="true"
-          />
-        </button>
-        {!isOpen && preview && (
-          <p
-            className="-mt-2 mb-5 line-clamp-2"
-            style={{
-              fontSize: "var(--text-sm)",
-              lineHeight: "var(--lh-relaxed)",
-              color: "var(--fg-tertiary)",
-            }}
-          >
-            {preview}
-          </p>
-        )}
-        <AnimatePresence initial={false}>
-          {isOpen && (
-            <motion.div
-              initial={{ height: 0, opacity: 0 }}
-              animate={{ height: "auto", opacity: 1 }}
-              exit={{ height: 0, opacity: 0 }}
-              transition={{ duration: 0.25, ease: "easeOut" }}
-              className="overflow-hidden"
-            >
-              <div
-                id={id ? `section-content-${id}` : undefined}
-                className="pb-6"
-              >
-                {children}
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </div>
-    );
-  }
-
   return (
-    <div ref={sectionRef} className="mb-6" id={id}>
+    <div
+      ref={sectionRef}
+      id={id}
+      className="border-t"
+      style={{ borderColor: "var(--rule-color)" }}
+    >
       <button
         type="button"
         onClick={() => setIsOpen(open => !open)}
-        className="w-full text-left group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 focus-visible:ring-offset-2 rounded-xl active:bg-sand-muted"
+        className="group flex w-full items-center justify-between gap-3 py-5 text-left transition-opacity hover:opacity-80 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]"
         aria-expanded={isOpen}
         aria-controls={id ? `section-content-${id}` : undefined}
         aria-label={`Abschnitt ${title} ${isOpen ? "zuklappen" : "aufklappen"}`}
       >
-        <div className="flex items-center justify-between gap-3 p-4 rounded-md bg-white hover:bg-sage-wash/50 active:bg-sage-wash/50 border border-border border-l-4 border-l-sage-dark transition-colors">
-          <div className="flex items-center gap-3 min-w-0">
-            {icon}
-            <h2 className="text-xl md:text-2xl font-normal text-foreground">
-              {title}
-            </h2>
-          </div>
-          <ChevronDown
-            className={`w-5 h-5 text-muted-foreground flex-shrink-0 transition-transform duration-200 ${
-              isOpen ? "rotate-180" : ""
-            }`}
-          />
-        </div>
-        {!isOpen && preview && (
-          <p className="text-sm text-muted-foreground mt-2 px-4 line-clamp-2">
-            {preview}
-          </p>
-        )}
+        <h2
+          className="font-display"
+          style={{
+            fontSize: "var(--text-xl)",
+            lineHeight: "var(--lh-snug)",
+            color: "var(--fg-primary)",
+            fontWeight: "var(--weight-display)",
+          }}
+        >
+          {title}
+        </h2>
+        <ChevronDown
+          className={`h-5 w-5 flex-shrink-0 transition-transform duration-200 ${
+            isOpen ? "rotate-180" : ""
+          }`}
+          style={{ color: "var(--fg-tertiary)" }}
+          aria-hidden="true"
+        />
       </button>
+      {!isOpen && preview && (
+        <p
+          className="-mt-2 mb-5 line-clamp-2"
+          style={{
+            fontSize: "var(--text-sm)",
+            lineHeight: "var(--lh-relaxed)",
+            color: "var(--fg-tertiary)",
+          }}
+        >
+          {preview}
+        </p>
+      )}
 
       <AnimatePresence initial={false}>
         {isOpen && (
@@ -198,10 +137,7 @@ export default function ContentSection({
             transition={{ duration: 0.25, ease: "easeOut" }}
             className="overflow-hidden"
           >
-            <div
-              id={id ? `section-content-${id}` : undefined}
-              className="pt-5 px-1 text-sm leading-relaxed"
-            >
+            <div id={id ? `section-content-${id}` : undefined} className="pb-6">
               {children}
             </div>
           </motion.div>

--- a/client/src/components/EvidenceNote.tsx
+++ b/client/src/components/EvidenceNote.tsx
@@ -1,4 +1,3 @@
-import { FileText } from "lucide-react";
 import type { EvidenceSource } from "@/domain/content-types";
 
 interface EvidenceNoteProps {
@@ -7,12 +6,8 @@ interface EvidenceNoteProps {
   sources: EvidenceSource[];
   reviewDate?: string;
   className?: string;
-  /**
-   * "card" (Default): bestehende Box mit muted-BG und FileText-Icon.
-   * "editorial": Phase-4-Editorial-Pattern — Hairline oben/unten, Fliesstext-
-   * Stil, kein Karten-Hintergrund, kein Icon, fg-tertiary für Quellen.
-   */
-  variant?: "card" | "editorial";
+  /** Kompatibilitäts-Prop für bestehende Callsites; nur editorial wird unterstützt. */
+  variant?: "editorial";
 }
 
 export default function EvidenceNote({
@@ -21,7 +16,7 @@ export default function EvidenceNote({
   sources,
   reviewDate,
   className = "",
-  variant = "card",
+  variant: _variant = "editorial",
 }: EvidenceNoteProps) {
   const scientificSources = sources.filter(
     source => source.type !== "versorgung"
@@ -31,29 +26,16 @@ export default function EvidenceNote({
   const renderSources = (items: EvidenceSource[]) => (
     <ul
       className="mt-2 space-y-1"
-      style={
-        variant === "editorial"
-          ? { fontSize: "var(--text-sm)", color: "var(--fg-tertiary)" }
-          : undefined
-      }
+      style={{ fontSize: "var(--text-sm)", color: "var(--fg-tertiary)" }}
     >
       {items.map(source => (
-        <li
-          key={source.label}
-          className={
-            variant === "editorial" ? "" : "text-xs text-muted-foreground"
-          }
-        >
+        <li key={source.label}>
           {source.href ? (
             <a
               href={source.href}
               target="_blank"
               rel="noopener noreferrer"
-              className={
-                variant === "editorial"
-                  ? "editorial-link"
-                  : "underline decoration-dotted underline-offset-2 hover:text-foreground"
-              }
+              className="editorial-link"
             >
               {source.label}
             </a>
@@ -66,105 +48,63 @@ export default function EvidenceNote({
     </ul>
   );
 
-  if (variant === "editorial") {
-    return (
-      <aside
-        className={`mt-8 border-t border-b py-5 ${className}`.trim()}
-        style={{ borderColor: "var(--rule-color)" }}
-        aria-label={title}
-      >
-        <p
-          className="uppercase"
-          style={{
-            fontSize: "var(--text-xs)",
-            letterSpacing: "var(--tracking-caps)",
-            color: "var(--accent-label)",
-            fontWeight: 500,
-          }}
-        >
-          {title}
-        </p>
-        {definition && (
-          <p
-            className="mt-2"
-            style={{
-              fontSize: "var(--text-sm)",
-              lineHeight: "var(--lh-relaxed)",
-              color: "var(--fg-secondary)",
-            }}
-          >
-            {definition}
-          </p>
-        )}
-        {scientificSources.length > 0 && renderSources(scientificSources)}
-        {serviceSources.length > 0 && (
-          <>
-            <p
-              className="mt-3 uppercase"
-              style={{
-                fontSize: "var(--text-xs)",
-                letterSpacing: "var(--tracking-caps)",
-                color: "var(--accent-label)",
-                fontWeight: 500,
-              }}
-            >
-              Versorgung / Hilfe
-            </p>
-            {renderSources(serviceSources)}
-          </>
-        )}
-        {reviewDate && (
-          <p
-            className="mt-3"
-            style={{
-              fontSize: "var(--text-xs)",
-              color: "var(--fg-tertiary)",
-            }}
-          >
-            Zuletzt redaktionell geprüft: {reviewDate}
-          </p>
-        )}
-      </aside>
-    );
-  }
-
   return (
     <aside
-      className={`rounded-lg border border-border/60 bg-muted/20 p-4 ${className}`.trim()}
+      className={`mt-8 border-t border-b py-5 ${className}`.trim()}
+      style={{ borderColor: "var(--rule-color)" }}
       aria-label={title}
     >
-      <div className="flex items-start gap-2">
-        <FileText className="mt-0.5 h-4 w-4 text-muted-foreground" />
-        <div className="min-w-0">
-          <p className="text-sm font-semibold text-foreground">{title}</p>
-          {definition && (
-            <p className="mt-1 text-xs text-muted-foreground">{definition}</p>
-          )}
-          {scientificSources.length > 0 && (
-            <div>
-              {serviceSources.length > 0 && (
-                <p className="mt-2 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                  Wissenschaftliche Evidenz
-                </p>
-              )}
-              {renderSources(scientificSources)}
-            </div>
-          )}
-          {serviceSources.length > 0 && (
-            <div>
-              <p className="mt-3 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
-                Versorgung / Hilfe
-              </p>
-              {renderSources(serviceSources)}
-            </div>
-          )}
-          {reviewDate && (
-            <p className="mt-3 text-[11px] text-muted-foreground">
-              Zuletzt redaktionell geprüft: {reviewDate}
-            </p>
-          )}
-        </div>
-      </div>
+      <p
+        className="uppercase"
+        style={{
+          fontSize: "var(--text-xs)",
+          letterSpacing: "var(--tracking-caps)",
+          color: "var(--accent-label)",
+          fontWeight: 500,
+        }}
+      >
+        {title}
+      </p>
+      {definition && (
+        <p
+          className="mt-2"
+          style={{
+            fontSize: "var(--text-sm)",
+            lineHeight: "var(--lh-relaxed)",
+            color: "var(--fg-secondary)",
+          }}
+        >
+          {definition}
+        </p>
+      )}
+      {scientificSources.length > 0 && renderSources(scientificSources)}
+      {serviceSources.length > 0 && (
+        <>
+          <p
+            className="mt-3 uppercase"
+            style={{
+              fontSize: "var(--text-xs)",
+              letterSpacing: "var(--tracking-caps)",
+              color: "var(--accent-label)",
+              fontWeight: 500,
+            }}
+          >
+            Versorgung / Hilfe
+          </p>
+          {renderSources(serviceSources)}
+        </>
+      )}
+      {reviewDate && (
+        <p
+          className="mt-3"
+          style={{
+            fontSize: "var(--text-xs)",
+            color: "var(--fg-tertiary)",
+          }}
+        >
+          Zuletzt redaktionell geprüft: {reviewDate}
+        </p>
+      )}
     </aside>
   );
 }

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -1,59 +1,10 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 import { useScrollLock } from "@/hooks/useScrollLock";
-import {
-  ChevronUp,
-  ChevronRight,
-  Home,
-  List,
-  X,
-  ArrowLeft,
-} from "lucide-react";
+import { ChevronRight, Home, List, X, ArrowLeft } from "lucide-react";
 import { Link, useLocation } from "wouter";
 import { motion, AnimatePresence } from "framer-motion";
 import { getMobileFloatingMode } from "@/domain/floating-ui";
-
-// Zurück-nach-oben-Button
-export function ScrollToTopButton() {
-  const [visible, setVisible] = useState(false);
-  const [location] = useLocation();
-  const floatingMode = getMobileFloatingMode(location);
-  const hideOnMobile = floatingMode !== "default";
-
-  useEffect(() => {
-    const toggleVisibility = () => {
-      setVisible(window.scrollY > 400);
-    };
-
-    window.addEventListener("scroll", toggleVisibility);
-    return () => window.removeEventListener("scroll", toggleVisibility);
-  }, []);
-
-  const scrollToTop = () => {
-    window.scrollTo({
-      top: 0,
-      behavior: "smooth",
-    });
-  };
-
-  return (
-    <AnimatePresence>
-      {visible && (
-        <motion.button
-          initial={{ opacity: 0, scale: 0.8, y: 20 }}
-          animate={{ opacity: 1, scale: 1, y: 0 }}
-          exit={{ opacity: 0, scale: 0.8, y: 20 }}
-          transition={{ duration: 0.4, ease: "easeOut" }}
-          onClick={scrollToTop}
-          className={`fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-40 w-11 h-11 sm:w-12 sm:h-12 rounded-full bg-navy hover:bg-navy-light text-white shadow-lg items-center justify-center transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
-          aria-label="Nach oben scrollen"
-        >
-          <ChevronUp className="w-6 h-6" />
-        </motion.button>
-      )}
-    </AnimatePresence>
-  );
-}
 
 // Breadcrumb-Navigation mit Zurück-Pfeil und kontextbezogener Hierarchie
 const pageNames: Record<string, string> = {

--- a/client/src/sections/VerstehenSupportSections.tsx
+++ b/client/src/sections/VerstehenSupportSections.tsx
@@ -56,6 +56,7 @@ export function VerstehenRelationshipSection() {
         </EditorialPullQuote>
       </div>
       <EvidenceNote
+        variant="editorial"
         title="Quellen zu Beziehungsmustern und Validierung"
         definition="Die beschriebenen Muster sind klinisch gut belegt, treten aber individuell unterschiedlich stark auf und erklären Verhalten nicht vollständig."
         reviewDate="24.03.2026"


### PR DESCRIPTION
## Summary
- remove the unused legacy `card` branches from shared editorial primitives
- drop the duplicate old `ScrollToTopButton` implementation from `UXEnhancements`
- make the remaining implicit `EvidenceNote` callsite explicit and update the regression test

## Why
The active product surfaces now consistently use the editorial variants. This PR locks that direction into the shared component layer so the legacy card path does not quietly drift back into new pages.

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
