### PR TITLE
fix(editorial): Hero-MarginNote auf text-[13px] angleichen

### DIFF
--- a/client/src/components/editorial/EditorialHero.tsx
+++ b/client/src/components/editorial/EditorialHero.tsx
@@ -33,8 +33,8 @@ interface EditorialHeroProps {
  *
  * Public-API unverändert seit PR #391 — Pages müssen nicht angepasst
  * werden. H1 + Lede sind intern auf <DisplayHeading> und <Lede>
- * umgestellt; Eyebrow-MarginNote bleibt handgerollt (text-xs statt
- * 13px-Variante der anderen MarginNotes).
+ * umgestellt; Eyebrow-MarginNote nutzt jetzt text-[13px] wie alle
+ * anderen MarginNotes der Site.
  */
 export function EditorialHero({
   eyebrow,
@@ -48,7 +48,7 @@ export function EditorialHero({
       {eyebrow && (
         <EditorialSection.MarginNote>
           <span
-            className="block text-xs font-medium uppercase"
+            className="block text-[13px] font-medium uppercase"
             style={{
               color: "var(--accent-label)",
               letterSpacing: "var(--tracking-caps)",


### PR DESCRIPTION
## Hintergrund

`EditorialHero`-MarginNote nutzte als einzige Stelle `text-xs` (12 px), während alle anderen MarginNotes auf der Site (`Anerkennung`, `Wegweiser`, `Beratungseinladung`, `Verstehen`-Hero, etc.) `text-[13px]` verwenden.

Inkonsistenz war seit langem da, ohne sichtbaren Grund. Angleichung auf 13 px ist die kleinste konsistente Änderung.

## Änderung

`client/src/components/editorial/EditorialHero.tsx`:
- `className="block text-xs font-medium uppercase"` → `className="block text-[13px] font-medium uppercase"`
- JSDoc-Kommentar entsprechend aktualisiert.

## Visueller Effekt

Hero-Eyebrow wird 1 px größer. Konsumenten:
- `Home.tsx` (über `EditorialHero`): „Fachstelle Angehörigenarbeit · Psychiatrische Universitätsklinik Zürich"

(Die direkten `<EditorialSection>`-Pages — Verstehen, Grenzen, Kommunizieren, etc. — nutzen `EditorialHero` nicht; sie haben ihre eigenen MarginNotes mit `text-[13px]` schon korrekt.)

## Diff-Stat

```
1 file changed, 2 insertions(+), 2 deletions(-)
```

## Test plan

- [x] `pnpm check` (TypeScript) — grün
- [x] `pnpm test` — 195/195 Tests grün
- [ ] Visuelle Prüfung Home Hero: Eyebrow „Fachstelle Angehörigenarbeit · PUK Zürich" 1 px größer als zuvor, immer noch dezent
- [ ] Vergleich zu MarginNote der nachfolgenden Anerkennung-Sektion („Zwischen zwei Polen"): jetzt gleiche Größe


---
_Generated by [Claude Code](https://claude.ai/code/session_01MCyRpvFh86yQDebwAibHGe)_