### PR TITLE
[codex] Polish final editorial shell details

### DIFF
--- a/client/src/components/Search.tsx
+++ b/client/src/components/Search.tsx
@@ -345,11 +345,11 @@ export default function Search({ isOpen, onClose }: SearchProps) {
                       >
                         <div className="flex-1 min-w-0">
                           <div className="flex items-center gap-2">
-                            <span className="text-xs font-medium text-sage-mid bg-sage-lighter px-2 py-0.5 rounded">
+                            <span className="rounded-sm border border-border/70 bg-white px-2 py-0.5 text-xs font-medium text-[color:var(--accent-label)]">
                               {result.section}
                             </span>
                           </div>
-                          <h4 className="font-medium text-foreground mt-1 group-hover:text-sage-mid transition-colors">
+                          <h4 className="mt-1 font-medium text-foreground transition-colors group-hover:text-[color:var(--accent-primary)]">
                             {result.title}
                           </h4>
                           <p className="text-sm text-muted-foreground line-clamp-1 mt-0.5">

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -292,7 +292,7 @@ export function TableOfContents() {
       {floatingMode === "content" && showFloatingButton && (
         <motion.button
           onClick={() => setIsOpen(true)}
-          className="min-[1800px]:hidden fixed right-4 bottom-[calc(7.5rem+env(safe-area-inset-bottom,0px))] z-40 flex h-11 items-center gap-2 rounded-full border border-border/70 bg-background/95 px-4 text-sm font-medium text-foreground shadow-[0_18px_40px_-34px_rgba(15,23,42,0.55)] backdrop-blur-sm"
+          className="min-[1800px]:hidden fixed right-4 bottom-[calc(7.5rem+env(safe-area-inset-bottom,0px))] z-40 flex h-11 items-center gap-2 rounded-full border border-border/70 bg-background px-4 text-sm font-medium text-foreground shadow-[0_14px_32px_-30px_rgba(15,23,42,0.42)]"
           aria-label="Inhaltsverzeichnis öffnen"
         >
           <List className="w-4 h-4" />
@@ -321,7 +321,7 @@ export function TableOfContents() {
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{ duration: 0.2, ease: "easeOut" }}
-            className="min-[1800px]:hidden fixed bottom-0 left-0 right-0 z-50 flex max-h-[70vh] flex-col overflow-hidden rounded-t-[1.75rem] border-t border-border/60 bg-background shadow-[0_-24px_48px_-36px_rgba(15,23,42,0.45)] pb-[env(safe-area-inset-bottom,0px)]"
+            className="min-[1800px]:hidden fixed bottom-0 left-0 right-0 z-50 flex max-h-[70vh] flex-col overflow-hidden rounded-t-[1.75rem] border-t border-border/60 bg-background shadow-[0_-18px_38px_-32px_rgba(15,23,42,0.32)] pb-[env(safe-area-inset-bottom,0px)]"
           >
             {/* Drawer Handle */}
             <div className="flex justify-center pt-3 pb-1">
@@ -373,7 +373,7 @@ export function TableOfContents() {
       {/* ─── Desktop: Sticky Sidebar in der linken Gutter-Zone ─── */}
       {/* left = 50vw - halbe Content-Breite (304px) - Abstand (2rem) - Sidebar-Breite (15rem) */}
       <div className="hidden min-[1800px]:block fixed left-[calc(50vw-304px-17rem)] top-[calc(8rem+env(safe-area-inset-top,0px))] z-30 max-h-[calc(100vh-9.5rem)] w-60">
-        <div className="flex max-h-full flex-col overflow-hidden rounded-[1.4rem] border border-border/60 bg-background/92 shadow-[0_28px_52px_-40px_rgba(15,23,42,0.28)] backdrop-blur-md">
+        <div className="flex max-h-full flex-col overflow-hidden rounded-[1.4rem] border border-border/60 bg-background/96 shadow-[0_22px_42px_-36px_rgba(15,23,42,0.22)] backdrop-blur-sm">
           <div className="border-b border-border/60 px-4 pt-4 pb-3">
             <span
               className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--accent-label)]"

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -59,7 +59,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
   }, [mobileMenuOpen]);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-border/55 bg-background/94 backdrop-blur-md">
+    <header className="sticky top-0 z-50 border-b border-border/55 bg-background/96 backdrop-blur-sm">
       <div className="container">
         <div className="flex min-h-16 items-center justify-between gap-2 py-2 md:min-h-20 md:gap-4 md:py-3">
           <AppLink href="/" className="flex items-center gap-3 group shrink-0">

--- a/client/src/components/layout/ScrollToTopButton.tsx
+++ b/client/src/components/layout/ScrollToTopButton.tsx
@@ -29,7 +29,7 @@ export function ScrollToTopButton() {
           behavior: "smooth",
         })
       }
