### PR TITLE
[codex] Fix notfallkarte and navigation regressions

### DIFF
--- a/client/src/__tests__/app-link.test.tsx
+++ b/client/src/__tests__/app-link.test.tsx
@@ -13,6 +13,7 @@ describe("AppLink", () => {
   it("classifies static crisis routes and assets as hard navigation", () => {
     expect(isHardNavigationHref("/soforthilfe")).toBe(true);
     expect(isHardNavigationHref("/notfall")).toBe(true);
+    expect(isHardNavigationHref("/notfallkarte")).toBe(true);
     expect(isHardNavigationHref("/notfallplan-krise-v03.pdf")).toBe(true);
     expect(isHardNavigationHref("/verstehen")).toBe(false);
   });

--- a/client/src/__tests__/datenschutz.test.tsx
+++ b/client/src/__tests__/datenschutz.test.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ElementType, HTMLAttributes, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { pageGovernance } from "@/data/pageGovernance";
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 import Datenschutz from "@/pages/Datenschutz";
 
 const MOTION_PROPS = new Set([
@@ -76,5 +78,19 @@ describe("Datenschutz", () => {
     expect(document.body).toHaveTextContent(
       /verwendet für ihre Einträge kein Cookie/i
     );
+  });
+
+  it("links the related card to the personal notfallkarte and keeps the stand in sync", () => {
+    render(<Datenschutz />);
+
+    const lastReviewed = pageGovernance["/datenschutz"]?.lastReviewed;
+    const expectedDate = lastReviewed?.split("-").reverse().join(".");
+
+    expect(
+      screen.getByRole("link", { name: /persönliche notfallkarte/i })
+    ).toHaveAttribute("href", PERSONAL_NOTFALLKARTE_PATH);
+    expect(
+      screen.getByText(new RegExp(`Stand der Erklärung: ${expectedDate}`))
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/__tests__/notfallkarte-storage.test.tsx
+++ b/client/src/__tests__/notfallkarte-storage.test.tsx
@@ -114,10 +114,34 @@ describe("Notfallkarte storage fallbacks", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /jetzt drucken/i }));
 
-    expect(openSpy).toHaveBeenCalledWith("/notfallkarte-print.html", "_blank");
+    expect(openSpy).toHaveBeenCalledWith(
+      "/notfallkarte-print.html?print=1",
+      "_blank"
+    );
     expect(postMessage).toHaveBeenCalledWith(
       expect.objectContaining({ type: "notfallkarte-print-data" }),
       window.location.origin
+    );
+  });
+
+  it("limits personal contacts to the three slots available in the print view", () => {
+    renderPage();
+
+    const addButton = screen.getByRole("button", {
+      name: /kontakt hinzufügen/i,
+    });
+
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+    fireEvent.click(addButton);
+
+    expect(
+      screen.getAllByRole("textbox", { name: /name der kontaktperson/i })
+    ).toHaveLength(3);
+    expect(addButton).toBeDisabled();
+    expect(addButton).toHaveAttribute(
+      "title",
+      "Maximal drei Kontaktpersonen für die Druckversion"
     );
   });
 

--- a/client/src/components/AppLink.tsx
+++ b/client/src/components/AppLink.tsx
@@ -1,7 +1,11 @@
 import { forwardRef } from "react";
 import { Link } from "wouter";
 
-const HARD_NAVIGATION_PATHS = new Set(["/notfall", "/soforthilfe"]);
+const HARD_NAVIGATION_PATHS = new Set([
+  "/notfall",
+  "/notfallkarte",
+  "/soforthilfe",
+]);
 const HARD_NAVIGATION_EXTENSION = /\.(?:html|pdf|webp|png|jpe?g|svg)$/i;
 const EXTERNAL_HREF_PATTERN = /^(?:[a-z][a-z\d+\-.]*:|\/\/)/i;
 

--- a/client/src/components/ContentSection.tsx
+++ b/client/src/components/ContentSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronDown } from "lucide-react";
 
@@ -39,7 +39,7 @@ export default function ContentSection({
     isOpenRef.current = isOpen;
   }, [isOpen]);
 
-  const scrollToSection = () => {
+  const scrollToSection = useCallback(() => {
     if (!sectionRef.current) return;
     const header = document.querySelector("header");
     const headerHeight = header?.getBoundingClientRect().height || 80;
@@ -47,7 +47,24 @@ export default function ContentSection({
     const top =
       sectionRef.current.getBoundingClientRect().top + window.scrollY - offset;
     window.scrollTo({ top, behavior: "smooth" });
-  };
+  }, []);
+
+  const openFromHash = useCallback(() => {
+    if (!id) return;
+
+    const hashTarget = decodeURIComponent(
+      window.location.hash.replace(/^#/, "")
+    );
+    if (hashTarget !== id) return;
+
+    if (!isOpenRef.current) {
+      pendingScrollRef.current = true;
+      setIsOpen(true);
+      return;
+    }
+
+    scrollToSection();
+  }, [id, scrollToSection]);
 
   // Auf Custom Event "open-section" lauschen
   useEffect(() => {
@@ -67,7 +84,18 @@ export default function ContentSection({
 
     window.addEventListener("open-section", handleOpenSection);
     return () => window.removeEventListener("open-section", handleOpenSection);
-  }, [id]);
+  }, [id, scrollToSection]);
+
+  useEffect(() => {
+    if (!id) return;
+
+    const handleHashChange = () => openFromHash();
+
+    openFromHash();
+    window.addEventListener("hashchange", handleHashChange);
+
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, [id, openFromHash]);
 
   // Nach dem Öffnen (State-Wechsel) sanft scrollen
   useEffect(() => {
@@ -79,42 +107,43 @@ export default function ContentSection({
       }, 100);
       return () => clearTimeout(timer);
     }
-  }, [isOpen]);
+  }, [isOpen, scrollToSection]);
 
   return (
     <div
       ref={sectionRef}
       id={id}
+      data-content-section=""
       className="border-t"
       style={{ borderColor: "var(--rule-color)" }}
     >
-      <button
-        type="button"
-        onClick={() => setIsOpen(open => !open)}
-        className="group flex w-full items-center justify-between gap-3 py-5 text-left transition-opacity hover:opacity-80 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]"
-        aria-expanded={isOpen}
-        aria-controls={id ? `section-content-${id}` : undefined}
-        aria-label={`Abschnitt ${title} ${isOpen ? "zuklappen" : "aufklappen"}`}
+      <h2
+        className="font-display"
+        style={{
+          fontSize: "var(--text-xl)",
+          lineHeight: "var(--lh-snug)",
+          color: "var(--fg-primary)",
+          fontWeight: "var(--weight-display)",
+        }}
       >
-        <h2
-          className="font-display"
-          style={{
-            fontSize: "var(--text-xl)",
-            lineHeight: "var(--lh-snug)",
-            color: "var(--fg-primary)",
-            fontWeight: "var(--weight-display)",
-          }}
+        <button
+          type="button"
+          onClick={() => setIsOpen(open => !open)}
+          className="group flex w-full items-center justify-between gap-3 py-5 text-left transition-opacity hover:opacity-80 focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--accent-primary)]"
+          aria-expanded={isOpen}
+          aria-controls={id ? `section-content-${id}` : undefined}
+          aria-label={`Abschnitt ${title} ${isOpen ? "zuklappen" : "aufklappen"}`}
         >
-          {title}
-        </h2>
-        <ChevronDown
-          className={`h-5 w-5 flex-shrink-0 transition-transform duration-200 ${
-            isOpen ? "rotate-180" : ""
-          }`}
-          style={{ color: "var(--fg-tertiary)" }}
-          aria-hidden="true"
-        />
-      </button>
+          <span>{title}</span>
+          <ChevronDown
+            className={`h-5 w-5 flex-shrink-0 transition-transform duration-200 ${
+              isOpen ? "rotate-180" : ""
+            }`}
+            style={{ color: "var(--fg-tertiary)" }}
+            aria-hidden="true"
+          />
+        </button>
+      </h2>
       {!isOpen && preview && (
         <p
           className="-mt-2 mb-5 line-clamp-2"

--- a/client/src/components/ScrollToTop.tsx
+++ b/client/src/components/ScrollToTop.tsx
@@ -17,19 +17,26 @@ export default function ScrollToTop() {
   const [location] = useLocation();
 
   useEffect(() => {
+    const hasHashTarget = window.location.hash.length > 1;
+
     // Deaktiviere Browser's automatische Scroll-Restoration
     if ("scrollRestoration" in history) {
       history.scrollRestoration = "manual";
     }
 
-    // Scrolle nach oben bei Route-Wechsel
-    window.scrollTo(0, 0);
+    // Scrolle nur dann nach oben, wenn keine Hash-Navigation
+    // auf einen konkreten Abschnitt zeigt.
+    if (!hasHashTarget) {
+      window.scrollTo(0, 0);
+    }
 
     // A11y: Focus auf <main> setzen, damit Screen-Reader-Nutzer
     // die Navigation wahrnehmen. preventScroll, da wir oben bereits
     // gescrollt haben. :focus-visible feuert nicht bei programmatic
     // focus, daher kein sichtbarer Focus-Ring.
-    document.getElementById("main-content")?.focus({ preventScroll: true });
+    if (!hasHashTarget) {
+      document.getElementById("main-content")?.focus({ preventScroll: true });
+    }
   }, [location]);
 
   useEffect(() => {

--- a/client/src/components/UXEnhancements.tsx
+++ b/client/src/components/UXEnhancements.tsx
@@ -137,12 +137,29 @@ export function TableOfContents() {
   useEffect(() => {
     // Kurz warten, damit ContentSections gerendert sind
     const timer = setTimeout(() => {
-      const elements = document.querySelectorAll("h2, h3");
+      const mainContent = document.getElementById("main-content");
+      if (!mainContent) {
+        setHeadings([]);
+        setActiveId("");
+        return;
+      }
+
+      const elements = mainContent.querySelectorAll("h2, h3");
       const items: TOCItem[] = [];
 
       elements.forEach((el, index) => {
+        if (
+          el.closest(
+            "nav, aside, footer, [role='dialog'], [aria-labelledby='related-links-editorial-heading']"
+          )
+        ) {
+          return;
+        }
+
         // Prüfen ob das Heading innerhalb einer ContentSection liegt
-        const contentSectionWrapper = el.closest("[id]:not(h2):not(h3)");
+        const contentSectionWrapper = el.closest(
+          "[data-content-section], [id]:not(h2):not(h3)"
+        );
         const isInsideContentSection =
           contentSectionWrapper?.querySelector("[aria-expanded]") !== null;
 
@@ -176,7 +193,7 @@ export function TableOfContents() {
     }, 200);
 
     return () => clearTimeout(timer);
-  }, []);
+  }, [location]);
 
   // Scroll-basierte aktive Markierung
   useEffect(() => {

--- a/client/src/components/layout/MobileMenu.tsx
+++ b/client/src/components/layout/MobileMenu.tsx
@@ -9,6 +9,7 @@ import {
 import { navItems, ressourcenItems } from "@/components/layout/navigationData";
 import { getRouteAccent } from "@/components/layout/routeAccent";
 import { useFocusTrap } from "@/hooks/useFocusTrap";
+import { useScrollLock } from "@/hooks/useScrollLock";
 
 interface MobileMenuProps {
   isOpen: boolean;
@@ -49,6 +50,8 @@ export function MobileMenu({
     `mobile-navigation-description-${Math.random().toString(36).slice(2, 10)}`
   );
 
+  useScrollLock(isOpen);
+
   useEffect(() => {
     if (isOpen) {
       dialogRef.current?.querySelector<HTMLElement>("a, button")?.focus();
@@ -61,10 +64,6 @@ export function MobileMenu({
     <div
       ref={dialogRef}
       id="mobile-navigation-dialog"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="mobile-navigation-title"
-      aria-describedby={descriptionId.current}
       className="lg:hidden max-h-[calc(100dvh-5rem)] overflow-y-auto overscroll-contain border-t border-border/50 bg-background [-webkit-overflow-scrolling:touch]"
       onKeyDown={e => {
         if (e.key === "Escape") {
@@ -74,7 +73,8 @@ export function MobileMenu({
     >
       <nav
         className="container flex flex-col gap-2 py-4 pb-[calc(16px+env(safe-area-inset-bottom,0px)+88px)]"
-        aria-label="Hauptnavigation"
+        aria-labelledby="mobile-navigation-title"
+        aria-describedby={descriptionId.current}
       >
         <div className="sr-only">
           <h2 id="mobile-navigation-title">Mobile Navigation</h2>

--- a/client/src/pages/Datenschutz.tsx
+++ b/client/src/pages/Datenschutz.tsx
@@ -8,13 +8,21 @@ import Layout from "@/components/Layout";
 import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
 import SEO from "@/components/SEO";
+import { pageGovernance } from "@/data/pageGovernance";
+import { PERSONAL_NOTFALLKARTE_PATH } from "@/domain/notfallkarte";
 
 export default function Datenschutz() {
+  const lastReviewed = pageGovernance["/datenschutz"]?.lastReviewed;
+
   const bodyStyle = {
     fontSize: "var(--text-sm)",
     lineHeight: "var(--lh-relaxed)",
     color: "var(--fg-secondary)",
   };
+
+  const formattedReviewDate = lastReviewed
+    ? lastReviewed.split("-").reverse().join(".")
+    : null;
 
   return (
     <Layout>
@@ -348,7 +356,9 @@ export default function Datenschutz() {
         </ContentSection>
 
         <EditorialSection label="Stand" title="Aktualität" rule>
-          <p style={bodyStyle}>Stand: Februar 2026</p>
+          <p style={bodyStyle}>
+            Stand der Erklärung: {formattedReviewDate ?? "nicht angegeben"}
+          </p>
         </EditorialSection>
 
         <RelatedLinksEditorial
@@ -364,7 +374,7 @@ export default function Datenschutz() {
               description: "Wie die Website zugänglich gestaltet wird.",
             },
             {
-              href: "/notfallkarte",
+              href: PERSONAL_NOTFALLKARTE_PATH,
               title: "Persönliche Notfallkarte",
               description:
                 "Wie lokale Speicherung und Löschfunktion praktisch funktionieren.",

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { EditorialPillButton } from "@/components/ui/EditorialPillButton";
 import {
   EditorialLayout,
@@ -42,12 +42,33 @@ const DEFAULT_STRATEGIES: CalmingStrategy[] = [
   { id: "s3", text: "Kaltes Wasser über die Handgelenke laufen lassen" },
 ];
 
-const EMPTY_DATA: NotfallkarteData = {
-  personalContacts: [],
-  calmingStrategies: DEFAULT_STRATEGIES,
-  notes: "",
-};
+const MAX_CONTACTS = 3;
+const MAX_STRATEGIES = 4;
+
 const NOTFALLKARTE_PRINT_MESSAGE_TYPE = "notfallkarte-print-data";
+
+function createEmptyData(): NotfallkarteData {
+  return {
+    personalContacts: [],
+    calmingStrategies: DEFAULT_STRATEGIES.map(strategy => ({ ...strategy })),
+    notes: "",
+  };
+}
+
+function normalizeData(raw: Partial<NotfallkarteData> | null | undefined) {
+  const fallback = createEmptyData();
+
+  return {
+    personalContacts: Array.isArray(raw?.personalContacts)
+      ? raw.personalContacts.slice(0, MAX_CONTACTS)
+      : fallback.personalContacts,
+    calmingStrategies:
+      Array.isArray(raw?.calmingStrategies) && raw.calmingStrategies.length > 0
+        ? raw.calmingStrategies.slice(0, MAX_STRATEGIES)
+        : fallback.calmingStrategies,
+    notes: typeof raw?.notes === "string" ? raw.notes : fallback.notes,
+  };
+}
 
 function createId() {
   return Math.random().toString(36).slice(2, 9);
@@ -60,11 +81,11 @@ const CARD_GRUEN = GRUEN.filter(k => k.id === "GRUEN_143");
 function loadData(): NotfallkarteData {
   try {
     const raw = localStorage.getItem(NOTFALLKARTE_STORAGE_KEY);
-    if (raw) return JSON.parse(raw);
+    if (raw) return normalizeData(JSON.parse(raw) as Partial<NotfallkarteData>);
   } catch {
     /* ignore corrupt data */
   }
-  return EMPTY_DATA;
+  return createEmptyData();
 }
 
 function isStorageAvailable(): boolean {
@@ -258,11 +279,17 @@ export default function Notfallkarte() {
   const [data, setData] = useState<NotfallkarteData>(loadData);
   const [storageError, setStorageError] = useState(false);
   const [announcement, setAnnouncement] = useState("");
+  const skipNextSaveRef = useRef(false);
 
   useEffect(() => {
     if (!isStorageAvailable()) setStorageError(true);
   }, []);
   useEffect(() => {
+    if (skipNextSaveRef.current) {
+      skipNextSaveRef.current = false;
+      return;
+    }
+
     if (!saveData(data)) setStorageError(true);
   }, [data]);
 
@@ -274,7 +301,8 @@ export default function Notfallkarte() {
     if (!confirmed) return;
 
     if (deleteStoredData()) {
-      setData(EMPTY_DATA);
+      skipNextSaveRef.current = true;
+      setData(createEmptyData());
       setAnnouncement("Lokale Notfallkarten-Daten wurden gelöscht.");
     } else {
       setStorageError(true);
@@ -283,7 +311,10 @@ export default function Notfallkarte() {
   }, []);
 
   const handlePrint = useCallback(() => {
-    const printWindow = window.open("/notfallkarte-print.html", "_blank");
+    const printWindow = window.open(
+      "/notfallkarte-print.html?print=1",
+      "_blank"
+    );
 
     if (!printWindow) {
       setAnnouncement("Druckansicht konnte nicht geöffnet werden");
@@ -327,14 +358,26 @@ export default function Notfallkarte() {
   }, [data]);
 
   const addContact = useCallback(() => {
-    setData(prev => ({
-      ...prev,
-      personalContacts: [
-        ...prev.personalContacts,
-        { id: createId(), name: "", phone: "", relation: "" },
-      ],
-    }));
-    setAnnouncement("Kontakt hinzugefügt");
+    let added = false;
+
+    setData(prev => {
+      if (prev.personalContacts.length >= MAX_CONTACTS) {
+        return prev;
+      }
+
+      added = true;
+      return {
+        ...prev,
+        personalContacts: [
+          ...prev.personalContacts,
+          { id: createId(), name: "", phone: "", relation: "" },
+        ],
+      };
+    });
+
+    setAnnouncement(
+      added ? "Kontakt hinzugefügt" : "Maximal drei Kontakte sind möglich."
+    );
   }, []);
   const updateContact = useCallback(
     (updated: PersonalContact) =>
@@ -353,7 +396,6 @@ export default function Notfallkarte() {
     }));
     setAnnouncement("Kontakt entfernt");
   }, []);
-  const MAX_STRATEGIES = 4;
   const addStrategy = useCallback(() => {
     setData(prev =>
       prev.calmingStrategies.length >= MAX_STRATEGIES
@@ -574,7 +616,13 @@ export default function Notfallkarte() {
               </div>
               <SecondaryButton
                 onClick={addContact}
+                disabled={data.personalContacts.length >= MAX_CONTACTS}
                 ariaLabel="Kontakt hinzufügen"
+                title={
+                  data.personalContacts.length >= MAX_CONTACTS
+                    ? "Maximal drei Kontaktpersonen für die Druckversion"
+                    : undefined
+                }
               >
                 + Hinzufügen
               </SecondaryButton>
@@ -589,7 +637,8 @@ export default function Notfallkarte() {
                 }}
               >
                 Fügen Sie hier Ihre persönlichen Kontaktpersonen hinzu – z.B.
-                Therapeut:in, Vertrauensperson, Nachbar:in.
+                Therapeut:in, Vertrauensperson, Nachbar:in. Die Druckversion
+                unterstützt bis zu drei Kontakte.
               </p>
             ) : (
               <div className="space-y-0.5">


### PR DESCRIPTION
## Summary
- fix hard navigation and wrong cross-links for the personal notfallkarte flow
- make hash-linked content sections open and scroll correctly without scroll-reset conflicts
- tighten TOC scanning, ContentSection semantics, and mobile menu accessibility behavior
- fix notfallkarte delete/print/contact-limit regressions and add regression coverage

## Root cause
Several regressions came from mismatches between static routes and SPA navigation, broad document-level section scanning, and assumptions in the notfallkarte persistence/print flow that did not match the actual product behavior.

## Validation
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
