### PR TITLE
[codex] Tighten mobile editorial page chrome

### DIFF
--- a/client/src/components/UnterstuetzenSubNav.tsx
+++ b/client/src/components/UnterstuetzenSubNav.tsx
@@ -13,10 +13,10 @@ export default function UnterstuetzenSubNav() {
   return (
     <nav
       aria-label="Unterstützen – Unterseiten"
-      className="border-b border-border/45 bg-background/92"
+      className="border-b border-border/45 bg-background/94"
     >
       <div className="container">
-        <div className="scrollbar-none flex overflow-x-auto -mb-px gap-1">
+        <div className="scrollbar-none -mb-px flex gap-0.5 overflow-x-auto">
           {tabs.map(({ href, label }) => {
             const isActive = location === href;
             return (
@@ -24,7 +24,7 @@ export default function UnterstuetzenSubNav() {
                 key={href}
                 href={href}
                 className={[
-                  "flex items-center px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors",
+                  "flex items-center border-b-2 px-3 py-2.5 text-[13px] font-medium whitespace-nowrap leading-none transition-colors sm:px-4 sm:py-3 sm:text-sm",
                   isActive
                     ? "border-[color:var(--accent-primary)] text-foreground"
                     : "border-transparent text-muted-foreground hover:text-foreground hover:border-border/70",

--- a/client/src/components/layout/Breadcrumbs.tsx
+++ b/client/src/components/layout/Breadcrumbs.tsx
@@ -86,17 +86,19 @@ export function Breadcrumbs() {
 
   return (
     <div className="border-b border-border/40 bg-background/92">
-      <nav className="container py-3 md:py-3.5" aria-label="Breadcrumb">
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+      <nav className="container py-2 md:py-3.5" aria-label="Breadcrumb">
+        <div className="flex items-center justify-between gap-3 sm:gap-4">
           <Link
             href={backHref}
-            className={`inline-flex items-center gap-2 rounded-full border px-3 py-2 text-sm font-medium transition-colors group sm:hidden ${accent.breadcrumbBack}`}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-[13px] font-medium transition-colors group sm:hidden ${accent.breadcrumbBack}`}
           >
             <ArrowLeft className="w-4 h-4" />
             <span>{backLabel}</span>
           </Link>
 
-          <p className={`text-sm font-medium sm:hidden ${accent.textAccent}`}>
+          <p
+            className={`min-w-0 flex-1 truncate text-right text-[13px] font-medium sm:hidden ${accent.textAccent}`}
+          >
             {pageName}
           </p>
 

--- a/client/src/components/layout/HeaderNav.tsx
+++ b/client/src/components/layout/HeaderNav.tsx
@@ -61,8 +61,11 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
   return (
     <header className="sticky top-0 z-50 border-b border-border/55 bg-background/96 backdrop-blur-sm">
       <div className="container">
-        <div className="flex min-h-16 items-center justify-between gap-2 py-2 md:min-h-20 md:gap-4 md:py-3">
-          <AppLink href="/" className="flex items-center gap-3 group shrink-0">
+        <div className="flex min-h-14 items-center justify-between gap-2 py-1.5 md:min-h-20 md:gap-4 md:py-3">
+          <AppLink
+            href="/"
+            className="flex items-center gap-2.5 group shrink-0"
+          >
             <BrandMark
               className="md:h-11 md:w-11"
               iconClassName="md:h-[22px] md:w-[22px]"
@@ -107,7 +110,7 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             />
           </nav>
 
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex items-center gap-1.5 shrink-0 sm:gap-2">
             <button
               type="button"
               onClick={onSearchOpen}
@@ -121,10 +124,10 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             <button
               type="button"
               onClick={onSearchOpen}
-              className="sm:hidden inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/60 bg-white/78 text-muted-foreground transition-all hover:text-foreground hover:bg-muted"
+              className="sm:hidden inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-white/78 text-muted-foreground transition-all hover:bg-muted hover:text-foreground"
               aria-label="Suche öffnen"
             >
-              <SearchIcon className="w-5 h-5" />
+              <SearchIcon className="h-[18px] w-[18px]" />
             </button>
 
             <Button
@@ -145,16 +148,16 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
             <AppLink
               href="/soforthilfe"
               aria-label="Soforthilfe – Notfallnummern und Krisenberatung"
-              className="sm:hidden inline-flex h-11 w-11 items-center justify-center rounded-full bg-alert text-white shadow-[0_8px_16px_-8px_rgba(197,95,61,0.6)]"
+              className="sm:hidden inline-flex h-10 w-10 items-center justify-center rounded-full bg-alert text-white shadow-[0_8px_16px_-10px_rgba(197,95,61,0.58)]"
             >
-              <Phone className="w-5 h-5" />
+              <Phone className="h-[18px] w-[18px]" />
             </AppLink>
 
             <button
               ref={menuButtonRef}
               type="button"
               onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-              className={`lg:hidden inline-flex h-11 w-11 items-center justify-center rounded-full border border-border/60 bg-white/78 transition-colors ${
+              className={`lg:hidden inline-flex h-10 w-10 items-center justify-center rounded-full border border-border/60 bg-white/78 transition-colors ${
                 mobileMenuOpen ? currentAccent.surfaceActive : "hover:bg-muted"
               }`}
               aria-controls="mobile-navigation-dialog"
@@ -162,9 +165,9 @@ export function HeaderNav({ onSearchOpen }: HeaderNavProps) {
               aria-label={mobileMenuOpen ? "Menü schliessen" : "Menü öffnen"}
             >
               {mobileMenuOpen ? (
-                <X className="w-6 h-6" />
+                <X className="h-5 w-5" />
               ) : (
-                <Menu className="w-6 h-6" />
+                <Menu className="h-5 w-5" />
               )}
             </button>
           </div>

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -318,10 +318,10 @@ export default function UnterstuetzenKrise() {
       <UnterstuetzenSubNav />
 
       {/* ── Sicherheits-Banner: bleibt prominent (sicherheitskritisch) ── */}
-      <section className="bg-alert py-4">
+      <section className="bg-alert py-3 sm:py-4">
         <div className="container">
-          <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
-            <p className="text-center text-white sm:text-left">
+          <div className="flex flex-col items-start justify-between gap-3 sm:flex-row sm:items-center sm:gap-4">
+            <p className="text-sm leading-relaxed text-white sm:text-left sm:text-base">
               <strong>Bei akuter Suizidgefahr:</strong> Rufen Sie sofort den
               Notruf{" "}
               <a href={`tel:${rot144.tel}`} className="font-bold underline">
@@ -334,7 +334,7 @@ export default function UnterstuetzenKrise() {
             </p>
             <AppLink
               href="/soforthilfe"
-              className="rounded bg-white px-3 py-2 text-sm font-medium text-alert hover:bg-white/90"
+              className="rounded bg-white px-3 py-2 text-sm font-medium text-alert transition-colors hover:bg-white/90"
             >
               Alle Notfallnummern
             </AppLink>
@@ -344,7 +344,7 @@ export default function UnterstuetzenKrise() {
 
       <EditorialLayout width="narrow">
         {/* ── Hero ── */}
-        <header className="pb-12 pt-12 md:pb-16 md:pt-16">
+        <header className="pb-10 pt-8 md:pb-16 md:pt-16">
           <p
             className="text-xs uppercase"
             style={{
@@ -356,7 +356,7 @@ export default function UnterstuetzenKrise() {
             Unterstützen — Krise
           </p>
           <h1
-            className="mt-8 font-display text-[var(--text-3xl)] md:text-[var(--text-4xl)]"
+            className="mt-6 font-display text-[var(--text-3xl)] md:mt-8 md:text-[var(--text-4xl)]"
             style={{
               lineHeight: "var(--lh-tight)",
               letterSpacing: "var(--tracking-tight)",
@@ -367,7 +367,7 @@ export default function UnterstuetzenKrise() {
             In der Krise <em>unterstützen</em>
           </h1>
           <p
-            className="mt-6"
+            className="mt-5 md:mt-6"
             style={{
               fontSize: "var(--text-lg)",
               lineHeight: "var(--lh-snug)",
@@ -380,7 +380,7 @@ export default function UnterstuetzenKrise() {
             ohne Ihre eigene Grenze aus dem Blick zu verlieren.
           </p>
           <p
-            className="mt-4"
+            className="mt-3 md:mt-4"
             style={{
               fontSize: "var(--text-sm)",
               color: "var(--fg-tertiary)",
@@ -388,8 +388,7 @@ export default function UnterstuetzenKrise() {
           >
             Vollständig ca. 6 Min · Auch abschnittweise lesbar.
           </p>
-          <LastVerifiedBadge path="/unterstuetzen/krise" className="mt-6" />
-          <ReviewBadge path="/unterstuetzen/krise" />
+          <LastVerifiedBadge path="/unterstuetzen/krise" className="mt-5" />
         </header>
 
         {/* ── Disclaimer ── */}
@@ -408,6 +407,8 @@ export default function UnterstuetzenKrise() {
 
         {/* ── Visualisierung (out-of-scope) ── */}
         <KrisenampelVisualisierung />
+
+        <ReviewBadge path="/unterstuetzen/krise" />
 
         {/* ── Intro: Was diese Seite in Krisen ordnet ── */}
         <EditorialSection


### PR DESCRIPTION
## Summary
- tighten the mobile header chrome so the first screen starts closer to content
- compress breadcrumbs and the supporting subnav on small viewports
- reduce the initial vertical density on the crisis support page without weakening emergency guidance

## Why
The browser review showed that the mobile opening on editorial pages, especially `/unterstuetzen/krise`, still spent too much vertical space on navigation chrome before the actual content began.

## Validation
- pnpm lint
- pnpm check
- pnpm test
- pnpm build