-      className={`fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-40 flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-background/95 text-[color:var(--accent-primary)] shadow-[0_18px_40px_-34px_rgba(15,23,42,0.55)] backdrop-blur-sm transition-colors hover:bg-background hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)]/30 focus-visible:ring-offset-2 sm:h-12 sm:w-12 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
+      className={`fixed right-4 bottom-[calc(1rem+env(safe-area-inset-bottom,0px))] z-40 flex h-11 w-11 items-center justify-center rounded-full border border-border/70 bg-background text-[color:var(--accent-primary)] shadow-[0_14px_32px_-30px_rgba(15,23,42,0.42)] transition-colors hover:bg-white hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)]/30 focus-visible:ring-offset-2 sm:h-12 sm:w-12 ${hideOnMobile ? "hidden sm:flex" : "flex"}`}
       aria-label="Nach oben scrollen"
     >
       <ChevronUp className="w-6 h-6" />

--- a/client/src/pages/HandoutTextPage.tsx
+++ b/client/src/pages/HandoutTextPage.tsx
@@ -171,7 +171,8 @@ export default function HandoutTextPage({
           <div className="mt-8 flex flex-wrap gap-3">
             <Button
               asChild
-              className="bg-sage-dark hover:bg-sage-mid text-white"
+              variant="outline"
+              className="border-[color:var(--accent-primary)] bg-[color:var(--accent-primary)] text-[color:var(--bg-primary)] shadow-none hover:border-[color:var(--accent-primary-h)] hover:bg-[color:var(--accent-primary-h)] hover:text-[color:var(--bg-primary)]"
             >
               <a href={openHref} target="_blank" rel="noopener noreferrer">
                 <ExternalLink className="w-4 h-4" />
@@ -247,7 +248,7 @@ export default function HandoutTextPage({
             </EditorialProse>
           ) : (
             <div className="flex items-center gap-3" style={bodyStyle}>
-              <Spinner className="size-5 text-sage-dark" />
+              <Spinner className="size-5 text-[color:var(--accent-primary)]" />
               <p>Die ausführliche Textversion wird geladen.</p>
             </div>
           )}
@@ -316,7 +317,7 @@ export default function HandoutTextPage({
         ) : (
           <EditorialSection title="Textversion lädt" rule>
             <div className="flex items-center gap-3" style={bodyStyle}>
-              <Spinner className="size-5 text-sage-dark" />
+              <Spinner className="size-5 text-[color:var(--accent-primary)]" />
               <p>Die Abschnitte dieser Textversion werden geladen.</p>
             </div>
           </EditorialSection>


### PR DESCRIPTION
## Summary
- soften the remaining shell and floating UI chrome to better match the editorial direction
- replace the last small sage-style accents in search results and the handout PDF CTA with editorial tokens
- keep all behavior unchanged while reducing blur, shadow weight, and old portal-like emphasis

## Testing
- pnpm lint
- pnpm check
- pnpm test
- pnpm build