### PR TITLE
[codex] Editorialize interactive learning modules

### DIFF
--- a/client/src/components/interactive/KommunikationsUebung.tsx
+++ b/client/src/components/interactive/KommunikationsUebung.tsx
@@ -1,6 +1,5 @@
 import { useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import {
   CheckCircle2,
@@ -278,39 +277,24 @@ const TECHNIQUE_META: Record<
   Technique,
   {
     label: string;
-    accentTextClass: string;
-    surfaceClass: string;
-    badgeClass: string;
-    noteBorderClass: string;
-    icon: React.ReactNode;
+    tintVar: string;
+    icon: React.ElementType;
   }
 > = {
   SET: {
     label: "SET-Kommunikation",
-    accentTextClass: "text-sage-dark",
-    surfaceClass: "bg-sage-wash",
-    badgeClass: "bg-white/70 text-sage-dark",
-    noteBorderClass:
-      "border-[color-mix(in_oklch,var(--color-sage-dark),transparent_70%)]",
-    icon: <Heart className="w-4 h-4" />,
+    tintVar: "--color-sage-dark",
+    icon: Heart,
   },
   DEAR: {
     label: "DEAR MAN",
-    accentTextClass: "text-sand-mid",
-    surfaceClass: "bg-sand-muted",
-    badgeClass: "bg-white/70 text-sand-mid",
-    noteBorderClass:
-      "border-[color-mix(in_oklch,var(--color-sand-mid),transparent_70%)]",
-    icon: <Scale className="w-4 h-4" />,
+    tintVar: "--color-sand-mid",
+    icon: Scale,
   },
   Validierung: {
     label: "Validierung",
-    accentTextClass: "text-sage-mid",
-    surfaceClass: "bg-sage-lighter",
-    badgeClass: "bg-white/70 text-sage-mid",
-    noteBorderClass:
-      "border-[color-mix(in_oklch,var(--color-sage-mid),transparent_70%)]",
-    icon: <Shield className="w-4 h-4" />,
+    tintVar: "--color-sage-mid",
+    icon: Shield,
   },
 };
 
@@ -354,6 +338,19 @@ function ScenarioCard({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [revealed, setRevealed] = useState(false);
   const meta = TECHNIQUE_META[scenario.technique];
+  const TechniqueIcon = meta.icon;
+  const tintStyle = {
+    color: `var(${meta.tintVar})`,
+  };
+  const tintBadgeStyle = {
+    color: `var(${meta.tintVar})`,
+    borderColor: `color-mix(in oklch, var(${meta.tintVar}) 28%, transparent)`,
+    backgroundColor: `color-mix(in oklch, var(${meta.tintVar}) 8%, white)`,
+  };
+  const tintPanelStyle = {
+    borderColor: `color-mix(in oklch, var(${meta.tintVar}) 22%, transparent)`,
+    backgroundColor: `color-mix(in oklch, var(${meta.tintVar}) 5%, var(--bg-primary))`,
+  };
 
   const selectedOption = scenario.options.find(o => o.id === selectedId);
 
@@ -372,36 +369,77 @@ function ScenarioCard({
   }, []);
 
   return (
-    <Card className="overflow-hidden border-border/60">
+    <article
+      className="overflow-hidden rounded-[1.35rem] border"
+      style={{
+        borderColor: "var(--rule-color)",
+        backgroundColor: "var(--bg-elevated)",
+      }}
+    >
       {/* Header */}
       <div
-        className={`border-b border-border/40 px-5 py-4 ${meta.surfaceClass}`}
+        className="border-b px-5 py-4"
+        style={{
+          borderColor: "var(--rule-color)",
+          backgroundColor: "color-mix(in oklch, var(--bg-primary) 78%, white)",
+        }}
       >
         <div className="flex items-center gap-2 mb-2">
           <span
-            className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${meta.badgeClass}`}
+            className="inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold"
+            style={tintBadgeStyle}
           >
-            {meta.icon}
+            <TechniqueIcon className="w-4 h-4" aria-hidden="true" />
             {meta.label}
           </span>
-          <span className="text-xs text-muted-foreground">
+          <span
+            style={{ fontSize: "var(--text-xs)", color: "var(--fg-tertiary)" }}
+          >
             Szenario {index + 1}
           </span>
         </div>
-        <h3 className="text-lg font-semibold text-foreground leading-tight">
+        <h3
+          className="leading-tight"
+          style={{
+            fontSize: "var(--text-lg)",
+            color: "var(--fg-primary)",
+            fontWeight: 600,
+          }}
+        >
           {scenario.title}
         </h3>
       </div>
 
-      <CardContent className="p-5 space-y-4">
+      <div className="p-5 space-y-4">
         {/* Context */}
-        <p className="text-sm text-muted-foreground leading-relaxed">
+        <p
+          style={{
+            fontSize: "var(--text-sm)",
+            lineHeight: "var(--lh-relaxed)",
+            color: "var(--fg-secondary)",
+          }}
+        >
           {scenario.context}
         </p>
 
         {/* Statement (what the person says) */}
-        <div className="bg-muted/40 rounded-xl p-4 border-l-4 border-l-[var(--color-sage-mid)]">
-          <p className="text-sm font-medium text-foreground italic leading-relaxed">
+        <div
+          className="rounded-[1rem] border-l-2 px-4 py-4"
+          style={{
+            borderColor: `var(${meta.tintVar})`,
+            backgroundColor:
+              "color-mix(in oklch, var(--bg-primary) 72%, white)",
+          }}
+        >
+          <p
+            className="italic"
+            style={{
+              fontSize: "var(--text-sm)",
+              lineHeight: "var(--lh-relaxed)",
+              color: "var(--fg-primary)",
+              fontWeight: 500,
+            }}
+          >
             {scenario.statement}
           </p>
         </div>
@@ -416,17 +454,17 @@ function ScenarioCard({
             const showResult = revealed;
 
             let borderClass =
-              "border-border/60 hover:border-[var(--color-sage-dark)]/40";
-            let bgClass = "bg-background hover:bg-muted/30";
+              "border-border/60 hover:border-[color:var(--rule-color-strong)]";
+            let bgClass = "bg-background hover:bg-muted/20";
 
             if (showResult && isSelected && option.correct) {
-              borderClass = "border-green-500/50";
+              borderClass = "border-green-500/60";
               bgClass = "bg-green-50";
             } else if (showResult && isSelected && !option.correct) {
-              borderClass = "border-red-400/50";
+              borderClass = "border-red-400/60";
               bgClass = "bg-red-50";
             } else if (showResult && option.correct) {
-              borderClass = "border-green-400/30";
+              borderClass = "border-green-400/40";
               bgClass = "bg-green-50/50";
             }
 
@@ -498,7 +536,7 @@ function ScenarioCard({
               transition={{ duration: 0.25, delay: 0.1 }}
               className="overflow-hidden"
             >
-              <div className="bg-green-50 border border-green-200 rounded-xl p-4">
+              <div className="rounded-[1rem] border border-green-200 bg-green-50/70 p-4">
                 <p className="text-sm font-medium text-green-800 mb-1 flex items-center gap-1.5">
                   <CheckCircle2 className="w-4 h-4" />
                   Bessere Antwort:
@@ -520,11 +558,9 @@ function ScenarioCard({
               transition={{ duration: 0.25, delay: 0.15 }}
               className="overflow-hidden"
             >
-              <div
-                className={`rounded-xl border p-4 ${meta.surfaceClass} ${meta.noteBorderClass}`}
-              >
+              <div className="rounded-[1rem] border p-4" style={tintPanelStyle}>
                 <p className="text-sm font-medium text-foreground mb-1 flex items-center gap-1.5">
-                  <Lightbulb className={`w-4 h-4 ${meta.accentTextClass}`} />
+                  <Lightbulb className="w-4 h-4" style={tintStyle} />
                   Merke
                 </p>
                 <p className="text-sm text-muted-foreground leading-relaxed">
@@ -549,8 +585,8 @@ function ScenarioCard({
             </Button>
           </div>
         )}
-      </CardContent>
-    </Card>
+      </div>
+    </article>
   );
 }
 
@@ -564,20 +600,40 @@ function TechniqueSection({
   scenarios: Scenario[];
 }) {
   const meta = TECHNIQUE_META[technique];
+  const TechniqueIcon = meta.icon;
+  const tintStyle = {
+    color: `var(${meta.tintVar})`,
+  };
+  const tintBadgeStyle = {
+    color: `var(${meta.tintVar})`,
+    borderColor: `color-mix(in oklch, var(${meta.tintVar}) 24%, transparent)`,
+    backgroundColor: `color-mix(in oklch, var(${meta.tintVar}) 6%, var(--bg-primary))`,
+  };
 
   return (
     <div>
       <div className="flex items-center gap-3 mb-4">
         <div
-          className={`flex h-9 w-9 items-center justify-center rounded-lg ${meta.surfaceClass} ${meta.accentTextClass}`}
+          className="flex h-9 w-9 items-center justify-center rounded-[0.9rem] border"
+          style={tintBadgeStyle}
         >
-          {meta.icon}
+          <TechniqueIcon className="w-4 h-4" aria-hidden="true" />
         </div>
         <div>
-          <h2 className="text-xl font-semibold text-foreground">
+          <h2
+            className="font-display"
+            style={{
+              fontSize: "var(--text-xl)",
+              lineHeight: "var(--lh-snug)",
+              color: "var(--fg-primary)",
+              fontWeight: "var(--weight-display)",
+            }}
+          >
             {meta.label}
           </h2>
-          <p className="text-xs text-muted-foreground">
+          <p
+            style={{ fontSize: "var(--text-xs)", color: "var(--fg-tertiary)" }}
+          >
             {scenarios.length}{" "}
             {scenarios.length === 1 ? "Szenario" : "Szenarien"}
           </p>
@@ -586,19 +642,21 @@ function TechniqueSection({
 
       {/* Technique component breakdown */}
       {TECHNIQUE_STEPS[technique] && (
-        <div
-          className={`mb-5 rounded-lg border border-border/30 p-3 ${meta.surfaceClass}`}
-        >
-          <p className={`mb-2.5 text-xs font-medium ${meta.accentTextClass}`}>
+        <div className="mb-5 rounded-[1rem] border p-3" style={tintBadgeStyle}>
+          <p className="mb-2.5 text-xs font-medium" style={tintStyle}>
             Aufbau der Technik
           </p>
           <div className="flex flex-wrap gap-2">
             {TECHNIQUE_STEPS[technique]!.map(comp => (
               <div
                 key={comp.letter}
-                className="flex items-center gap-1.5 bg-background/60 rounded px-2.5 py-1.5"
+                className="flex items-center gap-1.5 rounded-[0.8rem] border px-2.5 py-1.5"
+                style={{
+                  borderColor: "var(--rule-color)",
+                  backgroundColor: "var(--bg-elevated)",
+                }}
               >
-                <span className={`text-sm font-bold ${meta.accentTextClass}`}>
+                <span className="text-sm font-bold" style={tintStyle}>
                   {comp.letter}
                 </span>
                 <div>

--- a/client/src/components/interactive/ValidierungsStufenleiter.tsx
+++ b/client/src/components/interactive/ValidierungsStufenleiter.tsx
@@ -8,16 +8,13 @@ import {
   CheckCircle2,
   AlertTriangle,
 } from "lucide-react";
-import { Card, CardContent } from "@/components/ui/card";
 
 interface Stufe {
   level: number;
   title: string;
   subtitle: string;
   icon: React.ElementType;
-  badgeClass: string;
-  iconClass: string;
-  exampleClass: string;
+  tintVar: string;
   ziel: string;
   soGehts: string[];
   beispielsaetze: string[];
@@ -34,10 +31,7 @@ const stufen: Stufe[] = [
     title: "Aufmerksam sein",
     subtitle: "«Ich bin jetzt wirklich da.»",
     icon: Eye,
-    badgeClass: "bg-sand-border text-white",
-    iconClass: "text-sand-border",
-    exampleClass:
-      "bg-[color-mix(in_oklch,var(--color-sand-border)_10%,white)] text-sand-border",
+    tintVar: "--color-sand-border",
     ziel: "Sicherheit durch Präsenz.",
     soGehts: [
       "Kurz innehalten, Blick und Körper zuwenden",
@@ -59,10 +53,7 @@ const stufen: Stufe[] = [
     title: "Spiegeln",
     subtitle: "«Ich habe verstanden, was du meinst.»",
     icon: MessageSquare,
-    badgeClass: "bg-sage-dark text-white",
-    iconClass: "text-sage-dark",
-    exampleClass:
-      "bg-[color-mix(in_oklch,var(--color-sage-dark)_10%,white)] text-sage-dark",
+    tintVar: "--color-sage-dark",
     ziel: "Missverständnisse reduzieren, Tempo rausnehmen.",
     soGehts: [
       "In eigenen Worten zusammenfassen",
@@ -84,10 +75,7 @@ const stufen: Stufe[] = [
     title: "Zwischen den Zeilen verstehen",
     subtitle: "«Kann es sein, dass…?»",
     icon: Sparkles,
-    badgeClass: "bg-sand-mid text-white",
-    iconClass: "text-sand-mid",
-    exampleClass:
-      "bg-[color-mix(in_oklch,var(--color-sand-mid)_10%,white)] text-sand-mid",
+    tintVar: "--color-sand-mid",
     ziel: "Das Gefühl hinter der Reaktion erkennen.",
     soGehts: [
       "Vorsichtige Vermutung äussern",
@@ -109,10 +97,7 @@ const stufen: Stufe[] = [
     title: "Nachvollziehen",
     subtitle: "«Es macht Sinn, dass dich das trifft.»",
     icon: History,
-    badgeClass: "bg-sage-mid text-white",
-    iconClass: "text-sage-mid",
-    exampleClass:
-      "bg-[color-mix(in_oklch,var(--color-sage-mid)_10%,white)] text-sage-mid",
+    tintVar: "--color-sage-mid",
     ziel: "Bedeutung geben, ohne zu bewerten.",
     soGehts: [
       "Stress, Vorgeschichte oder Überforderung mitdenken",
@@ -134,10 +119,7 @@ const stufen: Stufe[] = [
     title: "Das Gültige anerkennen",
     subtitle: "«Diesen Teil kann ich gut nachvollziehen.»",
     icon: Users,
-    badgeClass: "bg-sage-dark text-white",
-    iconClass: "text-sage-dark",
-    exampleClass:
-      "bg-[color-mix(in_oklch,var(--color-sage-dark)_10%,white)] text-sage-dark",
+    tintVar: "--color-sage-dark",
     ziel: "Den verständlichen Kern benennen, ohne alles zu billigen.",
     soGehts: [
       "Gefühl oder Bedürfnis anerkennen",
@@ -159,10 +141,7 @@ const stufen: Stufe[] = [
     title: "Auf Augenhöhe bleiben",
     subtitle: "«Wir sind zwei gleichwertige Menschen.»",
     icon: Star,
-    badgeClass: "bg-sage-dark text-white",
-    iconClass: "text-sage-dark",
-    exampleClass:
-      "bg-[color-mix(in_oklch,var(--color-sage-dark)_10%,white)] text-sage-dark",
+    tintVar: "--color-sage-dark",
     ziel: "Respektvoll bleiben, ohne zu belehren oder zu psychologisieren.",
     soGehts: [
       "Klar, ruhig und respektvoll sprechen",
@@ -183,7 +162,7 @@ const stufen: Stufe[] = [
 
 export default function ValidierungsStufenleiter() {
   return (
-    <div className="mt-6 space-y-4">
+    <div className="mt-6 space-y-6">
       <p className="text-sm text-muted-foreground">
         Die sechs Stufen sind kein Schema, das immer vollständig abgearbeitet
         werden muss. Sie helfen eher dabei, den eigenen Ton zu klären: zuerst
@@ -192,111 +171,140 @@ export default function ValidierungsStufenleiter() {
 
       {stufen.map(stufe => {
         const Icon = stufe.icon;
+        const tintStyle = {
+          color: `var(${stufe.tintVar})`,
+        };
+        const tintBadgeStyle = {
+          color: `var(${stufe.tintVar})`,
+          borderColor: `color-mix(in oklch, var(${stufe.tintVar}) 28%, transparent)`,
+          backgroundColor: `color-mix(in oklch, var(${stufe.tintVar}) 8%, white)`,
+        };
+        const exampleStyle = {
+          borderColor: `color-mix(in oklch, var(${stufe.tintVar}) 22%, transparent)`,
+          backgroundColor: "var(--bg-elevated)",
+        };
+
         return (
-          <Card key={stufe.level} className="border-border/50">
-            <CardContent className="p-5">
-              <div className="flex items-start gap-3 mb-4">
-                <div
-                  className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold ${stufe.badgeClass}`}
-                >
-                  {stufe.level}
-                </div>
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-1">
-                    <Icon
-                      className={`h-4 w-4 ${stufe.iconClass}`}
-                      aria-hidden="true"
-                    />
-                    <h3 className="font-semibold text-foreground">
-                      {stufe.title}
-                    </h3>
-                  </div>
-                  <p className="text-sm italic text-muted-foreground">
-                    {stufe.subtitle}
-                  </p>
-                </div>
+          <article
+            key={stufe.level}
+            className="border-t pt-6"
+            style={{ borderColor: "var(--rule-color)" }}
+          >
+            <div className="flex items-start gap-3 mb-4">
+              <div
+                className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full border text-sm font-bold"
+                style={tintBadgeStyle}
+              >
+                {stufe.level}
               </div>
-
-              <p className="text-sm text-foreground mb-4">
-                <strong>Ziel:</strong> {stufe.ziel}
-              </p>
-
-              <div className="grid gap-4 md:grid-cols-2 mb-4">
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground mb-2">
-                    So kann es aussehen
-                  </p>
-                  <ul className="space-y-2">
-                    {stufe.soGehts.map((item, i) => (
-                      <li
-                        key={i}
-                        className="flex items-start gap-2 text-sm text-foreground"
-                      >
-                        <CheckCircle2
-                          className="w-3.5 h-3.5 text-sage-mid flex-shrink-0 mt-0.5"
-                          aria-hidden="true"
-                        />
-                        {item}
-                      </li>
-                    ))}
-                  </ul>
+              <div className="flex-1">
+                <div className="flex items-center gap-2 mb-1">
+                  <Icon
+                    className="h-4 w-4"
+                    style={tintStyle}
+                    aria-hidden="true"
+                  />
+                  <h3 className="font-semibold text-foreground">
+                    {stufe.title}
+                  </h3>
                 </div>
+                <p className="text-sm italic text-muted-foreground">
+                  {stufe.subtitle}
+                </p>
+              </div>
+            </div>
 
-                <div>
-                  <p className="text-xs font-medium text-muted-foreground mb-2">
-                    Typischer Stolperstein
-                  </p>
-                  <div className="rounded-lg border border-sand-border/40 bg-sand/50 p-3">
-                    <p className="text-sm text-foreground leading-relaxed flex items-start gap-2">
-                      <AlertTriangle
-                        className="w-4 h-4 text-sand-warm flex-shrink-0 mt-0.5"
+            <p className="text-sm text-foreground mb-4">
+              <strong>Ziel:</strong> {stufe.ziel}
+            </p>
+
+            <div className="grid gap-4 md:grid-cols-2 mb-4">
+              <div>
+                <p className="text-xs font-medium text-muted-foreground mb-2">
+                  So kann es aussehen
+                </p>
+                <ul className="space-y-2">
+                  {stufe.soGehts.map((item, i) => (
+                    <li
+                      key={i}
+                      className="flex items-start gap-2 text-sm text-foreground"
+                    >
+                      <CheckCircle2
+                        className="w-3.5 h-3.5 flex-shrink-0 mt-0.5"
+                        style={tintStyle}
                         aria-hidden="true"
                       />
-                      {stufe.typischerFehler}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="mb-4">
-                <p className="text-xs font-medium text-muted-foreground mb-2">
-                  Beispielsätze
-                </p>
-                <div className="space-y-2">
-                  {stufe.beispielsaetze.map((satz, i) => (
-                    <div
-                      key={i}
-                      className={`rounded-md px-3 py-2 text-sm font-medium ${stufe.exampleClass}`}
-                    >
-                      {satz}
-                    </div>
+                      {item}
+                    </li>
                   ))}
-                </div>
+                </ul>
               </div>
 
-              <div className="rounded-lg bg-muted/30 p-4 space-y-3">
-                <p className="text-xs font-medium text-muted-foreground">
-                  Kurzer Beispiel-Dialog
+              <div>
+                <p className="text-xs font-medium text-muted-foreground mb-2">
+                  Typischer Stolperstein
                 </p>
-                <div className="flex items-start gap-2">
-                  <span className="text-xs font-medium text-sand-warm bg-sand/50 px-2 py-0.5 rounded flex-shrink-0">
-                    B
-                  </span>
-                  <p className="text-sm text-foreground italic">
-                    {stufe.dialog.betroffener}
-                  </p>
-                </div>
-                <div className="flex items-start gap-2">
-                  <span className="text-xs font-medium text-sage-dark bg-sage-wash px-2 py-0.5 rounded flex-shrink-0">
-                    A
-                  </span>
-                  <p className="text-sm text-foreground font-medium">
-                    {stufe.dialog.angehoeriger}
+                <div className="rounded-[0.95rem] border border-sand-border/40 bg-sand/50 p-3">
+                  <p className="text-sm text-foreground leading-relaxed flex items-start gap-2">
+                    <AlertTriangle
+                      className="w-4 h-4 text-sand-warm flex-shrink-0 mt-0.5"
+                      aria-hidden="true"
+                    />
+                    {stufe.typischerFehler}
                   </p>
                 </div>
               </div>
-            </CardContent>
-          </Card>
+            </div>
+
+            <div className="mb-4">
+              <p className="text-xs font-medium text-muted-foreground mb-2">
+                Beispielsätze
+              </p>
+              <div className="space-y-2">
+                {stufe.beispielsaetze.map((satz, i) => (
+                  <div
+                    key={i}
+                    className="rounded-[0.95rem] border px-3 py-2 text-sm font-medium text-foreground"
+                    style={exampleStyle}
+                  >
+                    {satz}
+                  </div>
+                ))}
+              </div>
+            </div>
+
+            <div
+              className="space-y-3 rounded-[1rem] border p-4"
+              style={{
+                borderColor: "var(--rule-color)",
+                backgroundColor:
+                  "color-mix(in oklch, var(--bg-primary) 70%, white)",
+              }}
+            >
+              <p className="text-xs font-medium text-muted-foreground">
+                Kurzer Beispiel-Dialog
+              </p>
+              <div className="flex items-start gap-2">
+                <span className="flex-shrink-0 rounded-full border border-sand-border/40 bg-sand/40 px-2 py-0.5 text-xs font-medium text-sand-warm">
+                  B
+                </span>
+                <p className="text-sm text-foreground italic">
+                  {stufe.dialog.betroffener}
+                </p>
+              </div>
+              <div className="flex items-start gap-2">
+                <span
+                  className="flex-shrink-0 rounded-full border px-2 py-0.5 text-xs font-medium"
+                  style={tintBadgeStyle}
+                >
+                  A
+                </span>
+                <p className="text-sm text-foreground font-medium">
+                  {stufe.dialog.angehoeriger}
+                </p>
+              </div>
+            </div>
+          </article>
         );
       })}
     </div>


### PR DESCRIPTION
## Summary
- tone down the remaining portal-style card and color treatment in the two embedded learning modules
- keep the exercise logic and answer-state feedback intact while moving the presentation closer to the editorial system
- reserve stronger colors for real correctness and warning states instead of the general reading flow

## Why
Most content pages now follow the calmer editorial language. These two interactive teaching modules were still noticeable app-style islands inside otherwise editorialized pages, so this PR brings their containers and helper surfaces into line with the rest of the site.

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
