### PR TITLE
[codex] Tighten content safety and diagnostics guidance

### DIFF
--- a/client/public/soforthilfe/index.html
+++ b/client/public/soforthilfe/index.html
@@ -145,6 +145,40 @@
         </section>
 
         <section class="fallback-grid">
+          <!-- Spiegelung aus client/src/data/kontakte.ts: Gewalt-/Opferhilfe-Kontakte -->
+          <article class="fallback-card">
+            <h3>Gewalt, Bedrohung oder Übergriff</h3>
+            <ul class="fallback-list">
+              <li>
+                <a href="tel:117">117</a> Polizei bei akuter Bedrohung oder wenn
+                sofort Schutz vor Ort nötig ist
+              </li>
+              <li>
+                <a href="tel:144">144</a> Rettungsdienst bei Verletzung,
+                Bewusstseinsstörung oder medizinischer Notlage
+              </li>
+              <li><a href="tel:142">142</a> Opferhilfe 142, 24/7</li>
+              <li>
+                <a href="tel:+41444552142">044 455 21 42</a> Opferhilfe Zürich,
+                24/7
+              </li>
+              <li>
+                <a href="tel:0800090909">0800 09 09 09</a> Forensic Nurses
+                Zürich, 24/7
+              </li>
+              <li>
+                <a href="tel:+41442994050">044 299 40 50</a> Opferberatung
+                Zürich
+              </li>
+            </ul>
+            <p class="fallback-small">
+              Opferhilfe gilt auch für Angehörige, Männer, Frauen und
+              Vertrauenspersonen. Forensic Nurses unterstützen nach sexueller
+              oder häuslicher Gewalt bei medizinischer Hilfe und Spurensicherung
+              – auch ohne sofortige Anzeige.
+            </p>
+          </article>
+
           <article class="fallback-card">
             <h3>Weitere Hilfe</h3>
             <ul class="fallback-list">

--- a/client/src/__tests__/notfallkarte-architecture.test.ts
+++ b/client/src/__tests__/notfallkarte-architecture.test.ts
@@ -12,6 +12,16 @@ const repoRoot = path.resolve(__dirname, "../../..");
 const KIZ = INFO.find(kontakt => kontakt.id === "INFO_KIZ");
 const FACHSTELLE = INFO.find(kontakt => kontakt.id === "INFO_FACHSTELLE");
 const AERZTEFON = INFO.find(kontakt => kontakt.id === "INFO_AERZTEFON");
