### PR TITLE
Fix browser matrix production follow-up

### DIFF
--- a/client/src/__tests__/notfallkarte-storage.test.tsx
+++ b/client/src/__tests__/notfallkarte-storage.test.tsx
@@ -278,4 +278,34 @@ describe("Notfallkarte storage fallbacks", () => {
       screen.queryByRole("textbox", { name: /name der kontaktperson/i })
     ).not.toBeInTheDocument();
   });
+
+  it("flushes pending changes on pagehide before the debounce completes", async () => {
+    renderPage();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /kontakt hinzufügen/i })
+    );
+    fireEvent.change(screen.getByLabelText(/name der kontaktperson/i), {
+      target: { value: "Sofort speichern" },
+    });
+    fireEvent.change(screen.getByLabelText(/persönliche notizen/i), {
+      target: { value: "Nicht erst nach 500ms" },
+    });
+
+    window.dispatchEvent(new Event("pagehide"));
+
+    const saved = window.localStorage.getItem(NOTFALLKARTE_STORAGE_KEY);
+    expect(saved).toContain("Sofort speichern");
+    expect(saved).toContain("Nicht erst nach 500ms");
+
+    cleanup();
+    renderPage();
+
+    expect(screen.getByLabelText(/persönliche notizen/i)).toHaveValue(
+      "Nicht erst nach 500ms"
+    );
+    expect(screen.getByLabelText(/name der kontaktperson/i)).toHaveValue(
+      "Sofort speichern"
+    );
+  });
 });

--- a/client/src/pages/Notfallkarte.tsx
+++ b/client/src/pages/Notfallkarte.tsx
@@ -58,6 +58,17 @@ function createEmptyData(): NotfallkarteData {
   };
 }
 
+function isEmptyData(data: NotfallkarteData): boolean {
+  return (
+    data.personalContacts.length === 0 &&
+    data.notes.trim() === "" &&
+    data.calmingStrategies.length === DEFAULT_STRATEGIES.length &&
+    data.calmingStrategies.every(
+      (strategy, index) => strategy.text === DEFAULT_STRATEGIES[index]?.text
+    )
+  );
+}
+
 function normalizeData(raw: Partial<NotfallkarteData> | null | undefined) {
   const fallback = createEmptyData();
 
@@ -283,12 +294,17 @@ export default function Notfallkarte() {
   const [storageError, setStorageError] = useState(false);
   const [announcement, setAnnouncement] = useState("");
   const skipNextSaveRef = useRef(false);
+  const latestDataRef = useRef(data);
   const printIntervalRef = useRef<number | null>(null);
   const printTimeoutRef = useRef<number | null>(null);
 
   useEffect(() => {
     if (!isStorageAvailable()) setStorageError(true);
   }, []);
+
+  useEffect(() => {
+    latestDataRef.current = data;
+  }, [data]);
 
   useEffect(
     () => () => {
@@ -313,6 +329,28 @@ export default function Notfallkarte() {
 
     return () => window.clearTimeout(timeoutId);
   }, [data]);
+
+  useEffect(() => {
+    const flushPendingData = () => {
+      const currentData = latestDataRef.current;
+
+      if (isEmptyData(currentData)) {
+        return;
+      }
+
+      if (!saveData(currentData)) {
+        setStorageError(true);
+      }
+    };
+
+    window.addEventListener("pagehide", flushPendingData);
+    window.addEventListener("beforeunload", flushPendingData);
+
+    return () => {
+      window.removeEventListener("pagehide", flushPendingData);
+      window.removeEventListener("beforeunload", flushPendingData);
+    };
+  }, []);
 
   const handleDeleteData = useCallback(() => {
     const confirmed = window.confirm(

--- a/qa/scripts/release-browser-matrix.mjs
+++ b/qa/scripts/release-browser-matrix.mjs
@@ -152,14 +152,26 @@ async function visit(page, route) {
   await page.waitForLoadState("networkidle");
 }
 
-async function expectHashSectionOpen(page, route, buttonName, contentText) {
+async function expectHashSectionOpen(
+  page,
+  route,
+  { buttonName, headingName, contentText }
+) {
   await visit(page, route);
-  const toggle = page.getByRole("button", { name: buttonName });
-  await toggle.waitFor();
-  await page.waitForFunction(
-    element => element?.getAttribute("aria-expanded") === "true",
-    await toggle.elementHandle()
-  );
+
+  if (buttonName) {
+    const toggle = page.getByRole("button", { name: buttonName });
+    await toggle.waitFor();
+    await page.waitForFunction(
+      element => element?.getAttribute("aria-expanded") === "true",
+      await toggle.elementHandle()
+    );
+  } else if (headingName) {
+    await page.getByRole("heading", { name: headingName }).waitFor();
+  } else {
+    throw new Error("Hash-Case benötigt buttonName oder headingName");
+  }
+
   await page.getByText(contentText).waitFor();
 }
 
@@ -378,8 +390,7 @@ async function runFlow(page, profile) {
       .getByRole("heading", { level: 1, name: /Materialien/i })
       .waitFor();
     await page
-      .locator("button[aria-pressed]")
-      .filter({ hasText: "Verstehen" })
+      .getByRole("tab", { name: /Verstehen/i })
       .first()
       .click();
     await page.locator("article").first().waitFor();
@@ -481,7 +492,7 @@ async function runFlow(page, profile) {
   const hashCases = [
     {
       route: "/unterstuetzen/therapie#therapieangebote",
-      buttonName: "Abschnitt Therapieangebote im Kanton Zürich",
+      headingName: "Therapieangebote im Kanton Zürich",
       contentText: "HYPE Züri",
     },
     {
@@ -507,8 +518,7 @@ async function runFlow(page, profile) {
       await expectHashSectionOpen(
         page,
         hashCase.route,
-        hashCase.buttonName,
-        hashCase.contentText
+        hashCase
       );
     });
   }


### PR DESCRIPTION
## Summary
- flush pending personal notfallkarte changes on pagehide/beforeunload so immediate reloads keep entered data
- cover that persistence path with a regression test
- align the browser-matrix selectors with the current Materialien tabs and the static therapieangebote anchor

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build