### PR TITLE
Polish: Separator-Punkte sichtbar machen (opacity-70 → opacity-90)

### DIFF
--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -114,7 +114,7 @@ export default function KommunizierenMaterialsSection() {
                   }}
                 >
                   <span>{category.label}</span>
-                  <span aria-hidden="true" className="mx-2.5 opacity-70">
+                  <span aria-hidden="true" className="mx-2.5 opacity-90">
                     ·
                   </span>
                   <span>{count}</span>

--- a/client/src/sections/MaterialienLibrarySection.tsx
+++ b/client/src/sections/MaterialienLibrarySection.tsx
@@ -357,7 +357,7 @@ export default function MaterialienLibrarySection() {
                   onClick={() => setActiveCategory(cat.id)}
                 >
                   <span>{cat.label}</span>
-                  <span aria-hidden="true" className="mx-2.5 opacity-70">
+                  <span aria-hidden="true" className="mx-2.5 opacity-90">
                     ·
                   </span>
                   <span>{count}</span>

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -133,7 +133,7 @@ export default function SelbstfuersorgeInfografikenSection() {
                 }}
               >
                 <span>{cat.label}</span>
-                <span aria-hidden="true" className="mx-2.5 opacity-70">
+                <span aria-hidden="true" className="mx-2.5 opacity-90">
                   ·
                 </span>
                 <span>{cat.count}</span>

--- a/client/src/sections/VerstehenMaterialsSection.tsx
+++ b/client/src/sections/VerstehenMaterialsSection.tsx
@@ -126,7 +126,7 @@ export default function VerstehenMaterialsSection() {
                 }}
               >
                 <span>{cat.label}</span>
-                <span aria-hidden="true" className="mx-2.5 opacity-70">
+                <span aria-hidden="true" className="mx-2.5 opacity-90">
                   ·
                 </span>
                 <span>{cat.count}</span>


### PR DESCRIPTION
## Polish-Fix — visuelle Lesbarkeit der Filter-Separator

Reine Polish-Verbesserung. **Kein WCAG-Befund** (Separator-Punkte sind `aria-hidden="true"`), sondern visuelle Lesbarkeit. Erste von zwei empfohlenen Polish-PRs.

### Phase-1-Reproduktion (bestätigt)

Code-Inspektion an den vier verifizierten Stellen:

| Datei | Zeile | Vorher |
|---|---|---|
| `client/src/sections/MaterialienLibrarySection.tsx` | 360 | `opacity-70` |
| `client/src/sections/VerstehenMaterialsSection.tsx` | 129 | `opacity-70` |
| `client/src/sections/KommunizierenMaterialsSection.tsx` | 117 | `opacity-70` |
| `client/src/sections/SelbstfuersorgeInfografikenSection.tsx` | 136 | `opacity-70` |

Tailwind-Klassen sind statisch (keine bedingte Auflösung). Effektive `opacity: 0.7` ist garantiert.

### Befund

Die Filter-Buttons in vier Materials-Sections rendern als Pattern `[LABEL · COUNT]` (z. B. «ALLE·7», «GRUNDLAGEN·4»). Der Mittelpunkt `·` als Separator hatte `opacity-70`, was ihn auf cream-Hintergrund visuell fast verschwinden liess — «ALLE·7» las sich eher wie «ALLE 7» mit grossem Wortabstand, nicht wie ein bewusst getrenntes Label-Counter-Pattern.

### Änderung

```diff
- <span aria-hidden="true" className="mx-2.5 opacity-70">·</span>
+ <span aria-hidden="true" className="mx-2.5 opacity-90">·</span>
```

In allen 4 Dateien identisch.

### Kontrast-Tabelle (Separator gegen `bg #faf7f2`)

| Filter-State | Vorher (`opacity-70`) | Nachher (`opacity-90`) |
|---|--:|--:|
| Aktiv (`#1f2a37`) | 5.36 | **10.18** |
| Inaktiv (`#4f6b5e`) | **2.97** | **4.42** |

### Default-Begründung — `opacity-90`

| Wert | Inaktiv-Kontrast | Δ zu Label/Counter | Bewertung |
|---|--:|--:|---|
| opacity-70 (vorher) | 2.97 | Δ 2.49 | zu blass — visuell verloren |
| opacity-80 | 3.60 | Δ 1.86 | knapp |
| **opacity-90 (gewählt)** | **4.42** | **Δ 1.04** | sichtbar, aber klar subordinate |
| opacity-95 | 4.91 | Δ 0.55 | zu nahe an Label/Counter |

Label und Counter bleiben dominant (`opacity-1`), Separator sichtbar aber subordinate — visuelle Hierarchie erhalten.

### Verification

| Check | Ergebnis |
|---|---|
| Typecheck | ✅ |
| Lint | ✅ |
| Unit-Tests | ✅ 200/200 |
| Production-Build | ✅ |
| Visual-Regression | ✅ 21/21 (kein Baseline-Update nötig — Filter-Bars sind in den Snapshots nicht zentriert, Sub-Pixel-Diff unter Threshold) |

### Acceptance Criteria

- [x] Alle 4 Separator-Spans nutzen `opacity-90` statt `opacity-70`
- [x] Visuelle Hierarchie: Punkt sichtbar als Trenner, klar weniger dominant als Label/Counter
- [x] Keine anderen `opacity-70`-Verwendungen angefasst — legitime Close-Buttons in `dialog.tsx`/`sheet.tsx` mit `hover:opacity-100`-Pattern bleiben unverändert

### Hinweis

Separator ist `aria-hidden="true"` → WCAG wird durch den vorherigen Stand nicht verletzt. Diese PR ist reine visuelle Politur.

Vor/Nach-Screenshot der Filter-Bar wird nach Live-Deploy ergänzt (im Preview-Deploy verifizierbar).

https://claude.ai/code/session_01MCyRpvFh86yQDebwAibHGe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCyRpvFh86yQDebwAibHGe)_