### PR TITLE
feat(stream-2b): krise-banner entschärft, dispatch-position auf abschluss

### DIFF
--- a/_dev/CLUSTER-4-DECISIONS-2026-05-05.md
+++ b/_dev/CLUSTER-4-DECISIONS-2026-05-05.md
@@ -33,6 +33,7 @@ Quelle: Zanarini et al. (2010, 2012) — bereits in der bestehenden EvidenceNote
 **Entscheid:** Option A — Zur Kategorie «Für Eltern» hinzufügen.
 
 Eintrag-Daten:
+
 - `title`: "Borderline Personality Disorder in Adolescents"
 - `author`: "Blaise Aguirre"
 - `publisher`: "Fair Winds Press"
@@ -67,6 +68,7 @@ Begründung für Brief: Aguirre ist eine Leseempfehlung, kein Seiten-Beleg. Maso
 **Entscheid:** Option B — `_dev/STYLE-SPRACHREGELUNG.md`-Memo (intern).
 
 Inhalt des Memos:
+
 - Primäre Formulierung: «betroffene Person» (nicht «erkrankte Person»)
 - Begründung: «erkrankt» impliziert einen passiven, dauerhaften Krankheitszustand; «betroffen» ist offener und entspricht dem Entstigmatisierungs-Framing der Site
 - Ausnahmen: Medizinische/klinische Kontexte (z.B. EvidenceNotes, Diagnostik-Seite) dürfen «erkrankt» verwenden, wenn es dem Quellen-Kontext entspricht
@@ -101,6 +103,7 @@ Neuer Text:
 ## Nicht in Sitzung 1 (Sitzung 2)
 
 Die folgenden Rückfragen werden in Sitzung 2 behandelt:
+
 - #1 Mythen-Sektion-Architektur
 - #2 Mythen-Inhalt
 - #3 Mythen-Sub-Nav

--- a/_dev/CLUSTER-4-DECISIONS-S2-2026-05-05.md
+++ b/_dev/CLUSTER-4-DECISIONS-S2-2026-05-05.md
@@ -63,6 +63,7 @@ Inhalt: Die 9 DSM-5-Kriterien mit 5-Schwelle, kompakt formuliert für Angehörig
 Begründung: DSM-5 ist die Diagnosesprache, mit der Angehörige in der Schweiz am häufigsten konfrontiert werden. ICD-11 noch nicht flächendeckend eingeführt. Beide erzeugen Verwirrung ohne Mehrwert für Angehörige.
 
 DSM-5-Kriterien (9 Kriterien, mindestens 5 für Diagnose):
+
 1. Verzweifeltes Bemühen, reales oder vorgestelltes Verlassenwerden zu vermeiden
 2. Instabile und intensive zwischenmenschliche Beziehungen (Idealisierung ↔ Entwertung)
 3. Instabiles Selbstbild oder Selbstwahrnehmung
