### PR TITLE
[codex] Centralize review governance badges

### DIFF
--- a/client/src/__tests__/page-governance.test.ts
+++ b/client/src/__tests__/page-governance.test.ts
@@ -2,6 +2,22 @@ import { describe, expect, it } from "vitest";
 import { pageGovernance } from "@/data/pageGovernance";
 
 const isoDatePattern = /^\d{4}-\d{2}-\d{2}$/;
+const governanceBackedBadgePaths = [
+  "/beratung",
+  "/begleiterkrankungen",
+  "/datenschutz",
+  "/diagnostik",
+  "/fachstelle",
+  "/faq",
+  "/genesung",
+  "/grenzen",
+  "/notfallkarte",
+  "/notfallkarte/erstellen",
+  "/quellen",
+  "/unterstuetzen/alltag",
+  "/unterstuetzen/krise",
+  "/unterstuetzen/therapie",
+] as const;
 
 describe("pageGovernance", () => {
   it("sets review metadata for every high-risk page", () => {
@@ -30,6 +46,19 @@ describe("pageGovernance", () => {
         meta.nextReviewDue > meta.lastReviewed,
         `${path} nextReviewDue must be after lastReviewed`
       ).toBe(true);
+    }
+  });
+
+  it("covers every path-backed review or verification badge", () => {
+    for (const path of governanceBackedBadgePaths) {
+      expect(
+        pageGovernance[path],
+        `${path} needs governance metadata for badge rendering`
+      ).toBeDefined();
+      expect(
+        pageGovernance[path]?.lastReviewed,
+        `${path} needs lastReviewed for LastVerifiedBadge`
+      ).toMatch(isoDatePattern);
     }
   });
 });

--- a/client/src/data/pageGovernance.ts
+++ b/client/src/data/pageGovernance.ts
@@ -70,7 +70,31 @@ export const pageGovernance: Record<string, PageGovernance> = {
     nextReviewDue: "2026-10-31",
     owner: DEFAULT_OWNER,
   },
+  "/faq": {
+    riskLevel: "high",
+    lastReviewed: "2026-04-16",
+    nextReviewDue: "2026-10-16",
+    owner: DEFAULT_OWNER,
+  },
+  "/unterstuetzen/therapie": {
+    riskLevel: "high",
+    lastReviewed: "2026-04-16",
+    nextReviewDue: "2026-10-16",
+    owner: DEFAULT_OWNER,
+  },
+  "/fachstelle": {
+    riskLevel: "high",
+    lastReviewed: "2026-03-24",
+    nextReviewDue: "2026-09-24",
+    owner: DEFAULT_OWNER,
+  },
   "/verstehen": {
+    riskLevel: "medium",
+    lastReviewed: "2026-04-30",
+    nextReviewDue: "2027-04-30",
+    owner: DEFAULT_OWNER,
+  },
+  "/genesung": {
     riskLevel: "medium",
     lastReviewed: "2026-04-30",
     nextReviewDue: "2027-04-30",
@@ -86,6 +110,12 @@ export const pageGovernance: Record<string, PageGovernance> = {
     riskLevel: "medium",
     lastReviewed: "2026-04-30",
     nextReviewDue: "2027-04-30",
+    owner: DEFAULT_OWNER,
+  },
+  "/unterstuetzen/alltag": {
+    riskLevel: "medium",
+    lastReviewed: "2026-04-16",
+    nextReviewDue: "2027-04-16",
     owner: DEFAULT_OWNER,
   },
 };

--- a/client/src/pages/FAQ.tsx
+++ b/client/src/pages/FAQ.tsx
@@ -388,7 +388,7 @@ export default function FAQ() {
             Vollständig ca. 18 Min · Springen Sie zu einer Frage über das
             Inhaltsverzeichnis.
           </p>
-          <LastVerifiedBadge date="16.04.2026" className="mt-6" />
+          <LastVerifiedBadge path="/faq" className="mt-6" />
         </header>
 
         {/* ── Hinweis (vorher Card) ── */}

--- a/client/src/pages/Fachstelle.tsx
+++ b/client/src/pages/Fachstelle.tsx
@@ -114,7 +114,7 @@ export default function Fachstelle() {
           >
             Vollständig ca. 4 Min · Auch abschnittweise lesbar.
           </p>
-          <LastVerifiedBadge date="24.03.2026" className="mt-6" />
+          <LastVerifiedBadge path="/fachstelle" className="mt-6" />
         </header>
 
         {/* ── Unser Angebot ── */}

--- a/client/src/pages/Selbsthilfegruppen.tsx
+++ b/client/src/pages/Selbsthilfegruppen.tsx
@@ -379,7 +379,7 @@ export default function Selbsthilfegruppen() {
               style={{ borderColor: "var(--rule-color)" }}
             >
               <p style={subBlockTitleStyle}>HelpLine-Zeiten</p>
-              <LastVerifiedBadge date="24.03.2026" />
+              <LastVerifiedBadge path={canonicalPath} />
               <dl
                 className="grid grid-cols-[max-content_1fr] gap-x-6 gap-y-1"
                 style={bodyStyle}
@@ -411,7 +411,7 @@ export default function Selbsthilfegruppen() {
               {vaskZhTreffpunkte.map(treff => (
                 <div key={treff.titel} className="space-y-1">
                   <p style={subBlockTitleStyle}>{treff.titel}</p>
-                  <LastVerifiedBadge date="24.03.2026" />
+                  <LastVerifiedBadge path={canonicalPath} />
                   <p style={bodyStyle}>{treff.beschreibung}</p>
                   <p style={bodyStyle}>
                     <span className="uppercase" style={labelStyle}>

--- a/client/src/pages/UnterstuetzenAlltag.tsx
+++ b/client/src/pages/UnterstuetzenAlltag.tsx
@@ -312,7 +312,7 @@ export default function UnterstuetzenAlltag() {
           >
             Vollständig ca. 8 Min · Auch abschnittweise lesbar.
           </p>
-          <LastVerifiedBadge date="16.04.2026" className="mt-6" />
+          <LastVerifiedBadge path="/unterstuetzen/alltag" className="mt-6" />
         </header>
 
         {/* ── Intro: Was diese Seite im Alltag ordnet ── */}

--- a/client/src/pages/UnterstuetzenTherapie.tsx
+++ b/client/src/pages/UnterstuetzenTherapie.tsx
@@ -222,7 +222,7 @@ export default function UnterstuetzenTherapie() {
           >
             Vollständig ca. 10 Min · Auch abschnittweise lesbar.
           </p>
-          <LastVerifiedBadge date="16.04.2026" className="mt-6" />
+          <LastVerifiedBadge path="/unterstuetzen/therapie" className="mt-6" />
         </header>
 
         {/* ── Intro: Was diese Seite bei Therapie ordnet ── */}


### PR DESCRIPTION
## What changed
- moved the remaining hard-coded `LastVerifiedBadge` dates onto central `pageGovernance` metadata
- added governance entries for `/faq`, `/unterstuetzen/therapie`, `/unterstuetzen/alltag`, `/fachstelle`, and `/genesung`
- updated the Beratung sub-block badges to reuse the existing canonical governance path
- added a regression test so every path-backed review/verification badge must have governance metadata

## Why
A few pages were still maintaining review dates inline, which made review metadata easier to drift and left one existing path-backed badge (`/genesung`) without a matching governance entry.

## Impact
Review and verification badges now resolve from one source of truth, and future path-backed badge additions are protected by test coverage.

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
