### PR TITLE
[codex] Add language and source follow-up content

### DIFF
--- a/client/src/content/searchIndex.ts
+++ b/client/src/content/searchIndex.ts
@@ -1616,6 +1616,25 @@ export const searchableContent: SearchEntry[] = [
     section: "FAQ",
   },
   {
+    title:
+      "Was, wenn Deutsch nicht die Hauptsprache ist oder psychische Erkrankung tabuisiert ist?",
+    description:
+      "FAQ: Hilfe suchen, wenn Sprache, Scham oder Migration Gespräche erschweren",
+    keywords: [
+      "sprache",
+      "dolmetschung",
+      "migration",
+      "kulturell",
+      "scham",
+      "tabu",
+      "familie",
+      "übersetzen",
+      "faq",
+    ],
+    href: "/faq",
+    section: "FAQ",
+  },
+  {
     title: "Helfen Medikamente bei Borderline?",
     description:
       "FAQ: Was Medikamente leisten können und was sie nicht ersetzen",

--- a/client/src/pages/Begleiterkrankungen.tsx
+++ b/client/src/pages/Begleiterkrankungen.tsx
@@ -470,6 +470,36 @@ export default function Begleiterkrankungen() {
               davon ab, was gerade am dringendsten Stabilität braucht.
             </EditorialPullQuote>
           </div>
+          <EvidenceNote
+            variant="editorial"
+            title="Quellen zu Komorbidität und Medikation"
+            definition="Hohe Komorbiditätsraten bei Borderline sind gut belegt. Leitlinien empfehlen zugleich, Borderline selbst nicht primär medikamentös zu behandeln, Medikation aber bei Begleiterkrankungen gezielt einzusetzen."
+            sources={[
+              {
+                label:
+                  "APA Practice Guideline (2024) – Behandlung von Borderline-Persönlichkeitsstörung",
+                href: quellenLinks.apa2024,
+                type: "wissenschaft",
+              },
+              {
+                label: "AWMF S3-Leitlinie Persönlichkeitsstörungen (2022)",
+                href: quellenLinks.awmf2022,
+                type: "wissenschaft",
+              },
+              {
+                label:
+                  "Zanarini et al. (1998) – Achse-I-Komorbidität bei Borderline",
+                href: quellenLinks.zanarini1998,
+                type: "wissenschaft",
+              },
+              {
+                label:
+                  "Zanarini et al. (2004) – Verlauf häufiger Komorbiditäten",
+                href: quellenLinks.zanarini2004,
+                type: "wissenschaft",
+              },
+            ]}
+          />
         </ContentSection>
 
         {/* ── 7: Auch bei Ihnen (Mini-Sektion) ── */}

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -267,6 +267,22 @@ const faqCategories: FAQCategory[] = [
           "Sie müssen nicht alles erklären. Sagen Sie so viel, wie Sie möchten: «Eine mir nahestehende Person hat eine psychische Erkrankung, die starke Stimmungsschwankungen auslösen kann. Wir arbeiten daran.» Sie können auch Grenzen setzen: «Ich möchte nicht ins Detail gehen, aber ich schätze eure Unterstützung.» Wählen Sie sorgfältig aus, wem Sie was erzählen – nicht jeder muss alles wissen. Und: Bitten Sie um konkrete Hilfe statt allgemeinem Mitleid («Könntest du nächste Woche auf die Kinder aufpassen?»).",
       },
       {
+        question:
+          "Was, wenn Deutsch nicht die Hauptsprache ist oder psychische Erkrankung in unserer Familie tabuisiert ist?",
+        answer:
+          "Das ist häufiger, als viele denken. Hilfe kann auch dann sinnvoll sein, wenn das Wort «Borderline» in der Familie noch gar nicht fällt. Oft ist es leichter, zuerst über das Beobachtbare zu sprechen: Schlaf, Alarmzustand, Rückzug, Wutausbrüche, Selbstverletzung, Angst, Schule, Arbeit oder Sicherheit.",
+        bullets: [
+          "Verwenden Sie kurze, konkrete Sätze statt Fachsprache. Nicht jede Familie muss zuerst die Diagnose akzeptieren, bevor Unterstützung beginnen darf.",
+          "Fragen Sie in Praxis, Klinik oder Beratungsstelle ausdrücklich nach professioneller Dolmetschung, wenn Deutsch nicht für alle sicher genug ist. Gerade bei Diagnose-, Krisen- oder Gewaltgesprächen sollten Kinder diese Rolle nicht übernehmen müssen.",
+          "Wenn Scham, Angst vor Stigmatisierung oder Unsicherheit gegenüber Behörden gross sind, benennen Sie zuerst das Ziel: Schutz, Entlastung, weniger Eskalation, mehr Schlaf oder Sicherheit für die Kinder.",
+          "Bei akuter Gefahr gilt trotzdem: Sicherheit geht vor. Dann lieber früh Hilfe holen, auch wenn noch nicht alle Begriffe, Hintergründe oder Familienkonflikte geklärt sind.",
+        ],
+        links: [
+          { text: "Therapie begleiten", url: "/unterstuetzen/therapie" },
+          { text: "Soforthilfe", url: "/soforthilfe" },
+        ],
+      },
+      {
         question: "Wie gehe ich mit Eifersucht und Kontrolle um?",
         answer:
           "Eifersucht bei Borderline wurzelt aus Angehörigensicht häufig in Verlassensangst, nicht nur in Misstrauen. Verstehen Sie das, ohne es zu akzeptieren. Setzen Sie klare Grenzen: «Ich werde mein Handy nicht zeigen. Ich habe nichts zu verbergen, aber ich brauche Privatsphäre.» Geben Sie nicht nach, um Ruhe zu haben – das verstärkt das Muster. Gleichzeitig: Seien Sie transparent, wo es Ihnen möglich ist, ohne sich zu verbiegen. Ermutigen Sie Ihren Angehörigen, die Eifersucht in der Therapie zu bearbeiten.",

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -409,7 +409,7 @@ export default function UnterstuetzenTherapie() {
           <EvidenceNote
             variant="editorial"
             title="Quellen zu Therapieverfahren und Angehörigenprogrammen"
-            definition="DBT, MBT und andere BPS-spezifische Psychotherapien sind die am besten untersuchten Verfahren. Für Angehörige sind zusätzlich psychoedukative Programme wie Family Connections relevant."
+            definition="DBT, MBT und andere BPS-spezifische Psychotherapien sind die am besten untersuchten Verfahren. Für Angehörige sind psychoedukative Programme wie Family Connections nicht nur entlastend, sondern ebenfalls wissenschaftlich beschrieben."
             sources={[
               {
                 label:
@@ -431,6 +431,12 @@ export default function UnterstuetzenTherapie() {
               {
                 label: "Hoffman et al. (2005) – Family Connections",
                 href: quellenLinks.hoffman2005,
+                type: "wissenschaft",
+              },
+              {
+                label:
+                  "Gunderson, Berkowitz & Ruiz-Sancho (1997) – psychoedukative Familienarbeit",
+                href: quellenLinks.gunderson1997,
                 type: "wissenschaft",
               },
             ]}
@@ -459,6 +465,30 @@ export default function UnterstuetzenTherapie() {
                 suchen
               </li>
             </ul>
+            <p>
+              Wenn Sprache, Scham oder Migrationserfahrungen Gespräche
+              erschweren, ist das kein Ausschlusskriterium für Behandlung.
+              Hilfreich ist oft, zunächst über das Beobachtbare zu sprechen:
+              Schlaf, Alarmzustand, Rückzug, Selbstverletzung, Wut oder
+              Sicherheit. Fragen Sie in Praxis, Klinik oder Beratung aktiv nach
+              professioneller Dolmetschung, wenn Deutsch nicht für alle sicher
+              genug ist. Kinder sollten Diagnose-, Krisen- oder Gewaltgespräche
+              nicht dolmetschen müssen.
+            </p>
+            <p>
+              Und: Sie müssen nicht warten, bis die betroffene Person sofort
+              mitzieht. Psychoedukative Angehörigenprogramme wie Family
+              Connections sind nicht nur entlastende Zusatzangebote, sondern
+              fachlich beschrieben. Mehr dazu finden Sie auf der{" "}
+              <Link href="/quellen" className="editorial-link">
+                Quellen-Seite
+              </Link>{" "}
+              und unter{" "}
+              <Link href="/selbsthilfegruppen" className="editorial-link">
+                Selbsthilfegruppen & Netzwerke
+              </Link>
+              .
+            </p>
           </EditorialProse>
         </ContentSection>
 


### PR DESCRIPTION
## Summary
- add a new FAQ answer for language barriers, stigma, and migration-related stress in families
- make the therapy page more explicit about professional interpreting and the evidence basis of family programmes
- add a visible evidence note for medication and comorbidity guidance and index the new FAQ in search

## Why
Most of the earlier content review had already been addressed. This PR closes the remaining small content gaps around language-sensitive support and makes key source connections more visible where readers actually need them.

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
