### PR TITLE
[codex] Curate topic material sections

### DIFF
--- a/client/src/__tests__/selbstfuersorge-infografiken.test.tsx
+++ b/client/src/__tests__/selbstfuersorge-infografiken.test.tsx
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 import SelbstfuersorgeInfografikenSection from "@/sections/SelbstfuersorgeInfografikenSection";
 
 describe("SelbstfuersorgeInfografikenSection", () => {
-  it("shows text version links for Selbstfürsorge-Handouts", () => {
+  it("shows curated text version links for Selbstfürsorge-Handouts", () => {
     render(
       <Router>
         <SelbstfuersorgeInfografikenSection />
@@ -15,10 +15,10 @@ describe("SelbstfuersorgeInfografikenSection", () => {
     // Content ist immer sichtbar. Kein vorheriges fireEvent.click nötig.
 
     expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Radikale Akzeptanz/i,
+      screen.getByRole("heading", {
+        name: /Drei Materialien, die Selbstfürsorge greifbar machen/i,
       })
-    ).toHaveAttribute("href", "/materialien/text/radikale-akzeptanz");
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
         name: /Textversion lesen: Die Sauerstoffmaske/i,
@@ -36,16 +36,11 @@ describe("SelbstfuersorgeInfografikenSection", () => {
     ).toHaveAttribute("href", "/materialien/text/energie-konto");
     expect(
       screen.getByRole("link", {
-        name: /Textversion lesen: Erlaubnis-Karte/i,
-      })
-    ).toHaveAttribute("href", "/materialien/text/erlaubnis-karte");
-    expect(
-      screen.getByRole("link", {
-        name: /PDF öffnen: Radikale Akzeptanz \(neuer Tab\)/i,
+        name: /PDF öffnen: Die Sauerstoffmaske \(neuer Tab\)/i,
       })
     ).toHaveAttribute(
       "href",
-      "/api/material-download/radikale-akzeptanz?disposition=inline"
+      "/api/material-download/selbstfuersorge-sauerstoffmaske?disposition=inline"
     );
   });
 });

--- a/client/src/__tests__/smoke.test.tsx
+++ b/client/src/__tests__/smoke.test.tsx
@@ -861,24 +861,14 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toBeInTheDocument();
   });
 
-  it("Grenzen: zeigt Textversionen für Grenzen-Handouts", async () => {
+  it("Grenzen: zeigt kuratierte Textversionen für Grenzen-Handouts", async () => {
     const { default: Grenzen } = await import("@/pages/Grenzen");
     withRouter(<Grenzen />);
     expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Spickzettel Grenzen/i,
+      screen.getByRole("heading", {
+        name: /Drei Materialien für klare Grenzen/i,
       })
-    ).toHaveAttribute("href", "/materialien/text/grenzen-spickzettel");
-    expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Die DEAR-Technik/i,
-      })
-    ).toHaveAttribute("href", "/materialien/text/dear");
-    expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Spiegeln statt Aufsaugen/i,
-      })
-    ).toHaveAttribute("href", "/materialien/text/spiegeln-statt-aufsaugen");
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
         name: /Textversion lesen: Die 4 Arten von Grenzen/i,
@@ -891,29 +881,24 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/materialien/text/grenzen-erkennen");
     expect(
       screen.getByRole("link", {
-        name: /Textversion lesen: L\.M\.K\. \(Lebe Mit Konsequenzen\)/i,
+        name: /Textversion lesen: Spickzettel Grenzen/i,
       })
-    ).toHaveAttribute("href", "/materialien/text/lmk");
+    ).toHaveAttribute("href", "/materialien/text/grenzen-spickzettel");
   });
 
-  it("Kommunizieren: zeigt Textversionen für Kommunizieren-Handouts", async () => {
+  it("Kommunizieren: zeigt kuratierte Textversionen für Kommunizieren-Handouts", async () => {
     const { default: Kommunizieren } = await import("@/pages/Kommunizieren");
     withRouter(<Kommunizieren />);
     expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Wenn Worte treffen/i,
+      screen.getByRole("heading", {
+        name: /Drei Materialien für schwierige Gespräche/i,
       })
-    ).toHaveAttribute("href", "/materialien/text/wenn-worte-treffen");
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
         name: /Textversion lesen: Wenn Gespräche kippen: 3 Schritte/i,
       })
     ).toHaveAttribute("href", "/materialien/text/gespraeche-kippen");
-    expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Grenzen setzen, ohne zu eskalieren/i,
-      })
-    ).toHaveAttribute("href", "/materialien/text/grenzen-ohne-eskalation");
     expect(
       screen.getByRole("link", {
         name: /Textversion lesen: Pause statt Streit/i,
@@ -924,16 +909,6 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Zuhören ohne Zustimmen/i,
       })
     ).toHaveAttribute("href", "/materialien/text/zuhoeren-ohne-zustimmen");
