### PR TITLE
polish(krise-disclaimer): hairline-trenner + sage-akzent

### DIFF
--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -430,20 +430,31 @@ export default function UnterstuetzenKrise() {
           />
         </EditorialSection.MarginNote>
         <EditorialSection.Body>
-          <p
+          {/* Disclaimer: Hairline-Trenner darüber + italic + Sage-Akzent
+              (Sage-Color für italic Body schafft visuelle Differenzierung
+              zum normalen Body-Text, analog Wegweiser-Übergangs-Pattern in
+              Group C body) */}
+          <div
+            className="border-t pt-5"
             style={{
-              fontSize: "var(--text-sm)",
-              lineHeight: "var(--lh-relaxed)",
-              color: "var(--fg-secondary)",
-              fontStyle: "italic",
+              borderColor: "var(--rule-color)",
               marginBottom: "var(--space-5)",
             }}
           >
-            Diese Inhalte ersetzen keine professionelle Krisenberatung. Bei
-            akuter Gefahr direkt{" "}
-            <strong style={{ color: "var(--fg-primary)" }}>144 / 117</strong>{" "}
-            anrufen.
-          </p>
+            <p
+              style={{
+                fontSize: "var(--text-sm)",
+                lineHeight: "var(--lh-relaxed)",
+                color: "var(--accent-label)",
+                fontStyle: "italic",
+              }}
+            >
+              Diese Inhalte ersetzen keine professionelle Krisenberatung. Bei
+              akuter Gefahr direkt{" "}
+              <strong style={{ color: "var(--fg-primary)" }}>144 / 117</strong>{" "}
+              anrufen.
+            </p>
+          </div>
           <KrisenampelVisualisierung />
         </EditorialSection.Body>
       </EditorialSection>


### PR DESCRIPTION
## Polish-Item — Krise-Disclaimer typografisch nachjustiert

Beobachtung von Christa beim Phase-3-Stream-1-Audit (Krise-Page, PR #408): Der Disclaimer in der ORIENTIERUNG-Sektion rendert ohne ausreichende visuelle Differenzierung zum normalen Body-Text — er liest sich als erklärender Absatz, nicht als Hinweis.

## Was geändert ist

Eine Datei: `client/src/pages/UnterstuetzenKrise.tsx`

**Vorher:**
- Disclaimer als `<p>` mit `text-sm`, `italic`, `fg-secondary`
- Italic war typografisch zu schwach für visuelle Differenzierung

**Nachher (analog Wegweiser-Übergangs-Pattern):**
- Wrapper `<div>` mit `border-t pt-5` (Hairline-Trenner darüber)
- `marginBottom: var(--space-5)` Spacing zur KrisenampelVisualisierung darunter
- Disclaimer-Text in **`var(--accent-label)` (Sage-muted)** statt fg-secondary
- Italic + Strong-Hervorhebung «144 / 117» in fg-primary unverändert (sicherheitskritischer Notruf-Akzent)

Sage-Akzent kommt durch den Text-Farbton (Sage-muted) — die «Hinweis»-Wahrnehmung entsteht durch Farb-Differenzierung, nicht nur durch Schriftstil.

## Test plan

- [ ] /unterstuetzen/krise besuchen — ORIENTIERUNG-Sektion zeigt:
  - Hairline-Trenner über dem Disclaimer
  - Italic-Body in Sage-muted Color (deutlich anders als normaler Body-Text)
  - «144 / 117» in dunkel/fg-primary
- [ ] Sicherheits-Banner ganz oben unverändert (alert bg)
- [ ] KrisenampelVisualisierung darunter unverändert funktional
- [ ] Mobile (<640px): Disclaimer rendert mit Hairline + Sage, KrisenampelVisualisierung darunter

🤖 Generated with [Claude Code](https://claude.com/claude-code)