+const OPFERHILFE = INFO.find(kontakt => kontakt.id === "INFO_OPFERHILFE_142");
+const OPFERHILFE_ZH = INFO.find(
+  kontakt => kontakt.id === "INFO_OPFERHILFE_ZH_24_7"
+);
+const FORENSIC_NURSES = INFO.find(
+  kontakt => kontakt.id === "INFO_FORENSIC_NURSES"
+);
+const OPFERBERATUNG_ZH = INFO.find(
+  kontakt => kontakt.id === "INFO_OPFERBERATUNG_ZH"
+);
 
 function formatDate(date?: string) {
   if (!date) return null;
@@ -72,10 +82,18 @@ describe("notfallkarte architecture", () => {
       path.join(repoRoot, "client/public/soforthilfe-print.html"),
       "utf8"
     );
+    const soforthilfeDirect = fs.readFileSync(
+      path.join(repoRoot, "client/public/soforthilfe/index.html"),
+      "utf8"
+    );
 
     expect(AERZTEFON).toBeDefined();
     expect(KIZ).toBeDefined();
     expect(FACHSTELLE).toBeDefined();
+    expect(OPFERHILFE).toBeDefined();
+    expect(OPFERHILFE_ZH).toBeDefined();
+    expect(FORENSIC_NURSES).toBeDefined();
+    expect(OPFERBERATUNG_ZH).toBeDefined();
 
     expect(browserCard).toContain(AERZTEFON!.nummer);
     expect(browserCard).not.toContain("044 360 44 44");
@@ -94,6 +112,12 @@ describe("notfallkarte architecture", () => {
     expect(soforthilfePrint).toContain(FACHSTELLE!.nummer);
     expect(soforthilfePrint).not.toContain("044 296 73 00");
     expect(soforthilfePrint).not.toContain("058 384 27 00");
+
+    expect(soforthilfeDirect).toContain(OPFERHILFE!.nummer);
+    expect(soforthilfeDirect).toContain(OPFERHILFE_ZH!.nummer);
+    expect(soforthilfeDirect).toContain(FORENSIC_NURSES!.nummer);
+    expect(soforthilfeDirect).toContain(OPFERBERATUNG_ZH!.nummer);
+    expect(soforthilfeDirect).toMatch(/Gewalt, Bedrohung oder Übergriff/);
   });
 
   it("keeps the static browser card responsive without scaled mobile hitboxes", () => {

--- a/client/src/__tests__/selbsttest.test.tsx
+++ b/client/src/__tests__/selbsttest.test.tsx
@@ -1,0 +1,153 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import Selbsttest from "@/components/Selbsttest";
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: ReactNode }) => children,
+  motion: {
+    div: ({ children, ...props }: ComponentPropsWithoutRef<"div">) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+describe("Selbsttest", () => {
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("trennt Begleitdauer und Diagnose-Status in zwei Fragen", () => {
+    vi.useFakeTimers();
+    render(<Selbsttest />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Relativ stabil – Zeit zum Lernen und Vorbereiten/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: /Was beschäftigt Sie gerade am meisten\?/i,
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Ich weiss nicht, wie ich helfen kann/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: /Wie lange begleiten Sie Ihren Angehörigen schon\?/i,
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Seit einiger Zeit \(6 Monate bis 2 Jahre\)/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(
+      screen.getByRole("heading", {
+        name: /Wie ist der Diagnose-Status\?/i,
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: /Keine Diagnose, aber ich vermute Borderline/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("lässt das Notfall-Ergebnis dominant und ergänzt Diagnostik bei Verdacht", () => {
+    vi.useFakeTimers();
+    render(<Selbsttest />);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Akute Krise – Suizidgedanken, Selbstverletzung oder Gefahr/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: /Was beschäftigt Sie gerade am meisten\?/i,
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Ich verstehe nicht, was in meinem Angehörigen vorgeht/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: /Wie lange begleiten Sie Ihren Angehörigen schon\?/i,
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Seit kurzem \(unter 6 Monate\)/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: /Wie ist der Diagnose-Status\?/i,
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Keine Diagnose, aber ich vermute Borderline/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(
+      screen.getByRole("heading", {
+        name: /Wie geht es Ihnen selbst gerade\?/i,
+      })
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Überfordert – ich weiss nicht mehr weiter/i,
+      })
+    );
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(
+      screen.getByRole("heading", { name: /Sofortige Hilfe/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Zu den Notfallressourcen/i })
+    ).toHaveAttribute("href", "/soforthilfe");
+    expect(
+      screen.getByRole("link", { name: /Diagnostik einordnen/i })
+    ).toHaveAttribute("href", "/diagnostik");
+  });
+});

--- a/client/src/components/Selbsttest.tsx
+++ b/client/src/components/Selbsttest.tsx
@@ -1,4 +1,4 @@
-/* Interactive self-check with weighted routing and unchanged result logic. */
+/* Interactive self-check with weighted routing for Angehörigen-Orientierung. */
 import { useEffect, useRef, useState } from "react";
 import AppLink from "@/components/AppLink";
 import { motion, AnimatePresence } from "framer-motion";
@@ -91,7 +91,7 @@ const questions: Question[] = [
     subtext: "Dies hilft uns, passende Ressourcen zu empfehlen.",
     options: [
       {
-        text: "Die Diagnose ist neu (unter 6 Monate)",
+        text: "Seit kurzem (unter 6 Monate)",
         value: "neu",
         weight: { verstehen: 6, unterstuetzen: 4 },
       },
@@ -105,15 +105,43 @@ const questions: Question[] = [
         value: "lang",
         weight: { selbstfuersorge: 5, grenzen: 3, kommunizieren: 2 },
       },
-      {
-        text: "Keine offizielle Diagnose, aber ich vermute Borderline",
-        value: "vermutung",
-        weight: { verstehen: 7, unterstuetzen: 3 },
-      },
     ],
   },
   {
     id: 4,
+    text: "Wie ist der Diagnose-Status?",
+    subtext:
+      "Der Test dient der Orientierung für Angehörige, nicht der Selbstdiagnose.",
+    options: [
+      {
+        text: "Offizielle Diagnose liegt vor",
+        value: "diagnose",
+        weight: { unterstuetzen: 3, kommunizieren: 2, grenzen: 2 },
+      },
+      {
+        text: "Verdachtsdiagnose / Abklärung läuft",
+        value: "abklaerung",
+        weight: { diagnostik: 8, verstehen: 4 },
+      },
+      {
+        text: "Keine Diagnose, aber ich vermute Borderline",
+        value: "vermutung",
+        weight: { diagnostik: 8, verstehen: 5 },
+      },
+      {
+        text: "Die Diagnose wird abgelehnt",
+        value: "abgelehnt",
+        weight: { diagnostik: 7, kommunizieren: 3, grenzen: 3 },
+      },
+      {
+        text: "Ich weiss es nicht",
+        value: "unklar",
+        weight: { diagnostik: 7, verstehen: 5 },
+      },
+    ],
+  },
+  {
+    id: 5,
     text: "Wie geht es Ihnen selbst gerade?",
     options: [
       {
@@ -152,6 +180,18 @@ const results: Result[] = [
       { href: "/unterstuetzen/krise", text: "Krisenbegleitung lernen" },
     ],
     safetyCritical: true,
+  },
+  {
+    id: "diagnostik",
+    title: "Diagnostik einordnen",
+    description:
+      "Wenn Diagnose, Verdacht oder Ablehnung noch unklar sind, hilft eine ruhige Orientierung: Was spricht wofür, wer klärt ab und wie sprechen Sie darüber, ohne zu drängen?",
+    primaryLink: "/diagnostik",
+    primaryText: "Diagnostik verstehen",
+    secondaryLinks: [
+      { href: "/verstehen", text: "Borderline verstehen" },
+      { href: "/kommunizieren", text: "Über Diagnose sprechen" },
+    ],
   },
   {
     id: "krise",
@@ -257,6 +297,13 @@ const bodyStyle = {
   lineHeight: "var(--lh-relaxed)",
   color: "var(--fg-secondary)",
 };
+
+const diagnosisNeedsGuidance = new Set([
+  "abklaerung",
+  "vermutung",
+  "abgelehnt",
+  "unklar",
+]);
 
 // ─── Sub-components ──────────────────────────────────────
 
@@ -375,6 +422,10 @@ export default function Selbsttest() {
   };
 
   const getTopResult = (): Result => {
+    if (answers[1] === "akut") {
+      return results.find(r => r.id === "notfall") || results[0];
+    }
+
     let maxScore = 0;
     let topCategory = "verstehen";
 
@@ -385,7 +436,7 @@ export default function Selbsttest() {
       }
     });
 
-    return results.find(r => r.id === topCategory) || results[3];
+    return results.find(r => r.id === topCategory) || results[4];
   };
 
   const progress = ((currentQuestion + 1) / questions.length) * 100;
@@ -394,6 +445,17 @@ export default function Selbsttest() {
   if (showResult) {
     const result = getTopResult();
     const isSafetyCritical = result.safetyCritical === true;
+    const diagnosisStatus = answers[4];
+    const secondaryLinks =
+      diagnosisStatus && diagnosisNeedsGuidance.has(diagnosisStatus)
+        ? [
+            ...result.secondaryLinks,
+            ...(result.primaryLink === "/diagnostik" ||
+            result.secondaryLinks.some(link => link.href === "/diagnostik")
+              ? []
+              : [{ href: "/diagnostik", text: "Diagnostik einordnen" }]),
+          ]
+        : result.secondaryLinks;
 
     return (
       <motion.div
@@ -445,7 +507,7 @@ export default function Selbsttest() {
           </p>
 
           {/* Secondary Links */}
-          {result.secondaryLinks.length > 0 && (
+          {secondaryLinks.length > 0 && (
             <div
               className="mt-8 border-t pt-6"
               style={{ borderColor: "var(--rule-color)" }}
@@ -457,7 +519,7 @@ export default function Selbsttest() {
                 className="mt-3 flex flex-wrap gap-x-5 gap-y-1"
                 style={{ fontSize: "var(--text-md)" }}
               >
-                {result.secondaryLinks.map(link => (
+                {secondaryLinks.map(link => (
                   <AppLink
                     key={link.href + link.text}
                     href={link.href}

--- a/client/src/content/handoutTextVersionContent/genesung.content.ts
+++ b/client/src/content/handoutTextVersionContent/genesung.content.ts
@@ -19,7 +19,7 @@ export const handoutTextVersions = [
           },
           {
             title: "50%",
-            text: "erreichen eine vollständige Genesung im Sinn von Recovery.",
+            text: "erreichen eine umfassendere Genesung im Sinn von Recovery.",
           },
           {
             title: "77%",
@@ -64,7 +64,7 @@ export const handoutTextVersions = [
         title: "Begriffe kurz eingeordnet",
         calloutTitle: "Was die Grafik mit den Begriffen meint",
         calloutText:
-          "Remission meint eine deutliche Abnahme der Symptome. Recovery beschreibt vollständige Genesung. Anhaltende Remission meint eine stabilere Besserung über längere Zeit.",
+          "Remission meint eine deutliche Abnahme der Symptome. Recovery beschreibt eine umfassendere alltagsbezogene Genesung. Anhaltende Remission meint eine stabilere Besserung über längere Zeit.",
       },
       {
         title: "Was können Sie tun?",

--- a/client/src/content/handoutTextVersionContent/soforthilfe.content.ts
+++ b/client/src/content/handoutTextVersionContent/soforthilfe.content.ts
@@ -41,7 +41,7 @@ export const handoutTextVersions = [
         title: "Wichtiger Soforthinweis",
         calloutTitle: "Sicherheit vor Diskussion",
         calloutText:
-          "Person möglichst nicht allein lassen. Gefährliche Gegenstände, Medikamente, Alkohol oder andere Mittel wenn möglich entfernen. Bei Unsicherheit lieber einmal zu viel Hilfe holen als einmal zu wenig.",
+          "Die Person nach Möglichkeit nicht ohne Hilfe, Notfallplan oder professionelle Einschätzung allein lassen – sofern Sie selbst sicher bleiben können. Gefährliche Gegenstände, Medikamente, Alkohol oder andere Mittel wenn möglich entfernen. Bei Unsicherheit lieber einmal zu viel Hilfe holen als einmal zu wenig.",
       },
       {
         title:
@@ -84,7 +84,7 @@ export const handoutTextVersions = [
           "lange Diskussionen, warum das Leben doch schön sei",
           "argumentieren oder überzeugen wollen",
           "drohen oder bestrafen",
-          "die Person trotz akuter Gefahr allein lassen",
+          "die Person trotz akuter Gefahr ohne Hilfe oder Sicherheitsplan allein lassen",
           "Suizidgedanken als Geheimnis für sich behalten",
         ],
       },

--- a/client/src/content/quellenLinks.ts
+++ b/client/src/content/quellenLinks.ts
@@ -1,6 +1,8 @@
 export const quellenLinks = {
   apa2022: "/quellen#src-american-psychiatric-association-2022",
   apa2024: "/quellen#src-american-psychiatric-association-keepers-2024",
+  awmf2022:
+    "/quellen#src-arbeitsgemeinschaft-der-wissenschaftlichen-medizinischen-fachgesellschaften-awmf-2022",
   batemanFonagy2009: "/quellen#src-bateman-fonagy-2009",
   first2017: "/quellen#src-first-williamsw-benjamin-spitzer-2017",
   fruzzetti2006: "/quellen#src-fruzzetti-2006",
@@ -9,6 +11,7 @@ export const quellenLinks = {
   hoffman2005: "/quellen#src-hoffman-2005",
   icd11: "/quellen#src-world-health-organization-2019",
   ipde1999: "/quellen#src-loranger-1999",
+  lamberti2023: "/quellen#src-lamberti-2023",
   linehan1993: "/quellen#src-linehan-1993",
   linehan2015: "/quellen#src-linehan-2015",
   projectAir: "/quellen#src-project-air-strategy-laufend",

--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -1330,6 +1330,24 @@ export const searchableContent: SearchEntry[] = [
     section: "Krisenressourcen",
   },
   {
+    title: "Gewalt, Bedrohung oder Übergriff",
+    description:
+      "Soforthilfe bei häuslicher, körperlicher oder sexueller Gewalt: Polizei, Opferhilfe und Spurensicherung",
+    keywords: [
+      "gewalt",
+      "bedrohung",
+      "übergriff",
+      "opferhilfe",
+      "polizei",
+      "117",
+      "forensic nurses",
+      "spurensicherung",
+      "häusliche gewalt",
+    ],
+    href: "/soforthilfe",
+    section: "Krisenressourcen",
+  },
+  {
     title: "McLean-Studie & CLPS-Studie",
     description: "Langzeitstudien zur Remission bei Borderline",
     keywords: [
@@ -1581,7 +1599,34 @@ export const searchableContent: SearchEntry[] = [
   {
     title: "Wie schütze ich meine Kinder?",
     description: "FAQ: Kinder vor den Auswirkungen schützen",
-    keywords: ["kinder", "schützen", "schutz", "familie", "faq"],
+    keywords: [
+      "kinder",
+      "schützen",
+      "schutz",
+      "familie",
+      "kindeswohl",
+      "kesb",
+      "kjpd",
+      "schulpsychologischer dienst",
+      "elternnotruf",
+      "147",
+      "faq",
+    ],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
+    title: "Helfen Medikamente bei Borderline?",
+    description:
+      "FAQ: Was Medikamente leisten können und was sie nicht ersetzen",
+    keywords: [
+      "medikamente",
+      "borderline",
+      "tabletten",
+      "antidepressiva",
+      "symptome",
+      "faq",
+    ],
     href: "/faq",
     section: "FAQ",
   },
@@ -1622,8 +1667,19 @@ export const searchableContent: SearchEntry[] = [
     title: "Mythen und Einordnungen",
     description:
       "Häufige Missverständnisse über Borderline ruhig und differenziert eingeordnet",
-    keywords: ["mythos", "fakt", "vorurteil", "aufklärung", "einordnung"],
-    href: "/verstehen",
+    keywords: [
+      "mythos",
+      "fakt",
+      "vorurteil",
+      "aufklärung",
+      "einordnung",
+      "manipulation",
+      "frauen",
+      "männer",
+      "suizid ansprechen",
+      "schuld",
+    ],
+    href: "/verstehen#mythen-realitaet",
     section: "Verstehen",
   },
   {

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -9,11 +9,13 @@ import EvidenceNote from "@/components/EvidenceNote";
 import LastVerifiedBadge from "@/components/LastVerifiedBadge";
 import Layout from "@/components/Layout";
 import SEO, { FAQSchema } from "@/components/SEO";
+import { kontaktByIdStrict } from "@/data/kontakte";
 import { Link } from "wouter";
 
 interface FAQItem {
   question: string;
   answer: string;
+  bullets?: string[];
   links?: { text: string; url: string }[];
 }
 
@@ -41,6 +43,9 @@ function openSection(sectionId: string) {
     new CustomEvent("open-section", { detail: { sectionId } })
   );
 }
+
+const elternnotruf = kontaktByIdStrict("GRUEN_ELTERN");
+const proJuventute147 = kontaktByIdStrict("GRUEN_147");
 
 const faqCategories: FAQCategory[] = [
   {
@@ -174,16 +179,25 @@ const faqCategories: FAQCategory[] = [
       {
         question: "Darf ich meinen Angehörigen verlassen?",
         answer:
-          "Ja. Eine Beziehung zu beenden kann eine legitime und verantwortbare Entscheidung sein – auch wenn Ihr Angehöriger psychisch krank ist. Wenn die Beziehung Ihre psychische oder körperliche Gesundheit ernsthaft belastet oder gefährdet, braucht dieser Umstand ein grosses Gewicht. Wichtig ist, eine Trennung nach Möglichkeit nicht mitten in einer akuten Krise impulsiv zu vollziehen, sondern vorbereitet und mit Blick auf Sicherheit. Wenn es eine Behandlung gibt, kann es sinnvoll sein, Fachpersonen zu informieren. Und: Sie können eine Grenze ziehen oder gehen und trotzdem Mitgefühl behalten.",
+          "Ja. Eine Beziehung zu beenden kann eine legitime und verantwortbare Entscheidung sein – auch wenn Ihr Angehöriger psychisch krank ist. Wenn die Beziehung Ihre psychische oder körperliche Gesundheit ernsthaft belastet oder gefährdet, braucht dieser Umstand ein grosses Gewicht. Wichtig ist, eine Trennung nach Möglichkeit nicht mitten in einer akuten Krise impulsiv zu vollziehen, sondern vorbereitet, mit Blick auf Sicherheit und – wenn nötig – mit fachlicher Begleitung. Wenn Drohungen, Gewalt, Kinder oder Suizidankündigungen im Raum stehen, braucht es oft zuerst Schutzplanung und zusätzliche Beratung. Und: Sie können eine Grenze ziehen oder gehen und trotzdem Mitgefühl behalten.",
         links: [{ text: "Grenzen setzen", url: "/grenzen" }],
       },
       {
         question: "Wie schütze ich meine Kinder?",
         answer:
-          "Kinder brauchen Stabilität und Vorhersehbarkeit. Erklären Sie altersgerecht, dass Mama/Papa manchmal sehr starke Gefühle hat und das nicht die Schuld des Kindes ist. Schützen Sie Kinder vor eskalierenden Situationen – verlassen Sie mit ihnen den Raum, wenn nötig. Sorgen Sie für «Normalität»: Routinen, Freunde, Hobbys. Achten Sie auf Warnsignale beim Kind (Rückzug, Angst, Verhaltensänderungen) und holen Sie bei Bedarf professionelle Hilfe. Und: Kümmern Sie sich um sich selbst – ein stabiler Elternteil ist der beste Schutz für das Kind.",
+          "Wichtig ist, alltägliche Belastung, wiederholte Eskalation, Kindeswohlgefährdung und akute Gefahr auseinanderzuhalten. Nicht jede überforderte Familie braucht sofort eine Meldung – aber Kinder brauchen Schutz vor Gewalt, massiver Alarmstimmung und unberechenbaren Krisen. Erklären Sie altersgerecht, dass starke Gefühle nicht die Schuld des Kindes sind, und schützen Sie Kinder aktiv vor Eskalationen.",
+        bullets: [
+          "Im Alltag helfen Routinen, verlässliche Bezugspersonen, Schlaf, Schule, Freunde und eine einfache Sprache: «Bei uns ist es gerade schwer. Du hast daran keine Schuld.»",
+          `Bei wiederholten Eskalationen holen Sie früh Beratung dazu, zum Beispiel den ${elternnotruf.label} (${elternnotruf.nummer}). Zusätzlich kann eine Elternberatung wie die Pro Juventute Elternberatung 24/7 helfen.`,
+          `Wenn ein Kind selbst stark belastet ist, nennen Sie konkrete Anlaufstellen: ${proJuventute147.nummer} für Kinder und Jugendliche, der schulpsychologische Dienst, die Kinder- und Jugendpsychiatrie oder die örtliche Mütter-/Väterberatung.`,
+          "Bei ernsthafter Kindeswohlgefährdung – etwa bei Gewalt, massiver Vernachlässigung, Angst vor zuhause oder wenn ein Kind wiederholt Schutzräume braucht – ist eine Gefährdungsmeldung an die KESB oder eine lokale Kindesschutzstelle angemessen.",
+          "Bei akuter Gefahr gehen Sie mit dem Kind aus der Situation und holen Sie Hilfe über 117 oder 144.",
+        ],
         links: [
           { text: "Grenzen setzen", url: "/grenzen" },
           { text: "Selbstfürsorge als Elternteil", url: "/selbstfuersorge" },
+          { text: "Jugendliche & Diagnostik", url: "/diagnostik#jugendliche" },
+          { text: "Soforthilfe", url: "/soforthilfe" },
         ],
       },
       {
@@ -220,6 +234,15 @@ const faqCategories: FAQCategory[] = [
         ],
       },
       {
+        question: "Helfen Medikamente bei Borderline?",
+        answer:
+          "Medikamente «heilen» Borderline nicht. Sie können aber sinnvoll sein, wenn zusätzlich Depression, Angst, Schlafprobleme, starke innere Anspannung oder andere Begleiterkrankungen behandelt werden sollen. Wichtig ist: Einnahme, Umstellung oder Absetzen gehören in ärztliche Begleitung. Angehörige müssen nicht zum Medikamenten-Management werden – hilfreicher ist meist, Beobachtungen ruhig weiterzugeben und die Verantwortung bei der behandelnden Fachperson zu lassen.",
+        links: [
+          { text: "Begleiterkrankungen", url: "/begleiterkrankungen" },
+          { text: "Therapie begleiten", url: "/unterstuetzen/therapie" },
+        ],
+      },
+      {
         question: "Soll ich an der Therapie teilnehmen?",
         answer:
           "Wenn Sie eingeladen werden: Ja, das kann sehr hilfreich sein. Angehörigensitzungen oder Familiengespräche können Verständnis, Zusammenarbeit und Alltagstransfer verbessern. Sie lernen, wie Sie unterstützen können, ohne zu schaden, und der Therapeut kann Kommunikationsmuster beobachten. Wichtig: Gehen Sie nicht hin, um sich zu beschweren oder Recht zu bekommen. Ziel ist gemeinsames Lernen. Wenn Sie nicht eingeladen werden: Respektieren Sie das. Ihr Angehöriger braucht einen geschützten Raum. Sie können trotzdem eigene Beratung suchen.",
@@ -230,7 +253,7 @@ const faqCategories: FAQCategory[] = [
       {
         question: "Wie lange dauert die Behandlung?",
         answer:
-          "Borderline-Therapie ist keine Kurzzeitbehandlung: Rechnen Sie mit mindestens 1–3 Jahren für deutliche Verbesserungen. Stationäre Aufenthalte (z.B. DBT-Station) dauern typischerweise 8–12 Wochen und sind oft der Einstieg in eine längere ambulante Behandlung. Fortschritte sind nicht linear – Rückschläge sind normal und kein Zeichen von Versagen.",
+          "Borderline-Behandlung ist häufig längerfristig angelegt. Je nach Belastung, Komorbidität, Setting und Krisenverlauf können Monate bis mehrere Jahre relevant sein. Stationäre Aufenthalte (z.B. DBT-Station) dauern oft einige Wochen und sind eher ein Baustein als «die ganze Lösung». Fortschritte sind nicht linear – Rückschläge sind normal und kein Zeichen von Versagen.",
         links: [{ text: "Genesung & Prognose", url: "/genesung" }],
       },
     ],
@@ -408,6 +431,20 @@ export default function FAQ() {
                       >
                         <EditorialProse>
                           <p>{faq.answer}</p>
+                          {faq.bullets && faq.bullets.length > 0 && (
+                            <ul
+                              className="mt-4 space-y-2"
+                              style={{
+                                fontSize: "var(--text-md)",
+                                lineHeight: "var(--lh-relaxed)",
+                                color: "var(--fg-secondary)",
+                              }}
+                            >
+                              {faq.bullets.map(bullet => (
+                                <li key={bullet}>{bullet}</li>
+                              ))}
+                            </ul>
+                          )}
                           {faq.links && faq.links.length > 0 && (
                             <p className="mt-4 flex flex-wrap gap-x-5 gap-y-1">
                               {faq.links.map(link => (

--- a/client/src/pages/Glossar.tsx
+++ b/client/src/pages/Glossar.tsx
@@ -35,7 +35,7 @@ const glossaryTerms: GlossaryTerm[] = [
     abbreviation: "DBT",
     category: "therapie",
     definition:
-      "Die DBT ist die am besten erforschte Therapieform für Borderline. Sie wurde von Marsha Linehan entwickelt und kombiniert Verhaltenstherapie mit Achtsamkeitspraktiken. Der Begriff 'dialektisch' bezieht sich auf die Balance zwischen Akzeptanz (so wie es ist) und Veränderung (was besser werden kann).",
+      "Die DBT ist eine der am besten untersuchten und am breitesten etablierten Therapieformen für Borderline. Sie wurde von Marsha Linehan entwickelt und kombiniert Verhaltenstherapie mit Achtsamkeitspraktiken. Der Begriff 'dialektisch' bezieht sich auf die Balance zwischen Akzeptanz (so wie es ist) und Veränderung (was besser werden kann).",
     example:
       "In der DBT lernen Betroffene konkrete Fertigkeiten (Skills) zur Emotionsregulation, Stresstoleranz, zwischenmenschlichen Effektivität und Achtsamkeit.",
     relatedPage: "/unterstuetzen/therapie",
@@ -90,7 +90,7 @@ const glossaryTerms: GlossaryTerm[] = [
     term: "Recovery",
     category: "therapie",
     definition:
-      "Recovery geht über Remission hinaus und umfasst auch gutes soziales und berufliches Funktionieren sowie eine stabile Beziehung. Etwa 50% der Betroffenen erreichen nach 10 Jahren eine vollständige Recovery (Zanarini et al., 2012).",
+      "Recovery geht über Remission hinaus und meint eine umfassendere alltagsbezogene Genesung, also mehr funktionelle Stabilität in Beziehungen, Arbeit oder Ausbildung und im eigenen Leben. Etwa 50% der Betroffenen erreichen nach 10 Jahren eine solche umfassendere Genesung (Zanarini et al., 2012).",
     relatedPage: "/genesung",
     relatedPageTitle: "Genesung ist möglich",
   },

--- a/client/src/pages/Quellen.tsx
+++ b/client/src/pages/Quellen.tsx
@@ -38,6 +38,17 @@ const quellen: QuelleKategorie[] = [
         linkLabel: "PubMed",
       },
       {
+        autoren: "Lamberti, J.",
+        jahr: "2023",
+        titel:
+          "Sex differences in borderline personality disorder: A scoping review",
+        quelle: "Comprehensive Psychiatry 124, 152420",
+        hinweis:
+          "Scoping Review zu Geschlechtsunterschieden bei Borderline-Persönlichkeitsstörung. Hilfreich für die Einordnung, dass Borderline Menschen aller Geschlechter betreffen kann und klinische Darstellung oder Diagnosepfade unterschiedlich gelesen werden können.",
+        link: "https://pubmed.ncbi.nlm.nih.gov/36813014/",
+        linkLabel: "PubMed",
+      },
+      {
         autoren: "Zanarini, M. C. et al.",
         jahr: "2010",
         titel:
@@ -306,6 +317,17 @@ const quellen: QuelleKategorie[] = [
           "Aktuelle internationale Klassifikation mit Borderline pattern (6D11.5) als Spezifier innerhalb der Persönlichkeitsstörungen.",
         link: "https://icd.who.int/browse/2025-01/mms/en#2006821354",
         linkLabel: "WHO ICD-11",
+      },
+      {
+        autoren:
+          "Arbeitsgemeinschaft der Wissenschaftlichen Medizinischen Fachgesellschaften (AWMF)",
+        jahr: "2022",
+        titel: "S3-Leitlinie Persönlichkeitsstörungen",
+        quelle: "AWMF-Registernummer 038-015",
+        hinweis:
+          "Deutschsprachige Leitlinie zur Diagnostik und Behandlung von Persönlichkeitsstörungen. Ergänzt die internationale Quellenbasis um einen DACH-Bezug.",
+        link: "https://register.awmf.org/assets/guidelines/038-015l_S3_Persoenlichkeitsstoerungen_2022-10.pdf",
+        linkLabel: "AWMF PDF",
       },
       {
         autoren:

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -62,7 +62,7 @@ const ampelHandlungen = [
     items: [
       "Professionelle Hilfe holen",
       "Eigene Sicherheit sichern",
-      "Nicht allein lassen",
+      "Nicht ohne Hilfe oder Notfallplan allein lassen",
     ],
   },
   {
@@ -641,7 +641,9 @@ export default function UnterstuetzenKrise() {
                 <span className="text-alert" aria-hidden="true">
                   ✗
                 </span>
-                Die Person alleine lassen, wenn Suizidgefahr besteht
+                Die Person ohne Hilfe, Notfallplan oder professionelle
+                Einschätzung allein lassen – sofern Sie selbst sicher bleiben
+                können
               </li>
               <li className="flex items-start gap-2">
                 <span className="text-alert" aria-hidden="true">

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -72,7 +72,7 @@ const zusammenarbeitSzenarien = [
       "Direkt ansprechen (in stabiler Phase): «Mir scheint, dass die Therapie für dich gerade schwierig ist. Was macht sie dir schwierig?»",
       "Sie können Motivation nicht erzwingen – aber Sie können Interesse zeigen",
       "Nur bei Sicherheitsgefährdung: eigenständig Kontakt mit Therapeutin aufnehmen",
-      "Therapieverweigerung ist oft Teil des Krankheitsbildes – nicht persönlich nehmen",
+      "Therapieambivalenz kann viele Gründe haben – Scham, Angst, Überforderung, schlechte Erfahrungen oder Misstrauen. Nehmen Sie das nicht vorschnell persönlich.",
     ],
   },
   {

--- a/client/src/pages/Verstehen.tsx
+++ b/client/src/pages/Verstehen.tsx
@@ -526,6 +526,175 @@ export default function Verstehen() {
           </EditorialProse>
         </ContentSection>
 
+        <ContentSection
+          variant="editorial"
+          title="Häufige Mythen — und was realistischer ist"
+          id="mythen-realitaet"
+          preview="Viele Sätze über Borderline klingen eindeutig, greifen aber zu kurz. Eine realistischere Einordnung hilft Angehörigen, Betroffenen und Fachpersonen."
+        >
+          <EditorialProse>
+            <h4
+              style={{
+                fontSize: "var(--text-md)",
+                fontWeight: 600,
+                color: "var(--fg-primary)",
+              }}
+            >
+              «Borderline ist nicht behandelbar.»
+            </h4>
+            <p>
+              Realistischer ist: Borderline ist belastend, aber behandelbar.
+              Viele Menschen erleben über Jahre deutliche Besserungen, Remission
+              oder umfassendere Genesung — oft nicht geradlinig, aber gut
+              dokumentiert. Mehr dazu auf{" "}
+              <Link href="/genesung" className="editorial-link">
+                Genesung
+              </Link>
+              .
+            </p>
+
+            <h4
+              className="mt-6"
+              style={{
+                fontSize: "var(--text-md)",
+                fontWeight: 600,
+                color: "var(--fg-primary)",
+              }}
+            >
+              «Menschen mit Borderline manipulieren bewusst.»
+            </h4>
+            <p>
+              Manche Verhaltensweisen können auf Angehörige manipulativ wirken.
+              Hilfreicher ist aber oft die Frage, welche innere Not, Angst,
+              Scham oder Überflutung darunter mitläuft. Das entschuldigt
+              destruktives Verhalten nicht, macht es aber genauer lesbar. Mehr
+              dazu auf{" "}
+              <Link href="/kommunizieren" className="editorial-link">
+                Kommunizieren
+              </Link>{" "}
+              und{" "}
+              <Link href="/grenzen" className="editorial-link">
+                Grenzen
+              </Link>
+              .
+            </p>
+
+            <h4
+              className="mt-6"
+              style={{
+                fontSize: "var(--text-md)",
+                fontWeight: 600,
+                color: "var(--fg-primary)",
+              }}
+            >
+              «Angehörige sind schuld.»
+            </h4>
+            <p>
+              Borderline entsteht nicht durch eine einzelne Person und nicht
+              durch «falsche Liebe». Angehörige können Beziehungsmuster
+              entlasten oder belasten, sie verursachen die Störung aber nicht.
+              Schuld hilft weder Verständnis noch Veränderung.
+            </p>
+
+            <h4
+              className="mt-6"
+              style={{
+                fontSize: "var(--text-md)",
+                fontWeight: 600,
+                color: "var(--fg-primary)",
+              }}
+            >
+              «Grenzen setzen ist lieblos.»
+            </h4>
+            <p>
+              Grenzen sind kein Verrat, sondern oft die Voraussetzung dafür,
+              dass Beziehung tragfähig bleibt. Sie schützen Sie selbst und
+              schaffen mehr Orientierung als wechselnde Nachgiebigkeit.
+            </p>
+
+            <h4
+              className="mt-6"
+              style={{
+                fontSize: "var(--text-md)",
+                fontWeight: 600,
+                color: "var(--fg-primary)",
+              }}
+            >
+              «Suizid direkt anzusprechen macht es schlimmer.»
+            </h4>
+            <p>
+              Bei konkreter Sorge ist das Gegenteil hilfreicher: ruhig, klar und
+              direkt fragen. Offenes Ansprechen erhöht das Risiko nicht, sondern
+              zeigt, dass Sie die Lage ernst nehmen und Hilfe einbeziehen. Mehr
+              dazu auf{" "}
+              <Link href="/soforthilfe" className="editorial-link">
+                Soforthilfe
+              </Link>
+              .
+            </p>
+
+            <h4
+              className="mt-6"
+              style={{
+                fontSize: "var(--text-md)",
+                fontWeight: 600,
+                color: "var(--fg-primary)",
+              }}
+            >
+              «Wenn jemand bei anderen stabiler wirkt, spielt er oder sie nur.»
+            </h4>
+            <p>
+              Enge Beziehungen aktivieren oft genau die Muster, die bei Fremden
+              weniger sichtbar sind. Mehr Stabilität in anderen Kontexten ist
+              deshalb nicht automatisch Täuschung, sondern kann Ausdruck
+              unterschiedlicher Bindungsbelastung sein.
+            </p>
+
+            <h4
+              className="mt-6"
+              style={{
+                fontSize: "var(--text-md)",
+                fontWeight: 600,
+                color: "var(--fg-primary)",
+              }}
+            >
+              «Borderline betrifft nur Frauen.»
+            </h4>
+            <p>
+              Borderline kann Menschen aller Geschlechter betreffen. Männer
+              suchen teilweise später Hilfe oder werden mit anderen
+              Problembildern gelesen, etwa Substanzkonsum, Wut oder Rückzug.
+              Angehörige männlicher Betroffener sind hier ausdrücklich mit
+              gemeint.
+            </p>
+          </EditorialProse>
+          <EvidenceNote
+            variant="editorial"
+            title="Quellen zu Mythen, Verlauf und Geschlecht"
+            definition="Die Einordnungen stützen sich auf Behandlungsforschung, Verlaufsstudien und eine Übersichtsarbeit zu Geschlechtsunterschieden."
+            sources={[
+              {
+                label:
+                  "Storebø et al. (2020) – Psychotherapien bei Borderline (Cochrane Review)",
+                href: quellenLinks.storebo2020,
+                type: "wissenschaft",
+              },
+              {
+                label:
+                  "Zanarini et al. (2012) – Remission und Recovery im Langzeitverlauf",
+                href: quellenLinks.zanarini2012,
+                type: "wissenschaft",
+              },
+              {
+                label:
+                  "Lamberti (2023) – Geschlechtsunterschiede bei Borderline (Scoping Review)",
+                href: quellenLinks.lamberti2023,
+                type: "wissenschaft",
+              },
+            ]}
+          />
+        </ContentSection>
+
         <VerstehenDiagnosticSection />
 
         <VerstehenMaterialsSection />


### PR DESCRIPTION
## Summary
- extend the static `/soforthilfe` page with violence and victim-support contacts
- make child-protection guidance, crisis wording, and therapy wording more specific and safety-aware
- split Selbsttest duration from diagnosis status and route unclear cases toward diagnostics
- add a myths-and-reality section plus source and search-index updates

## Why
This addresses the latest content review around safety gaps, stigma reduction, and clearer diagnostic orientation for Angehörige.

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