@@ -86,12 +87,12 @@ Neuer Subtext: «Dies hilft uns, passende Ressourcen zu empfehlen.» (unverände
 
 Neue Optionen mit angepassten Gewichtungen:
 
-| Option | value | Gewichtung |
-|---|---|---|
-| Kaum spürbar — ich komme gut zurecht | `niedrig` | `{ verstehen: 4, unterstuetzen: 4 }` |
-| Deutlich spürbar — es kostet mich Kraft | `mittel` | `{ kommunizieren: 4, grenzen: 3, selbstfuersorge: 3 }` |
-| Sehr stark — ich bin oft erschöpft | `hoch` | `{ selbstfuersorge: 6, grenzen: 3, kommunizieren: 2 }` |
-| Ich bin am Limit | `limit` | `{ selbstfuersorge: 8, krise: 3, grenzen: 2 }` |
+| Option                                  | value     | Gewichtung                                             |
+| --------------------------------------- | --------- | ------------------------------------------------------ |
+| Kaum spürbar — ich komme gut zurecht    | `niedrig` | `{ verstehen: 4, unterstuetzen: 4 }`                   |
+| Deutlich spürbar — es kostet mich Kraft | `mittel`  | `{ kommunizieren: 4, grenzen: 3, selbstfuersorge: 3 }` |
+| Sehr stark — ich bin oft erschöpft      | `hoch`    | `{ selbstfuersorge: 6, grenzen: 3, kommunizieren: 2 }` |
+| Ich bin am Limit                        | `limit`   | `{ selbstfuersorge: 8, krise: 3, grenzen: 2 }`         |
 
 Hinweis: 4 Optionen statt 3 — UX-Mehraufwand minimal, da kein zusätzlicher Schritt.
 
@@ -99,9 +100,9 @@ Hinweis: 4 Optionen statt 3 — UX-Mehraufwand minimal, da kein zusätzlicher Sc
 
 ## Zusammenfassung: 4 Edits in 3 Dateien
 
-| Edit | Datei | Was |
-|---|---|---|
-| A | `client/src/pages/Verstehen.tsx` | Neuer Mythos «Borderline ist dasselbe wie Trauma.» einfügen |
-| B | `client/src/pages/Glossar.tsx` | DSM-5-Kriterien als Aufklapp-Block im BPS-Eintrag ergänzen |
-| C | `client/src/components/Selbsttest.tsx` | Frage 3 umformulieren — Dauer → Intensität, 3 → 4 Optionen |
-| D | `client/src/__tests__/` | Tests für Selbsttest-Frage-3-Optionen anpassen (neue values) |
+| Edit | Datei                                  | Was                                                          |
+| ---- | -------------------------------------- | ------------------------------------------------------------ |
+| A    | `client/src/pages/Verstehen.tsx`       | Neuer Mythos «Borderline ist dasselbe wie Trauma.» einfügen  |
+| B    | `client/src/pages/Glossar.tsx`         | DSM-5-Kriterien als Aufklapp-Block im BPS-Eintrag ergänzen   |
+| C    | `client/src/components/Selbsttest.tsx` | Frage 3 umformulieren — Dauer → Intensität, 3 → 4 Optionen   |
+| D    | `client/src/__tests__/`                | Tests für Selbsttest-Frage-3-Optionen anpassen (neue values) |

--- a/_dev/CLUSTER-4-SITZUNG-1-BRIEF-2026-05-05.md
+++ b/_dev/CLUSTER-4-SITZUNG-1-BRIEF-2026-05-05.md
@@ -11,13 +11,13 @@ PR-Titel: `feat(cluster-4-s1): Recovery-Zeit, Aguirre, Sprachregelung, Geschlech
 
 ## Übersicht der Änderungen
 
-| Edit | Datei | Art | Aufwand |
-|---|---|---|---|
-| A | `client/src/pages/Genesung.tsx` | Text-Edit (1 Satz) | trivial |
-| B | `client/src/pages/Buchempfehlungen.tsx` | Neuer Eintrag (Objekt) | klein |
-| C | `client/src/pages/Home.tsx` | Text-Edit (1 Wort) | trivial |
-| D | `client/src/pages/Verstehen.tsx` | Text-Edit (1 Satz) | trivial |
-| E | `_dev/STYLE-SPRACHREGELUNG.md` | Neue Datei | klein |
+| Edit | Datei                                   | Art                    | Aufwand |
+| ---- | --------------------------------------- | ---------------------- | ------- |
+| A    | `client/src/pages/Genesung.tsx`         | Text-Edit (1 Satz)     | trivial |
+| B    | `client/src/pages/Buchempfehlungen.tsx` | Neuer Eintrag (Objekt) | klein   |
+| C    | `client/src/pages/Home.tsx`             | Text-Edit (1 Wort)     | trivial |
+| D    | `client/src/pages/Verstehen.tsx`        | Text-Edit (1 Satz)     | trivial |
+| E    | `_dev/STYLE-SPRACHREGELUNG.md`          | Neue Datei             | klein   |
 
 ---
 
@@ -26,12 +26,14 @@ PR-Titel: `feat(cluster-4-s1): Recovery-Zeit, Aguirre, Sprachregelung, Geschlech
 **Datei:** `client/src/pages/Genesung.tsx`
 
 **Suche:**
+
 ```
 erreichen eine umfassendere Genesung mit funktioneller
                 Stabilität.
 ```
 
 **Ersetze durch:**
+
 ```
 erreichen eine umfassendere Genesung mit funktioneller
                 Stabilität — meist innerhalb von 10 bis 20 Jahren.
@@ -46,6 +48,7 @@ erreichen eine umfassendere Genesung mit funktioneller
 **Datei:** `client/src/pages/Buchempfehlungen.tsx`
 
 **Suche** (letzter Eintrag in der «Für Eltern»-Kategorie, ~Zeile 120):
+
 ```
       {
         title: "Borderline verstehen und bewältigen",
@@ -62,6 +65,7 @@ erreichen eine umfassendere Genesung mit funktioneller
 ```
 
 **Ersetze durch:**
+
 ```
       {
         title: "Borderline verstehen und bewältigen",
@@ -95,11 +99,13 @@ erreichen eine umfassendere Genesung mit funktioneller
 **Datei:** `client/src/pages/Home.tsx`
 
 **Suche:**
+
 ```
 erkrankte Person. Orientierung, Gespräch und Materialien für
 ```
 
 **Ersetze durch:**
+
 ```
 betroffene Person. Orientierung, Gespräch und Materialien für
 ```
@@ -113,11 +119,13 @@ betroffene Person. Orientierung, Gespräch und Materialien für
 **Datei:** `client/src/pages/Verstehen.tsx`
 
 **Suche:**
+
 ```
                 Borderline kann Menschen aller Geschlechter betreffen. Männer
 ```
 
 **Ersetze durch:**
+
 ```
                 Borderline kommt bei allen Geschlechtern vor — klinisch werden Frauen häufiger diagnostiziert. Männer
 ```
@@ -131,6 +139,7 @@ betroffene Person. Orientierung, Gespräch und Materialien für
 **Datei:** `_dev/STYLE-SPRACHREGELUNG.md` (neu erstellen)
 
 **Inhalt:**
+
 ```markdown
 ---
 Datum: 2026-05-05

--- a/_dev/CLUSTER-4-SITZUNG-2-BRIEF-2026-05-05.md
+++ b/_dev/CLUSTER-4-SITZUNG-2-BRIEF-2026-05-05.md
@@ -21,6 +21,7 @@ Lies diesen Brief vollständig, dann setze die 4 Edits (A–D) um. Erstelle dana
 **Einfüge-Position:** Nach dem `</p>`-Abschluss des «Grenzen setzen ist lieblos.»-Blocks, vor dem `<h4>`-Tag von «Suizid direkt anzusprechen macht es schlimmer.».
 
 **Suche diesen Kontext:**
+
 ```tsx
               <p>
                 Grenzen sind kein Verrat, sondern oft die Voraussetzung dafür,
@@ -39,6 +40,7 @@ Lies diesen Brief vollständig, dann setze die 4 Edits (A–D) um. Erstelle dana
 ```
 
 **Ersetze durch (neuen Block einfügen zwischen den beiden):**
+
 ```tsx
               <p>
                 Grenzen sind kein Verrat, sondern oft die Voraussetzung dafür,
@@ -129,32 +131,34 @@ interface GlossaryTerm {
 **Schritt 3:** Im Render-Teil des Glossars (in der `group.terms.map`-Schleife, nach dem `{t.example && ...}`-Block) das `criteria`-Feld rendern:
 
 ```tsx
-                    {t.criteria && (
-                      <dd>
-                        <details className="mt-1">
-                          <summary
-                            className="cursor-pointer uppercase"
-                            style={{
-                              ...labelStyle,
-                              color: "var(--accent-primary)",
-                            }}
-                          >
-                            DSM-5-Kriterien anzeigen
-                          </summary>
-                          <div className="mt-3 space-y-2">
-                            <p style={ddStyle}>{t.criteria.intro}</p>
-                            <ol
-                              className="ml-4 mt-2 space-y-1"
-                              style={{ ...ddStyle, listStyleType: "decimal" }}
-                            >
-                              {t.criteria.items.map((item, i) => (
-                                <li key={i}>{item}</li>
-                              ))}
-                            </ol>
-                          </div>
-                        </details>
-                      </dd>
-                    )}
+{
+  t.criteria && (
+    <dd>
+      <details className="mt-1">
+        <summary
+          className="cursor-pointer uppercase"
+          style={{
+            ...labelStyle,
+            color: "var(--accent-primary)",
+          }}
+        >
+          DSM-5-Kriterien anzeigen
+        </summary>
+        <div className="mt-3 space-y-2">
+          <p style={ddStyle}>{t.criteria.intro}</p>
+          <ol
+            className="ml-4 mt-2 space-y-1"
+            style={{ ...ddStyle, listStyleType: "decimal" }}
+          >
+            {t.criteria.items.map((item, i) => (
+              <li key={i}>{item}</li>
+            ))}
+          </ol>
+        </div>
+      </details>
+    </dd>
+  );
+}
 ```
 
 ---
@@ -164,6 +168,7 @@ interface GlossaryTerm {
 **Was:** Frage 3 von Dauer-Messung auf Intensitäts-Messung umformulieren. 3 Optionen → 4 Optionen.
 
 **Suche:**
+
 ```tsx
   {
     id: 3,
@@ -190,6 +195,7 @@ interface GlossaryTerm {
 ```
 
 **Ersetze durch:**
+
 ```tsx
   {
     id: 3,

--- a/_dev/CLUSTER-4-STATUS-2026-05-05.md
+++ b/_dev/CLUSTER-4-STATUS-2026-05-05.md
@@ -16,51 +16,53 @@ Alle 16 Rückfragen aus `§9` des Mappings sind weiterhin offen. Kein Cluster-4-
 
 ### KLEIN — 6 direkte Entscheide, kein Editorial-Aufwand
 
-| # | Rückfrage | Mapping-Referenz | Optionen | Empfehlung Mapping |
-|---|---|---|---|---|
-| #6 | Recovery-Zeit: Zeitangabe in 50%-Zelle ergänzen oder Über-/Unter-Satz? | §3 | A (Zelle) / B (Satz) | — |
-| #16 | Sitzungs-Modell: I (eine Sitzung), II (zwei nach Aufwand), III (drei nach Thema)? | §8 | I / II / III | II |
-| #5 | Geschlechterverteilung: Wortlaut kurz-neutral oder ausführlich mit NESARC-Bezug? | §2 | kurz / ausführlich | — |
-| #12 | Home.tsx:204 «erkrankte Person» → «betroffene Person» normalisieren? | §6 | ja / nein | — |
-| #13 | Aguirre: Option A (Eltern-Kategorie), B (eigene Unterkategorie englisch), C (Verzicht)? | §7 | A / B / C | A |
-| #14 | Aguirre: `highlight: true` wie Trasselli in derselben Kategorie? | §7 | ja / nein | — |
+| #   | Rückfrage                                                                               | Mapping-Referenz | Optionen             | Empfehlung Mapping |
+| --- | --------------------------------------------------------------------------------------- | ---------------- | -------------------- | ------------------ |
+| #6  | Recovery-Zeit: Zeitangabe in 50%-Zelle ergänzen oder Über-/Unter-Satz?                  | §3               | A (Zelle) / B (Satz) | —                  |
+| #16 | Sitzungs-Modell: I (eine Sitzung), II (zwei nach Aufwand), III (drei nach Thema)?       | §8               | I / II / III         | II                 |
+| #5  | Geschlechterverteilung: Wortlaut kurz-neutral oder ausführlich mit NESARC-Bezug?        | §2               | kurz / ausführlich   | —                  |
+| #12 | Home.tsx:204 «erkrankte Person» → «betroffene Person» normalisieren?                    | §6               | ja / nein            | —                  |
+| #13 | Aguirre: Option A (Eltern-Kategorie), B (eigene Unterkategorie englisch), C (Verzicht)? | §7               | A / B / C            | A                  |
+| #14 | Aguirre: `highlight: true` wie Trasselli in derselben Kategorie?                        | §7               | ja / nein            | —                  |
 
 ### KLEIN (bedingt) — 4 Entscheide, die von vorgelagerten Entscheiden abhängen
 
-| # | Rückfrage | Abhängigkeit | Optionen |
-|---|---|---|---|
-| #15 | Aguirre zusätzlich in Quellen.tsx aufnehmen (analog Mason & Kreger)? | bedingt durch #13 ≠ C | ja / nein |
+| #   | Rückfrage                                                                                 | Abhängigkeit                     | Optionen      |
+| --- | ----------------------------------------------------------------------------------------- | -------------------------------- | ------------- |
+| #15 | Aguirre zusätzlich in Quellen.tsx aufnehmen (analog Mason & Kreger)?                      | bedingt durch #13 ≠ C            | ja / nein     |
 | #11 | Sprachregelung: Option A (Glossar), B (Memo), C (Memo + Konsistenz-Pass), D (Status quo)? | unabhängig, aber beeinflusst #12 | A / B / C / D |
-| #10 | Selbsttest: 8 statt 7 Fragen für die UX akzeptabel? | bedingt durch #9 = A | ja / nein |
-| #3 | Mythen-Sub-Nav: Eintrag in welcher Gruppe? | bedingt durch #1 = B | Gruppe wählen |
+| #10 | Selbsttest: 8 statt 7 Fragen für die UX akzeptabel?                                       | bedingt durch #9 = A             | ja / nein     |
+| #3  | Mythen-Sub-Nav: Eintrag in welcher Gruppe?                                                | bedingt durch #1 = B             | Gruppe wählen |
 
 ### MITTEL — 4 Entscheide mit Editorial-Aufwand oder Architektur-Spannung
 
-| # | Rückfrage | Mapping-Referenz | Kern-Spannung |
-|---|---|---|---|
-| #4 | Geschlechterverteilung: Architektur Option A (Verstehen-Satz), B (Glossar), C (FAQ), D (mit Mythen verschränkt)? | §2 | verschränkt mit #1 |
-| #2 | Mythen-Inhalt: Welche Mythen aufnehmen? (Vorschlag: Behandelbarkeit, Manipulation, Trauma/PTBS, Suizid-Direktansprache, Geschlecht) | §1 | bedingt durch #1 ≠ D |
-| #7 | DSM-5-Kriterien: Option A (Verstehen-Aufklapp), B (Glossar), C (Diagnostik-Sektion), D (Verzicht)? | §4 | Brief-Spannung «kein Etikett-Framing» |
-| #8 | DSM-5 vs. ICD-11: Nur DSM-5, nur ICD-11, oder beides? | §4 | bedingt durch #7 ≠ D |
+| #   | Rückfrage                                                                                                                           | Mapping-Referenz | Kern-Spannung                         |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------- | ---------------- | ------------------------------------- |
+| #4  | Geschlechterverteilung: Architektur Option A (Verstehen-Satz), B (Glossar), C (FAQ), D (mit Mythen verschränkt)?                    | §2               | verschränkt mit #1                    |
+| #2  | Mythen-Inhalt: Welche Mythen aufnehmen? (Vorschlag: Behandelbarkeit, Manipulation, Trauma/PTBS, Suizid-Direktansprache, Geschlecht) | §1               | bedingt durch #1 ≠ D                  |
+| #7  | DSM-5-Kriterien: Option A (Verstehen-Aufklapp), B (Glossar), C (Diagnostik-Sektion), D (Verzicht)?                                  | §4               | Brief-Spannung «kein Etikett-Framing» |
+| #8  | DSM-5 vs. ICD-11: Nur DSM-5, nur ICD-11, oder beides?                                                                               | §4               | bedingt durch #7 ≠ D                  |
 
 ### GROSS — 2 Entscheide mit strukturellen Konsequenzen
 
-| # | Rückfrage | Mapping-Referenz | Konsequenz |
-|---|---|---|---|
-| #1 | Mythen-Sektion-Architektur: Option A (Sektion auf Verstehen), B (eigene `/mythen`-Page), C (FAQ-Kategorie), D (Status quo)? | §1 | bestimmt #2, #3, #4 |
-| #9 | Selbsttest Frage 3: Option A (Splitting 3a/3b), B (Umformulierung), C (vierte Option entfernen), D (Status quo)? | §5 | A wäre Mechanik-Umbau |
+| #   | Rückfrage                                                                                                                   | Mapping-Referenz | Konsequenz            |
+| --- | --------------------------------------------------------------------------------------------------------------------------- | ---------------- | --------------------- |
+| #1  | Mythen-Sektion-Architektur: Option A (Sektion auf Verstehen), B (eigene `/mythen`-Page), C (FAQ-Kategorie), D (Status quo)? | §1               | bestimmt #2, #3, #4   |
+| #9  | Selbsttest Frage 3: Option A (Splitting 3a/3b), B (Umformulierung), C (vierte Option entfernen), D (Status quo)?            | §5               | A wäre Mechanik-Umbau |
 
 ---
 
 ## Mappings-Empfehlung Sitzungs-Modell II
 
 **Sitzung 1 — niedrige Hängefrucht (~30 Min Implementation):**
+
 - #6 Recovery-Zeit (1-Wort-Edit auf /genesung)
 - #13/#14/#15 Aguirre-Block (Buchempfehlungen + optional Quellen.tsx)
 - #11/#12 Sprachregelung-Memo + Home.tsx-Normalisierung
 - #5 Geschlechterverteilung Mini-Variante (Option A oder B)
 
 **Sitzung 2 — eigentliche Editorial-Arbeit:**
+
 - #1 Mythen-Sektion-Architektur (Entscheid zieht #2, #3, #4 nach sich)
 - #7/#8 DSM-5-Kriterien-Architektur
 - #9/#10 Selbsttest Frage 3

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -740,34 +740,51 @@ export default function UnterstuetzenKrise() {
             id="vermeiden"
             preview="Drohen, Vorwürfe machen oder Gefühle herunterspielen – diese Reaktionen können die Krise verschärfen."
           >
-            <aside className="mt-2 border border-alert/20 border-l-4 border-l-alert bg-alert/6 p-6">
+            <aside
+              className="mt-2 border border-[--color-sos-amber-border] border-l-2 border-l-[--color-sos-amber-text] bg-[--color-sos-amber-wash] p-6"
+            >
               <ul className="space-y-2.5" style={bodyStyle}>
                 <li className="flex items-start gap-2">
-                  <span className="text-alert" aria-hidden="true">
+                  <span
+                    className="text-[--color-sos-amber-text]"
+                    aria-hidden="true"
+                  >
                     ✗
                   </span>
                   Drohen oder Ultimaten stellen
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-alert" aria-hidden="true">
+                  <span
+                    className="text-[--color-sos-amber-text]"
+                    aria-hidden="true"
+                  >
                     ✗
                   </span>
                   Vorwürfe machen oder Schuld zuweisen
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-alert" aria-hidden="true">
+                  <span
+                    className="text-[--color-sos-amber-text]"
+                    aria-hidden="true"
+                  >
                     ✗
                   </span>
                   Die Gefühle herunterspielen («So schlimm ist es doch nicht»)
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-alert" aria-hidden="true">
+                  <span
+                    className="text-[--color-sos-amber-text]"
+                    aria-hidden="true"
+                  >
                     ✗
                   </span>
                   Logisch argumentieren oder überzeugen wollen
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-alert" aria-hidden="true">
+                  <span
+                    className="text-[--color-sos-amber-text]"
+                    aria-hidden="true"
+                  >
                     ✗
                   </span>
                   Die Person ohne Hilfe, Notfallplan oder professionelle
@@ -775,7 +792,10 @@ export default function UnterstuetzenKrise() {
                   können
                 </li>
                 <li className="flex items-start gap-2">
-                  <span className="text-alert" aria-hidden="true">
+                  <span
+                    className="text-[--color-sos-amber-text]"
+                    aria-hidden="true"
+                  >
                     ✗
                   </span>
                   Sich selbst in Gefahr bringen

--- a/client/src/pages/UnterstuetzenKrise.tsx
+++ b/client/src/pages/UnterstuetzenKrise.tsx
@@ -740,9 +740,7 @@ export default function UnterstuetzenKrise() {
             id="vermeiden"
             preview="Drohen, Vorwürfe machen oder Gefühle herunterspielen – diese Reaktionen können die Krise verschärfen."
           >
-            <aside
-              className="mt-2 border border-[--color-sos-amber-border] border-l-2 border-l-[--color-sos-amber-text] bg-[--color-sos-amber-wash] p-6"
-            >
+            <aside className="mt-2 border border-[--color-sos-amber-border] border-l-2 border-l-[--color-sos-amber-text] bg-[--color-sos-amber-wash] p-6">
               <ul className="space-y-2.5" style={bodyStyle}>
                 <li className="flex items-start gap-2">
                   <span

--- a/client/src/pages/UnterstuetzenUebersicht.tsx
+++ b/client/src/pages/UnterstuetzenUebersicht.tsx
@@ -361,89 +361,7 @@ export default function UnterstuetzenUebersicht() {
         </EditorialSection.Body>
       </EditorialSection>
 
-      {/* ── 5 Dispatch: Was möchten Sie vertiefen? ── */}
-      <EditorialSection variant="cream">
-        <EditorialSection.MarginNote>
-          <span
-            className="block text-[13px] font-medium uppercase"
-            style={{
-              color: "var(--accent-label)",
-              letterSpacing: "var(--tracking-caps)",
-              lineHeight: 1.3,
-            }}
-          >
-            Vertiefung
-          </span>
-          <div
-            aria-hidden="true"
-            className="mt-3 border-t"
-            style={{ borderColor: "var(--rule-color)" }}
-          />
-        </EditorialSection.MarginNote>
-        <EditorialSection.Body>
-          <p
-            className="text-xs uppercase"
-            style={{
-              color: "var(--accent-label)",
-              letterSpacing: "var(--tracking-caps)",
-              fontWeight: 500,
-              marginBottom: "var(--space-4)",
-            }}
-          >
-            Vertiefen
-          </p>
-          <h2
-            className="font-display"
-            style={{
-              fontSize: "var(--text-2xl)",
-              lineHeight: "var(--lh-snug)",
-              color: "var(--fg-primary)",
-              fontWeight: "var(--weight-display)",
-              letterSpacing: "var(--tracking-tight)",
-              marginBottom: "var(--space-5)",
-            }}
-          >
-            Was möchten Sie vertiefen?
-          </h2>
-          <ul className="space-y-6">
-            <li>
-              <h3 style={h4Style}>
-                <Link href="/unterstuetzen/alltag" className="editorial-link">
-                  Im Alltag unterstützen
-                </Link>
-              </h3>
-              <p className="mt-1" style={bodyStyle}>
-                Verlässlichkeit, Klarheit, Konflikt-Repair und kleine stabile
-                Kontaktangebote.
-              </p>
-            </li>
-            <li>
-              <h3 style={h4Style}>
-                <Link href="/unterstuetzen/krise" className="editorial-link">
-                  Krisen begleiten
-                </Link>
-              </h3>
-              <p className="mt-1" style={bodyStyle}>
-                Ampel-System, Deeskalation, Was sagen / Was vermeiden, Nach der
-                Krise.
-              </p>
-            </li>
-            <li>
-              <h3 style={h4Style}>
-                <Link href="/unterstuetzen/therapie" className="editorial-link">
-                  Therapie unterstützen
-                </Link>
-              </h3>
-              <p className="mt-1" style={bodyStyle}>
-                Wie Sie den therapeutischen Prozess sinnvoll begleiten — ohne zu
-                übernehmen.
-              </p>
-            </li>
-          </ul>
-        </EditorialSection.Body>
-      </EditorialSection>
-
-      {/* ── 6 Group C: Woran es tragfähig wird ── familiendynamik + woran-erkennbar + grenzen-der-unterstuetzung
+      {/* ── 5 Group C: Woran es tragfähig wird ── familiendynamik + woran-erkennbar + grenzen-der-unterstuetzung
            Plus Grenzen-Übergangs-Block als typografisch markierter Intro
            (kursiv, Hairline-Trenner darüber) — Christa-Decision Variante d */}
       <EditorialSection variant="cream">
@@ -737,6 +655,88 @@ export default function UnterstuetzenUebersicht() {
               .
             </p>
           </EditorialProse>
+        </EditorialSection.Body>
+      </EditorialSection>
+
+      {/* ── 9 Dispatch: Was möchten Sie vertiefen? ── */}
+      <EditorialSection variant="cream">
+        <EditorialSection.MarginNote>
+          <span
+            className="block text-[13px] font-medium uppercase"
+            style={{
+              color: "var(--accent-label)",
+              letterSpacing: "var(--tracking-caps)",
+              lineHeight: 1.3,
+            }}
+          >
+            Vertiefung
+          </span>
+          <div
+            aria-hidden="true"
+            className="mt-3 border-t"
+            style={{ borderColor: "var(--rule-color)" }}
+          />
+        </EditorialSection.MarginNote>
+        <EditorialSection.Body>
+          <p
+            className="text-xs uppercase"
+            style={{
+              color: "var(--accent-label)",
+              letterSpacing: "var(--tracking-caps)",
+              fontWeight: 500,
+              marginBottom: "var(--space-4)",
+            }}
+          >
+            Vertiefen
+          </p>
+          <h2
+            className="font-display"
+            style={{
+              fontSize: "var(--text-2xl)",
+              lineHeight: "var(--lh-snug)",
+              color: "var(--fg-primary)",
+              fontWeight: "var(--weight-display)",
+              letterSpacing: "var(--tracking-tight)",
+              marginBottom: "var(--space-5)",
+            }}
+          >
+            Was möchten Sie vertiefen?
+          </h2>
+          <ul className="space-y-6">
+            <li>
+              <h3 style={h4Style}>
+                <Link href="/unterstuetzen/alltag" className="editorial-link">
+                  Im Alltag unterstützen
+                </Link>
+              </h3>
+              <p className="mt-1" style={bodyStyle}>
+                Verlässlichkeit, Klarheit, Konflikt-Repair und kleine stabile
+                Kontaktangebote.
+              </p>
+            </li>
+            <li>
+              <h3 style={h4Style}>
+                <Link href="/unterstuetzen/krise" className="editorial-link">
+                  Krisen begleiten
+                </Link>
+              </h3>
+              <p className="mt-1" style={bodyStyle}>
+                Ampel-System, Deeskalation, Was sagen / Was vermeiden, Nach der
+                Krise.
+              </p>
+            </li>
+            <li>
+              <h3 style={h4Style}>
+                <Link href="/unterstuetzen/therapie" className="editorial-link">
+                  Therapie unterstützen
+                </Link>
+              </h3>
+              <p className="mt-1" style={bodyStyle}>
+                Wie Sie den therapeutischen Prozess sinnvoll begleiten — ohne zu
+                übernehmen.
+              </p>
+            </li>
+          </ul>
         </EditorialSection.Body>
       </EditorialSection>
 


### PR DESCRIPTION
## Stream 2B — Implementierungs-Brief

### Scope
2 Edits in 2 Dateien. Keine neuen Komponenten, keine Test-Anpassungen erwartet.

---

### Edit 1 — `UnterstuetzenKrise.tsx`

**Aside «Was Sie vermeiden sollten» von alert-rot auf sos-amber-Warn-Gelb entschärft.**

Vorher: `border border-alert/20 border-l-4 border-l-alert bg-alert/6` + `text-alert` auf allen 6 ✗-Symbolen

Nachher: `border border-[--color-sos-amber-border] border-l-2 border-l-[--color-sos-amber-text] bg-[--color-sos-amber-wash]` + `text-[--color-sos-amber-text]`

Begründung: Der Aside ist ein redaktioneller Hinweis, kein Notfall-Banner. Alert-Rot ist dem Sicherheits-Notruf-Banner (#1) vorbehalten. Warn-Gelb (sos-amber-Tokens) signalisiert Hinweis-Charakter ohne Notfall-Dringlichkeit. Banner #1 bleibt unverändert.

---

### Edit 2 — `UnterstuetzenUebersicht.tsx`

**Dispatch-Sektion «Was möchten Sie vertiefen?» von Position 5 ans Ende verschoben.**

Vorher: Position 5 — nach Group B (Was es schwer macht), vor Group C (Woran es tragfähig wird)

Nachher: Position 9 — nach Weiter-Hinweis, vor VERWANDT-Block (cream-deep)

Begründung: SubNav = Schnellzugriff (oben), Dispatch = Abschluss-Verteiler (unten). Zwei sauber getrennte Funktionen statt Doppelung. Inhalt unverändert, nur Position.

---

### Abnahme-Kriterien
- [ ] `/unterstuetzen/krise` → Aside «Was Sie vermeiden sollten» zeigt amber-Gelb, nicht rot
- [ ] Banner #1 (Sicherheits-Notruf, bg-alert) bleibt unverändert
- [ ] `/unterstuetzen` → Dispatch-Sektion erscheint nach dem Weiter-Hinweis, vor VERWANDT
- [ ] 178/178 Tests grün