-    expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Beispiel-Dialog/i,
-      })
-    ).toHaveAttribute("href", "/materialien/text/beispiel-dialog");
-    expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Spickzettel Krisenkommunikation \(A4\)/i,
-      })
-    ).toHaveAttribute("href", "/materialien/text/krisenkommunikation");
   });
 
   it("Genesung: zeigt Textversionen für Genesung-Handouts", async () => {
@@ -1022,12 +997,17 @@ describe("Smoke Tests – Kritische Seiten", () => {
     ).toHaveAttribute("href", "/materialien/text/4-alltags-tipps");
   });
 
-  it("Selbstfürsorge: zeigt Textversionen für Selbstfürsorge-Handouts", async () => {
+  it("Selbstfürsorge: zeigt kuratierte Textversionen für Selbstfürsorge-Handouts", async () => {
     const { default: Selbstfuersorge } =
       await import("@/pages/Selbstfuersorge");
     withRouter(<Selbstfuersorge />);
     // Materialien-Section ist nach Phase-2-Migration kein collapsible
     // ContentSection mehr — Content ist immer sichtbar.
+    expect(
+      screen.getByRole("heading", {
+        name: /Drei Materialien, die Selbstfürsorge greifbar machen/i,
+      })
+    ).toBeInTheDocument();
     expect(
       screen.getByRole("link", {
         name: /Textversion lesen: Die Sauerstoffmaske/i,
@@ -1043,11 +1023,6 @@ describe("Smoke Tests – Kritische Seiten", () => {
         name: /Textversion lesen: Ihr Energie-Konto/i,
       })
     ).toHaveAttribute("href", "/materialien/text/energie-konto");
-    expect(
-      screen.getByRole("link", {
-        name: /Textversion lesen: Erlaubnis-Karte/i,
-      })
-    ).toHaveAttribute("href", "/materialien/text/erlaubnis-karte");
   });
 
   it("NotFound: rendert 404-Seite", async () => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -535,6 +535,143 @@
       min-width: 240px;
     }
   }
+
+  /* Curated topic materials: one visual anchor plus two selected next steps.
+     Used on content pages where the full material library would create noise. */
+  .topic-materials-note {
+    font-size: var(--text-sm);
+    line-height: var(--lh-relaxed);
+    color: var(--fg-secondary);
+    max-width: 30rem;
+  }
+
+  .topic-materials-grid {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  .topic-materials-stack {
+    display: grid;
+    gap: var(--space-4);
+  }
+
+  @media (min-width: 1024px) {
+    .topic-materials-grid {
+      grid-template-columns: minmax(0, 1.16fr) minmax(19rem, 0.84fr);
+      align-items: stretch;
+    }
+  }
+
+  .topic-material-card {
+    display: grid;
+    min-width: 0;
+    overflow: hidden;
+    border: 1px solid var(--rule-color);
+    border-radius: 0.75rem;
+    background: var(--bg-elevated);
+  }
+
+  .topic-material-card__media {
+    display: block;
+    min-width: 0;
+    background: var(--bg-cream-deep);
+  }
+
+  .topic-material-card__media img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    padding: var(--space-3);
+  }
+
+  .topic-material-card--featured .topic-material-card__media {
+    aspect-ratio: 4 / 3;
+    border-bottom: 1px solid var(--rule-color);
+  }
+
+  .topic-material-card--featured .topic-material-card__media img {
+    padding: var(--space-4);
+  }
+
+  .topic-material-card--compact {
+    grid-template-columns: minmax(9rem, 0.42fr) minmax(0, 1fr);
+  }
+
+  .topic-material-card--compact .topic-material-card__media {
+    min-height: 11rem;
+    border-right: 1px solid var(--rule-color);
+  }
+
+  .topic-material-card__content {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    padding: var(--space-4);
+  }
+
+  .topic-material-card--compact .topic-material-card__content {
+    padding: var(--space-3);
+  }
+
+  .topic-material-card__kicker {
+    margin: 0;
+    font-size: var(--text-xs);
+    font-weight: 500;
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+    color: var(--fg-tertiary);
+  }
+
+  .topic-material-card__title {
+    margin-top: var(--space-2);
+    font-family: var(--font-display);
+    font-size: var(--text-xl);
+    font-weight: var(--weight-display);
+    line-height: var(--lh-snug);
+    letter-spacing: var(--tracking-tight);
+    color: var(--fg-primary);
+  }
+
+  .topic-material-card--compact .topic-material-card__title {
+    font-size: var(--text-md);
+  }
+
+  .topic-material-card__description,
+  .topic-material-card__guidance {
+    margin-top: var(--space-2);
+    font-size: var(--text-sm);
+    line-height: var(--lh-relaxed);
+    color: var(--fg-secondary);
+  }
+
+  .topic-material-card__guidance {
+    padding-left: var(--space-3);
+    border-left: 2px solid var(--rule-color-strong);
+  }
+
+  .topic-material-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2) var(--space-4);
+    margin-top: auto;
+    padding-top: var(--space-3);
+    font-size: var(--text-sm);
+  }
+
+  .topic-materials-library-link {
+    margin-top: var(--space-5);
+    font-size: var(--text-sm);
+  }
+
+  @media (max-width: 639px) {
+    .topic-material-card--compact {
+      grid-template-columns: minmax(6.5rem, 0.38fr) minmax(0, 1fr);
+    }
+
+    .topic-material-card--compact .topic-material-card__media {
+      min-height: 9rem;
+    }
+  }
 }
 
 /* Scrollbar ausblenden für horizontale Tab-Leisten */

--- a/client/src/pages/Grenzen.tsx
+++ b/client/src/pages/Grenzen.tsx
@@ -2,7 +2,6 @@ import { useCallback } from "react";
 import ContentSection from "@/components/ContentSection";
 import {
   DisplayHeading,
-  EditorialBody,
   EditorialProse,
   EditorialPullQuote,
   EditorialSection,
@@ -17,10 +16,8 @@ import RelatedLinksEditorial from "@/components/RelatedLinksEditorial";
 import ReviewBadge from "@/components/ReviewBadge";
 import SEO, { MedicalPageSchema } from "@/components/SEO";
 import { TableOfContents } from "@/components/UXEnhancements";
-import { grenzenItems } from "@/content/grenzen";
-import { getHandoutOpenHref } from "@/content/handouts";
-import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
 import { kontaktByIdStrict } from "@/data/kontakte";
+import GrenzenMaterialsSection from "@/sections/GrenzenMaterialsSection";
 import { Link } from "wouter";
 
 /** Öffnet eine ContentSection via Custom Event und scrollt dorthin. */
@@ -848,99 +845,8 @@ export default function Grenzen() {
         </EditorialSection.Body>
       </EditorialSection>
 
-      {/* ── 8 Materialien ── EditorialSection cream + full-width tile section */}
-      <EditorialSection variant="cream">
-        <EditorialSection.MarginNote>
-          <span
-            className="block text-[13px] font-medium uppercase"
-            style={{
-              color: "var(--accent-label)",
-              letterSpacing: "var(--tracking-caps)",
-              lineHeight: 1.3,
-            }}
-          >
-            Materialien zum Vertiefen
-          </span>
-          <div
-            aria-hidden="true"
-            className="mt-3 border-t"
-            style={{ borderColor: "var(--rule-color)" }}
-          />
-        </EditorialSection.MarginNote>
-        <EditorialSection.Body>
-          <EyebrowLabel>Materialien</EyebrowLabel>
-          <DisplayHeading level={2}>
-            Spickzettel und Infografiken zu Grenzen
-          </DisplayHeading>
-          <EditorialBody className="max-w-[36em]">
-            Wenn verfügbar, führt «Textversion lesen» zur Web-Version. «PDF
-            öffnen» öffnet die A4-Druckversion im neuen Tab.
-          </EditorialBody>
-        </EditorialSection.Body>
-      </EditorialSection>
-
-      <section
-        className="bg-[var(--bg-primary)] px-[var(--container-pad)] pb-20 md:px-[var(--container-pad-md)] md:pb-[120px]"
-        aria-label="Spickzettel und Infografiken zu Grenzen — Tile-Liste"
-      >
-        <div className="mx-auto max-w-page">
-          <div className="grid grid-cols-1 gap-x-8 gap-y-10 sm:grid-cols-2 xl:grid-cols-3">
-            {grenzenItems.map(item => {
-              const textVersionHref = getHandoutTextVersionHrefBySource(
-                item.pdfUrl
-              );
-              const pdfHref = getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl;
-              return (
-                <article
-                  key={item.title}
-                  className="space-y-3 border-t pt-6"
-                  style={{ borderColor: "var(--rule-color)" }}
-                >
-                  <img
-                    src={item.thumbnailUrl ?? item.url}
-                    alt={item.title}
-                    className="aspect-[3/4] w-full rounded-md object-cover object-top"
-                    style={{ backgroundColor: "var(--bg-elevated)" }}
-                    loading="lazy"
-                    width={600}
-                    height={848}
-                    decoding="async"
-                  />
-                  <h3 style={h4Style}>{item.title}</h3>
-                  <div
-                    className="flex flex-wrap gap-x-5 gap-y-1"
-                    style={{ fontSize: "var(--text-sm)" }}
-                  >
-                    {textVersionHref && (
-                      <Link
-                        href={textVersionHref}
-                        className="editorial-link"
-                        aria-label={`Textversion lesen: ${item.title}`}
-                      >
-                        Textversion lesen
-                      </Link>
-                    )}
-                    <a
-                      href={pdfHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="editorial-link"
-                      aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                    >
-                      PDF öffnen
-                    </a>
-                  </div>
-                </article>
-              );
-            })}
-          </div>
-          <p className="mt-12" style={bodyStyle}>
-            <Link href="/materialien" className="editorial-link">
-              Alle Materialien ansehen
-            </Link>
-          </p>
-        </div>
-      </section>
+      {/* ── 8 Materialien ── kuratierte Auswahl statt kompletter Galerie */}
+      <GrenzenMaterialsSection />
 
       {/* ── 9 Weiter-Hinweis ── */}
       <EditorialSection variant="cream">

--- a/client/src/sections/CuratedMaterialsSection.tsx
+++ b/client/src/sections/CuratedMaterialsSection.tsx
@@ -1,0 +1,169 @@
+import { ExternalLink, FileText } from "lucide-react";
+import { Link } from "wouter";
+import {
+  DisplayHeading,
+  EditorialBody,
+  EditorialSection,
+  EyebrowLabel,
+} from "@/components/editorial";
+import { getHandoutOpenHref } from "@/content/handouts";
+import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
+
+export interface CuratedMaterialCard {
+  id: string;
+  title: string;
+  description: string;
+  categoryLabel: string;
+  imageUrl: string;
+  thumbnailUrl?: string;
+  pdfUrl: string;
+  previewUrl?: string;
+  guidance?: string;
+}
+
+interface CuratedMaterialsSectionProps {
+  marginLabel: string;
+  title: string;
+  intro: string;
+  curationNote: string;
+  items: CuratedMaterialCard[];
+  ariaLabel: string;
+  allMaterialsLabel?: string;
+}
+
+export default function CuratedMaterialsSection({
+  marginLabel,
+  title,
+  intro,
+  curationNote,
+  items,
+  ariaLabel,
+  allMaterialsLabel = "Alle Materialien ansehen",
+}: CuratedMaterialsSectionProps) {
+  const [featured, ...supporting] = items.slice(0, 3);
+
+  if (!featured) return null;
+
+  return (
+    <>
+      <EditorialSection variant="cream" density="compact">
+        <EditorialSection.MarginNote>
+          <span
+            className="block text-[13px] font-medium uppercase"
+            style={{
+              color: "var(--accent-label)",
+              letterSpacing: "var(--tracking-caps)",
+              lineHeight: 1.3,
+            }}
+          >
+            {marginLabel}
+          </span>
+          <div
+            aria-hidden="true"
+            className="mt-3 border-t"
+            style={{ borderColor: "var(--rule-color)" }}
+          />
+        </EditorialSection.MarginNote>
+        <EditorialSection.Body>
+          <EyebrowLabel>Materialien</EyebrowLabel>
+          <DisplayHeading level={2}>{title}</DisplayHeading>
+          <EditorialBody className="max-w-[36em]">{intro}</EditorialBody>
+        </EditorialSection.Body>
+        <EditorialSection.Aside background="cream-deep">
+          <p className="topic-materials-note">{curationNote}</p>
+        </EditorialSection.Aside>
+      </EditorialSection>
+
+      <section
+        className="bg-[var(--bg-primary)] px-[var(--container-pad)] pb-[var(--section-y-normal-mobile)] md:px-[var(--container-pad-md)] md:pb-[var(--section-y-normal-desktop)]"
+        aria-label={ariaLabel}
+      >
+        <div className="mx-auto max-w-page">
+          <div className="topic-materials-grid">
+            <MaterialCard item={featured} featured />
+            <div className="topic-materials-stack">
+              {supporting.map(item => (
+                <MaterialCard key={item.id} item={item} />
+              ))}
+            </div>
+          </div>
+          <p className="topic-materials-library-link">
+            <Link href="/materialien" className="editorial-link">
+              {allMaterialsLabel}
+            </Link>
+          </p>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function MaterialCard({
+  item,
+  featured = false,
+}: {
+  item: CuratedMaterialCard;
+  featured?: boolean;
+}) {
+  const textVersionHref = getHandoutTextVersionHrefBySource(item.pdfUrl);
+  const pdfHref = getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl;
+  const imageSrc = featured
+    ? item.imageUrl
+    : (item.thumbnailUrl ?? item.imageUrl);
+  const previewHref = item.previewUrl ?? item.imageUrl;
+
+  return (
+    <article
+      className={`topic-material-card ${featured ? "topic-material-card--featured" : "topic-material-card--compact"}`}
+    >
+      <a
+        href={previewHref}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`${item.title} – Vorschau öffnen`}
+        className="topic-material-card__media"
+      >
+        <img
+          src={imageSrc}
+          alt={item.title}
+          loading={featured ? "eager" : "lazy"}
+          decoding="async"
+        />
+      </a>
+      <div className="topic-material-card__content">
+        <p className="topic-material-card__kicker">{item.categoryLabel}</p>
+        <h3 className="topic-material-card__title">{item.title}</h3>
+        <p className="topic-material-card__description">{item.description}</p>
+        {item.guidance ? (
+          <p className="topic-material-card__guidance">{item.guidance}</p>
+        ) : null}
+        <div className="topic-material-card__actions">
+          {textVersionHref ? (
+            <Link
+              href={textVersionHref}
+              aria-label={`Textversion lesen: ${item.title}`}
+              className="editorial-link"
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <FileText className="h-4 w-4" />
+                Textversion
+              </span>
+            </Link>
+          ) : null}
+          <a
+            href={pdfHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
+            className="editorial-link"
+          >
+            <span className="inline-flex items-center gap-1.5">
+              <ExternalLink className="h-4 w-4" />
+              PDF
+            </span>
+          </a>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/client/src/sections/GrenzenMaterialsSection.tsx
+++ b/client/src/sections/GrenzenMaterialsSection.tsx
@@ -1,0 +1,56 @@
+import CuratedMaterialsSection, {
+  type CuratedMaterialCard,
+} from "@/sections/CuratedMaterialsSection";
+import { grenzenItems } from "@/content/grenzen";
+
+const selectedIds = [
+  "4-arten-von-grenzen",
+  "grenzen-erkennen",
+  "grenzen-spickzettel",
+] as const;
+
+const guidanceById: Record<(typeof selectedIds)[number], string> = {
+  "4-arten-von-grenzen":
+    "Als Überblick: Welche Grenze ist gerade gemeint — körperlich, emotional, zeitlich oder materiell?",
+  "grenzen-erkennen":
+    "Für den Moment davor: Körpersignale ernst nehmen, bevor eine Grenze erst im Konflikt sichtbar wird.",
+  "grenzen-spickzettel":
+    "Für die Umsetzung: kurze Sätze, die Sie in ruhigen Momenten vorbereiten können.",
+};
+
+export default function GrenzenMaterialsSection() {
+  return (
+    <CuratedMaterialsSection
+      marginLabel="Auswahl"
+      title="Drei Materialien für klare Grenzen"
+      intro="Hier geht es nicht um möglichst viele Downloads, sondern um Orientierung: Grenze erkennen, Art der Grenze benennen, Satz vorbereiten."
+      curationNote="Grenzsetzung wird schnell unübersichtlich. Diese Auswahl ist deshalb absichtlich klein: erst sortieren, dann formulieren, dann konsequent bleiben."
+      items={curatedItems}
+      ariaLabel="Ausgewählte Materialien zu Grenzen"
+    />
+  );
+}
+
+const curatedItems: CuratedMaterialCard[] = selectedIds.map(id => {
+  const item = grenzenItems.find(candidate => candidate.id === id);
+  if (!item) {
+    throw new Error(`Grenzen-Material fehlt: ${id}`);
+  }
+
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description,
+    categoryLabel: categoryLabel(item.category),
+    imageUrl: item.url,
+    thumbnailUrl: item.thumbnailUrl,
+    pdfUrl: item.pdfUrl,
+    guidance: guidanceById[id],
+  };
+});
+
+function categoryLabel(category: (typeof grenzenItems)[number]["category"]) {
+  if (category === "erkennen") return "Erkennen";
+  if (category === "kommunizieren") return "Formulieren";
+  return "Handeln";
+}

--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -1,219 +1,56 @@
-import { useRef, useState } from "react";
-import { ExternalLink, FileText } from "lucide-react";
-import { Link } from "wouter";
-import {
-  DisplayHeading,
-  EditorialBody,
-  EditorialSection,
-  EyebrowLabel,
-} from "@/components/editorial";
-import { EditorialPillButton } from "@/components/ui/EditorialPillButton";
-import {
-  kommItems,
-  kommSubcategories,
-  type KommunikationsKategorie,
-} from "@/content/kommunizieren";
-import { getHandoutOpenHref } from "@/content/handouts";
-import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
+import CuratedMaterialsSection, {
+  type CuratedMaterialCard,
+} from "@/sections/CuratedMaterialsSection";
+import { kommItems } from "@/content/kommunizieren";
 
-const labelStyle = {
-  fontSize: "var(--text-xs)",
-  letterSpacing: "var(--tracking-caps)",
-  color: "var(--fg-tertiary)",
-  fontWeight: 500,
-} as const;
+const selectedIds = [
+  "zuhoeren-ohne-zustimmen",
+  "gespraeche-kippen",
+  "pause-statt-streit",
+] as const;
 
-const entryTitleStyle = {
-  fontFamily: "var(--font-display)",
-  fontSize: "var(--text-md)",
-  fontWeight: "var(--weight-display)",
-  lineHeight: "var(--lh-snug)",
-  color: "var(--fg-primary)",
-  letterSpacing: "var(--tracking-tight)",
-};
-
-const bodyStyle = {
-  fontSize: "var(--text-sm)",
-  lineHeight: "var(--lh-relaxed)",
-  color: "var(--fg-secondary)",
+const guidanceById: Record<(typeof selectedIds)[number], string> = {
+  "zuhoeren-ohne-zustimmen":
+    "Als Erstes öffnen, wenn ein Gespräch emotional hochgeht und Sie bei Beziehung bleiben möchten, ohne allem zuzustimmen.",
+  "gespraeche-kippen":
+    "Für den Moment, in dem aus Austausch plötzlich Streit, Rückzug oder Rechtfertigung wird.",
+  "pause-statt-streit":
+    "Hilft, eine Unterbrechung nicht als Abbruch, sondern als Schutz des Gesprächs zu formulieren.",
 };
 
 export default function KommunizierenMaterialsSection() {
-  const [activeFilter, setActiveFilter] =
-    useState<KommunikationsKategorie>("alle");
-  const gridRef = useRef<HTMLDivElement>(null);
-
-  const filteredItems =
-    activeFilter === "alle"
-      ? kommItems
-      : kommItems.filter(item => item.category === activeFilter);
-
-  const scrollToResults = () => {
-    setTimeout(() => {
-      gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }, 50);
-  };
-
   return (
-    <>
-      <EditorialSection variant="cream">
-        <EditorialSection.MarginNote>
-          <span
-            className="block text-[13px] font-medium uppercase"
-            style={{
-              color: "var(--accent-label)",
-              letterSpacing: "var(--tracking-caps)",
-              lineHeight: 1.3,
-            }}
-          >
-            Materialien zum Vertiefen
-          </span>
-          <div
-            aria-hidden="true"
-            className="mt-3 border-t"
-            style={{ borderColor: "var(--rule-color)" }}
-          />
-        </EditorialSection.MarginNote>
-        <EditorialSection.Body>
-          <EyebrowLabel>Materialien</EyebrowLabel>
-          <DisplayHeading level={2}>Spickzettel & Infografiken</DisplayHeading>
-          <EditorialBody className="max-w-[36em]">
-            Diese Materialien verdichten Gesprächstechniken, Deeskalation und
-            konkrete Formulierungen. Wenn verfügbar, führt «Textversion lesen»
-            zur lesbaren Web-Version. «PDF öffnen» öffnet die A4-Druckversion im
-            neuen Tab.
-          </EditorialBody>
-        </EditorialSection.Body>
-      </EditorialSection>
-
-      <section
-        className="bg-[var(--bg-primary)] px-[var(--container-pad)] pb-20 md:px-[var(--container-pad-md)] md:pb-[120px]"
-        aria-label="Materialien zum Vertiefen — Filter und Tile-Liste"
-      >
-        <div className="mx-auto max-w-page">
-          <div
-            className="flex flex-wrap items-baseline gap-x-1 gap-y-2 overflow-x-auto pb-3"
-            role="tablist"
-            aria-label="Filter Kommunikations-Materialien"
-          >
-            {kommSubcategories.map(category => {
-              const count =
-                category.id === "alle"
-                  ? kommItems.length
-                  : kommItems.filter(item => item.category === category.id)
-                      .length;
-
-              return (
-                <EditorialPillButton
-                  key={category.id}
-                  variant="filter"
-                  selected={activeFilter === category.id}
-                  onClick={() => {
-                    setActiveFilter(category.id);
-                    scrollToResults();
-                  }}
-                >
-                  <span>{category.label}</span>
-                  <span aria-hidden="true" className="mx-2.5 opacity-90">
-                    ·
-                  </span>
-                  <span>{count}</span>
-                </EditorialPillButton>
-              );
-            })}
-          </div>
-
-          <div
-            ref={gridRef}
-            className="mt-8 grid grid-cols-1 gap-x-8 gap-y-10 sm:grid-cols-2 xl:grid-cols-3"
-          >
-            {filteredItems.map(item => {
-              const textVersionHref = getHandoutTextVersionHrefBySource(
-                item.pdfUrl
-              );
-              const pdfHref = getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl;
-
-              return (
-                <article
-                  key={item.title}
-                  className="space-y-3 border-t pt-6"
-                  style={{ borderColor: "var(--rule-color)" }}
-                >
-                  <a
-                    href={item.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`${item.title} – Vorschau öffnen`}
-                    className="block overflow-hidden rounded-sm"
-                    style={{ backgroundColor: "var(--bg-elevated)" }}
-                  >
-                    <img
-                      src={item.thumbnailUrl ?? item.url}
-                      alt={item.title}
-                      className="aspect-[4/3] w-full object-cover object-top"
-                      loading="lazy"
-                      width={600}
-                      height={848}
-                      decoding="async"
-                    />
-                  </a>
-
-                  <p className="uppercase" style={labelStyle}>
-                    {categoryLabel(item.category)}
-                  </p>
-                  <h3 style={entryTitleStyle}>{item.title}</h3>
-                  <p style={bodyStyle}>{item.description}</p>
-
-                  <p
-                    className="flex flex-wrap gap-x-5 gap-y-1 pt-1"
-                    style={{ fontSize: "var(--text-sm)" }}
-                  >
-                    {textVersionHref ? (
-                      <Link
-                        href={textVersionHref}
-                        aria-label={`Textversion lesen: ${item.title}`}
-                        className="editorial-link"
-                      >
-                        <span className="inline-flex items-center gap-1.5">
-                          <FileText className="h-4 w-4" />
-                          Textversion lesen
-                        </span>
-                      </Link>
-                    ) : null}
-                    <a
-                      href={pdfHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                      className="editorial-link"
-                    >
-                      <span className="inline-flex items-center gap-1.5">
-                        <ExternalLink className="h-4 w-4" />
-                        PDF öffnen
-                      </span>
-                    </a>
-                  </p>
-                </article>
-              );
-            })}
-          </div>
-
-          <p
-            className="mt-12 flex flex-wrap gap-x-5 gap-y-1"
-            style={{ fontSize: "var(--text-sm)" }}
-          >
-            <Link href="/materialien" className="editorial-link">
-              Alle Materialien ansehen
-            </Link>
-          </p>
-        </div>
-      </section>
-    </>
+    <CuratedMaterialsSection
+      marginLabel="Auswahl"
+      title="Drei Materialien für schwierige Gespräche"
+      intro="Nicht jede Gesprächssituation braucht eine ganze Bibliothek. Diese Auswahl führt von Validierung über Deeskalation zur rechtzeitigen Pause."
+      curationNote="Die vollständige Materialsammlung bleibt auf der Bibliotheksseite. Hier stehen nur die drei Hilfen, die beim Lesen dieser Seite unmittelbar weiterführen."
+      items={curatedItems}
+      ariaLabel="Ausgewählte Materialien für schwierige Gespräche"
+    />
   );
 }
 
-function categoryLabel(category: Exclude<KommunikationsKategorie, "alle">) {
-  if (category === "techniken") return "Techniken";
-  if (category === "konflikte") return "Konflikte";
+const curatedItems: CuratedMaterialCard[] = selectedIds.map(id => {
+  const item = kommItems.find(candidate => candidate.id === id);
+  if (!item) {
+    throw new Error(`Kommunikations-Material fehlt: ${id}`);
+  }
+
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.description,
+    categoryLabel: categoryLabel(item.category),
+    imageUrl: item.url,
+    thumbnailUrl: item.thumbnailUrl,
+    pdfUrl: item.pdfUrl,
+    guidance: guidanceById[id],
+  };
+});
+
+function categoryLabel(category: (typeof kommItems)[number]["category"]) {
+  if (category === "techniken") return "Technik";
+  if (category === "konflikte") return "Konfliktmoment";
   return "Praxis";
 }

--- a/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
+++ b/client/src/sections/SelbstfuersorgeInfografikenSection.tsx
@@ -1,237 +1,61 @@
-import { useRef, useState } from "react";
-import { Link } from "wouter";
-import { ExternalLink, FileText } from "lucide-react";
-import {
-  DisplayHeading,
-  EditorialBody,
-  EditorialSection,
-  EyebrowLabel,
-} from "@/components/editorial";
-import { EditorialPillButton } from "@/components/ui/EditorialPillButton";
-import {
-  selbstfuersorgeInfografiken,
-  type SelbstfuersorgeKategorie,
-} from "@/content/selbstfuersorge";
-import { getHandoutOpenHref } from "@/content/handouts";
-import { getHandoutTextVersionHrefBySource } from "@/content/handoutTextVersions";
+import CuratedMaterialsSection, {
+  type CuratedMaterialCard,
+} from "@/sections/CuratedMaterialsSection";
+import { selbstfuersorgeInfografiken } from "@/content/selbstfuersorge";
 
-const selbstfuersorgeCategories = [
-  {
-    id: "alle",
-    label: "Alle",
-    count: selbstfuersorgeInfografiken.length,
-  },
-  {
-    id: "erkennen",
-    label: "Erkennen",
-    count: selbstfuersorgeInfografiken.filter(i => i.category === "erkennen")
-      .length,
-  },
-  {
-    id: "techniken",
-    label: "Techniken",
-    count: selbstfuersorgeInfografiken.filter(i => i.category === "techniken")
-      .length,
-  },
-  {
-    id: "ressourcen",
-    label: "Ressourcen",
-    count: selbstfuersorgeInfografiken.filter(i => i.category === "ressourcen")
-      .length,
-  },
+const selectedIds = [
+  "sauerstoffmaske",
+  "stopp-technik",
+  "energie-konto",
 ] as const;
 
-const labelStyle = {
-  fontSize: "var(--text-xs)",
-  letterSpacing: "var(--tracking-caps)",
-  color: "var(--fg-tertiary)",
-  fontWeight: 500,
-} as const;
-
-const entryTitleStyle = {
-  fontFamily: "var(--font-display)",
-  fontSize: "var(--text-md)",
-  fontWeight: "var(--weight-display)",
-  lineHeight: "var(--lh-snug)",
-  color: "var(--fg-primary)",
-  letterSpacing: "var(--tracking-tight)",
-};
-
-const bodyStyle = {
-  fontSize: "var(--text-sm)",
-  lineHeight: "var(--lh-relaxed)",
-  color: "var(--fg-secondary)",
+const guidanceById: Record<(typeof selectedIds)[number], string> = {
+  sauerstoffmaske:
+    "Der visuelle Kern dieser Seite: Selbstfürsorge ist kein Extra, sondern das, was den Kreislauf stabilisiert.",
+  "stopp-technik":
+    "Für akute Überforderung: ein kurzer Ablauf, bevor Sie antworten, retten oder weiterdiskutieren.",
+  "energie-konto":
+    "Für die ruhigere Nacharbeit: Was entzieht Kraft, was gibt sie zurück, und wo braucht es Ausgleich?",
 };
 
 export default function SelbstfuersorgeInfografikenSection() {
-  const [activeFilter, setActiveFilter] =
-    useState<SelbstfuersorgeKategorie>("alle");
-  const gridRef = useRef<HTMLDivElement>(null);
-
-  const filteredItems =
-    activeFilter === "alle"
-      ? selbstfuersorgeInfografiken
-      : selbstfuersorgeInfografiken.filter(
-          item => item.category === activeFilter
-        );
-
-  const scrollToResults = () => {
-    setTimeout(() => {
-      gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
-    }, 50);
-  };
-
   return (
-    <>
-      <EditorialSection variant="cream">
-        <EditorialSection.MarginNote>
-          <span
-            className="block text-[13px] font-medium uppercase"
-            style={{
-              color: "var(--accent-label)",
-              letterSpacing: "var(--tracking-caps)",
-              lineHeight: 1.3,
-            }}
-          >
-            Materialien zum Vertiefen
-          </span>
-          <div
-            aria-hidden="true"
-            className="mt-3 border-t"
-            style={{ borderColor: "var(--rule-color)" }}
-          />
-        </EditorialSection.MarginNote>
-        <EditorialSection.Body>
-          <EyebrowLabel>Materialien</EyebrowLabel>
-          <DisplayHeading level={2}>Materialien zum Download</DisplayHeading>
-          <EditorialBody className="max-w-[36em]">
-            Infografiken als hochauflösende PDFs zum Herunterladen und lesbare
-            Textversionen, wenn verfügbar. «PDF öffnen» öffnet die
-            A4-Druckversion im neuen Tab.
-          </EditorialBody>
-        </EditorialSection.Body>
-      </EditorialSection>
-
-      <section
-        className="bg-[var(--bg-primary)] px-[var(--container-pad)] pb-20 md:px-[var(--container-pad-md)] md:pb-[120px]"
-        aria-label="Materialien zum Download — Filter und Tile-Liste"
-      >
-        <div className="mx-auto max-w-page">
-          <div
-            className="flex flex-wrap items-baseline gap-x-1 gap-y-2 overflow-x-auto pb-3"
-            role="tablist"
-            aria-label="Filter Selbstfürsorge-Materialien"
-          >
-            {selbstfuersorgeCategories.map(cat => (
-              <EditorialPillButton
-                key={cat.id}
-                variant="filter"
-                selected={activeFilter === cat.id}
-                onClick={() => {
-                  setActiveFilter(cat.id);
-                  scrollToResults();
-                }}
-              >
-                <span>{cat.label}</span>
-                <span aria-hidden="true" className="mx-2.5 opacity-90">
-                  ·
-                </span>
-                <span>{cat.count}</span>
-              </EditorialPillButton>
-            ))}
-          </div>
-
-          <div
-            ref={gridRef}
-            className="mt-8 grid grid-cols-1 gap-x-8 gap-y-10 sm:grid-cols-2 xl:grid-cols-3"
-          >
-            {filteredItems.map(item => {
-              const textVersionHref = getHandoutTextVersionHrefBySource(
-                item.pdf
-              );
-              const pdfHref = getHandoutOpenHref(item.pdf) ?? item.pdf;
-
-              return (
-                <article
-                  key={item.id}
-                  className={`${item.featured && activeFilter === "alle" ? "sm:col-span-2 xl:col-span-3" : ""} space-y-3 border-t pt-6`}
-                  style={{ borderColor: "var(--rule-color)" }}
-                >
-                  <a
-                    href={item.webp}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`${item.title} – Vorschau öffnen`}
-                    className="block overflow-hidden rounded-sm"
-                    style={{ backgroundColor: "var(--bg-elevated)" }}
-                  >
-                    <img
-                      src={item.thumbnailUrl ?? item.webp}
-                      alt={item.title}
-                      className="aspect-[3/4] w-full object-cover object-top"
-                      loading="lazy"
-                      width={600}
-                      height={848}
-                      decoding="async"
-                    />
-                  </a>
-
-                  <p className="uppercase" style={labelStyle}>
-                    {categoryLabel(item.category)}
-                  </p>
-                  <h3 style={entryTitleStyle}>{item.title}</h3>
-                  <p style={bodyStyle}>{item.desc}</p>
-
-                  <p
-                    className="flex flex-wrap gap-x-5 gap-y-1 pt-1"
-                    style={{ fontSize: "var(--text-sm)" }}
-                  >
-                    {textVersionHref ? (
-                      <Link
-                        href={textVersionHref}
-                        aria-label={`Textversion lesen: ${item.title}`}
-                        className="editorial-link"
-                      >
-                        <span className="inline-flex items-center gap-1.5">
-                          <FileText className="h-4 w-4" />
-                          Textversion lesen
-                        </span>
-                      </Link>
-                    ) : null}
-                    <a
-                      href={pdfHref}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      aria-label={`PDF öffnen: ${item.title} (neuer Tab)`}
-                      className="editorial-link"
-                    >
-                      <span className="inline-flex items-center gap-1.5">
-                        <ExternalLink className="h-4 w-4" />
-                        PDF öffnen
-                      </span>
-                    </a>
-                  </p>
-                </article>
-              );
-            })}
-          </div>
-
-          <p
-            className="mt-12 flex flex-wrap gap-x-5 gap-y-1"
-            style={{ fontSize: "var(--text-sm)" }}
-          >
-            <Link href="/materialien" className="editorial-link">
-              Alle Materialien anzeigen
-            </Link>
-          </p>
-        </div>
-      </section>
-    </>
+    <CuratedMaterialsSection
+      marginLabel="Bildführung"
+      title="Drei Materialien, die Selbstfürsorge greifbar machen"
+      intro="Diese Seite braucht vor allem eine klare innere Logik: erkennen, stoppen, Kräfte wieder auffüllen. Die Auswahl folgt genau dieser Reihenfolge."
+      curationNote="Die Sauerstoffmaske bleibt der visuelle Hauptanker. Weitere Selbstfürsorge-PDFs sind bewusst in die Materialbibliothek ausgelagert, damit diese Seite nicht zur Galerie wird."
+      items={curatedItems}
+      ariaLabel="Ausgewählte Materialien zu Selbstfürsorge"
+      allMaterialsLabel="Weitere Selbstfürsorge-Materialien ansehen"
+    />
   );
 }
 
-function categoryLabel(category: Exclude<SelbstfuersorgeKategorie, "alle">) {
+const curatedItems: CuratedMaterialCard[] = selectedIds.map(id => {
+  const item = selbstfuersorgeInfografiken.find(
+    candidate => candidate.id === id
+  );
+  if (!item) {
+    throw new Error(`Selbstfürsorge-Material fehlt: ${id}`);
+  }
+
+  return {
+    id: item.id,
+    title: item.title,
+    description: item.desc,
+    categoryLabel: categoryLabel(item.category),
+    imageUrl: item.webp,
+    thumbnailUrl: item.thumbnailUrl,
+    pdfUrl: item.pdf,
+    guidance: guidanceById[id],
+  };
+});
+
+function categoryLabel(
+  category: (typeof selbstfuersorgeInfografiken)[number]["category"]
+) {
   if (category === "erkennen") return "Erkennen";
-  if (category === "techniken") return "Techniken";
-  return "Ressourcen";
+  if (category === "techniken") return "Technik";
+  return "Ressource";
 }


### PR DESCRIPTION
## What changed

This PR replaces the full material/filter galleries on the topic pages with curated visual material sections.

- Adds a shared `CuratedMaterialsSection` for topic pages.
- Uses one large visual anchor plus two supporting materials on `Kommunizieren`, `Grenzen`, and `Selbstfürsorge`.
- Moves the full-library behaviour back to `/materialien` instead of repeating it inside reading pages.
- Updates smoke and Selbstfürsorge material tests to assert the curated page-level selections.

## Why

The previous topic pages repeated too many material cards and behaved like small gallery pages. This pass makes the materials work as reader guidance: fewer choices, clearer hierarchy, calmer visual rhythm.

## Validation

- `pnpm prettier --check .`
- `pnpm lint`
- `pnpm check`
- `pnpm test`
- `pnpm build`
- `GUARD_URL=http://127.0.0.1:4177 pnpm audit:smoke`
- Local desktop/mobile screenshots reviewed for the new curated sections.

## Notes

The untracked local file `_dev/STREAM-2B-BRIEF-2026-05-05.md` is intentionally not included.
