### PR TITLE
Counter-Kontrast in drei verbleibenden Materials-Sections (Follow-up zu #467)

### DIFF
--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -114,10 +114,10 @@ export default function KommunizierenMaterialsSection() {
                   }}
                 >
                   <span>{category.label}</span>
-                  <span aria-hidden="true" className="mx-2.5 opacity-50">
+                  <span aria-hidden="true" className="mx-2.5 opacity-70">
                     ·
                   </span>
-                  <span className="opacity-70">{count}</span>
+                  <span>{count}</span>
                 </EditorialPillButton>
               );
             })}

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -133,10 +133,10 @@ export default function SelbstfuersorgeInfografikenSection() {
                 }}
               >
                 <span>{cat.label}</span>
-                <span aria-hidden="true" className="mx-2.5 opacity-50">
+                <span aria-hidden="true" className="mx-2.5 opacity-70">
                   ·
                 </span>
-                <span className="opacity-70">{cat.count}</span>
+                <span>{cat.count}</span>
               </EditorialPillButton>
             ))}
           </div>

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -126,10 +126,10 @@ export default function VerstehenMaterialsSection() {
                 }}
               >
                 <span>{cat.label}</span>
-                <span aria-hidden="true" className="mx-2.5 opacity-50">
+                <span aria-hidden="true" className="mx-2.5 opacity-70">
                   ·
                 </span>
-                <span className="opacity-70">{cat.count}</span>
+                <span>{cat.count}</span>
               </EditorialPillButton>
             ))}
           </div>


### PR DESCRIPTION
## Counter-Kontrast in drei verbleibenden Materials-Sections

Follow-up zu #467. Beim ersten Counter-Fix wurde nur `MaterialienLibrarySection.tsx` angepasst. Drei andere Sections nutzen das exakt selbe Filter-Button-Pattern (Copy-Paste-Erbe) und wurden nicht erwischt:

- `client/src/sections/VerstehenMaterialsSection.tsx` (Z. 128–132)
- `client/src/sections/KommunizierenMaterialsSection.tsx` (Z. 116–120)
- `client/src/sections/SelbstfuersorgeInfografikenSection.tsx` (Z. 135–139)

### Phase-1-Reproduktion

Alle drei Stellen identisch — bestätigt via Code-Inspektion:
```tsx
<span>{label}</span>
<span aria-hidden="true" className="mx-2.5 opacity-50">·</span>
<span className="opacity-70">{count}</span>
```

### Änderungen pro Datei (identisch zu PR #467)

```diff
- <span aria-hidden="true" className="mx-2.5 opacity-50">·</span>
+ <span aria-hidden="true" className="mx-2.5 opacity-70">·</span>

- <span className="opacity-70">{count}</span>
+ <span>{count}</span>
```

### Kontrast-Verhältnisse (gegen `--bg-primary` `#faf7f2`)

| Element | State | vor | nach | AA-Pass? |
|---|---|---:|---:|:---:|
| Counter | unselected (accent-label) | 2.97 | **5.07** | ✅ |
| Counter | selected (fg-primary) | 5.29 | **10.13** | ✅ |
| Separator (aria-hidden) | unselected | 2.08 | 2.97 | n/a |

### Verifikation

| Check | Ergebnis |
|---|---|
| Typecheck | ✅ |
| Lint | ✅ |
| Unit-Tests | ✅ 200/200 |
| Production-Build | ✅ |
| Visual-Regression | ✅ 21/21 (kein Baseline-Update nötig) |

### Hinweis

Während Phase 1 wurde optional vorgeschlagen, auch den Separator anzugleichen (statt nur Counter). User-Entscheidung: separator `opacity-50` → `opacity-70` zusätzlich umsetzen für volle Konsistenz mit PR #467.

https://claude.ai/code/session_01MCyRpvFh86yQDebwAibHGe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCyRpvFh86yQDebwAibHGe)_