### PR TITLE
[codex] Update production release gate reports

### DIFF
--- a/qa/release-browser-matrix.json
+++ b/qa/release-browser-matrix.json
@@ -1,15 +1,15 @@
 {
-  "label": "Production Browser Matrix 2026-05-22",
-  "createdAt": "2026-05-22T17:47:41.551Z",
+  "label": "Production Browser Matrix 2026-05-23",
+  "createdAt": "2026-05-23T12:59:20.085Z",
   "baseUrl": "https://borderline-angehoerige.netlify.app",
-  "gitHead": "30eaf5a",
+  "gitHead": "244a527",
   "profiles": [
     {
       "device": "iPhone",
       "browser": "Safari",
       "optional": false,
       "status": "bestanden mit Hinweis",
-      "testedAt": "2026-05-22",
+      "testedAt": "2026-05-23",
       "testedBy": "Codex",
       "notes": "Playwright WebKit mit iPhone-13-Emulation; starke WebKit-Abdeckung, aber kein physisches iOS-Gerät",
       "findings": [],
@@ -17,158 +17,158 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:10.593Z",
-          "finishedAt": "2026-05-22T17:45:12.813Z"
+          "startedAt": "2026-05-23T12:56:59.816Z",
+          "finishedAt": "2026-05-23T12:57:01.702Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:12.813Z",
-          "finishedAt": "2026-05-22T17:45:13.684Z"
+          "startedAt": "2026-05-23T12:57:01.702Z",
+          "finishedAt": "2026-05-23T12:57:02.576Z"
         },
         {
           "name": "Mobiles Menü öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:13.684Z",
-          "finishedAt": "2026-05-22T17:45:13.768Z"
+          "startedAt": "2026-05-23T12:57:02.576Z",
+          "finishedAt": "2026-05-23T12:57:02.643Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:13.768Z",
-          "finishedAt": "2026-05-22T17:45:13.771Z"
+          "startedAt": "2026-05-23T12:57:02.643Z",
+          "finishedAt": "2026-05-23T12:57:02.647Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:13.771Z",
-          "finishedAt": "2026-05-22T17:45:14.899Z"
+          "startedAt": "2026-05-23T12:57:02.647Z",
+          "finishedAt": "2026-05-23T12:57:03.544Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:14.899Z",
-          "finishedAt": "2026-05-22T17:45:16.076Z"
+          "startedAt": "2026-05-23T12:57:03.545Z",
+          "finishedAt": "2026-05-23T12:57:04.455Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:16.077Z",
-          "finishedAt": "2026-05-22T17:45:17.633Z"
+          "startedAt": "2026-05-23T12:57:04.455Z",
+          "finishedAt": "2026-05-23T12:57:05.690Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:17.633Z",
-          "finishedAt": "2026-05-22T17:45:20.506Z"
+          "startedAt": "2026-05-23T12:57:05.690Z",
+          "finishedAt": "2026-05-23T12:57:08.538Z"
         },
         {
           "name": "Notfallkarte Kontaktlimit bis 3",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:20.506Z",
-          "finishedAt": "2026-05-22T17:45:20.621Z"
+          "startedAt": "2026-05-23T12:57:08.538Z",
+          "finishedAt": "2026-05-23T12:57:08.654Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:20.621Z",
-          "finishedAt": "2026-05-22T17:45:22.586Z"
+          "startedAt": "2026-05-23T12:57:08.654Z",
+          "finishedAt": "2026-05-23T12:57:10.424Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:22.586Z",
-          "finishedAt": "2026-05-22T17:45:23.226Z"
+          "startedAt": "2026-05-23T12:57:10.424Z",
+          "finishedAt": "2026-05-23T12:57:11.040Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:23.226Z",
-          "finishedAt": "2026-05-22T17:45:24.737Z"
+          "startedAt": "2026-05-23T12:57:11.040Z",
+          "finishedAt": "2026-05-23T12:57:12.606Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:24.737Z",
-          "finishedAt": "2026-05-22T17:45:25.604Z"
+          "startedAt": "2026-05-23T12:57:12.606Z",
+          "finishedAt": "2026-05-23T12:57:13.448Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:25.604Z",
-          "finishedAt": "2026-05-22T17:45:27.828Z"
+          "startedAt": "2026-05-23T12:57:13.448Z",
+          "finishedAt": "2026-05-23T12:57:14.282Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:27.828Z",
-          "finishedAt": "2026-05-22T17:45:28.552Z"
+          "startedAt": "2026-05-23T12:57:14.282Z",
+          "finishedAt": "2026-05-23T12:57:14.663Z"
         },
         {
           "name": "Release-PDF-Routen direkt prüfen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:28.552Z",
-          "finishedAt": "2026-05-22T17:45:30.242Z"
+          "startedAt": "2026-05-23T12:57:14.663Z",
+          "finishedAt": "2026-05-23T12:57:15.878Z"
         },
         {
           "name": "/unterstuetzen/therapie#therapieangebote öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:30.242Z",
-          "finishedAt": "2026-05-22T17:45:31.427Z"
+          "startedAt": "2026-05-23T12:57:15.878Z",
+          "finishedAt": "2026-05-23T12:57:16.814Z"
         },
         {
           "name": "/diagnostik#anbieter öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:31.427Z",
-          "finishedAt": "2026-05-22T17:45:32.554Z"
+          "startedAt": "2026-05-23T12:57:16.814Z",
+          "finishedAt": "2026-05-23T12:57:17.683Z"
         },
         {
           "name": "/begleiterkrankungen#depression öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:32.554Z",
-          "finishedAt": "2026-05-22T17:45:33.842Z"
+          "startedAt": "2026-05-23T12:57:17.683Z",
+          "finishedAt": "2026-05-23T12:57:18.597Z"
         },
         {
           "name": "/grenzen#gewalt öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:33.842Z",
-          "finishedAt": "2026-05-22T17:45:35.614Z"
+          "startedAt": "2026-05-23T12:57:18.597Z",
+          "finishedAt": "2026-05-23T12:57:19.659Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:35.614Z",
-          "finishedAt": "2026-05-22T17:45:36.234Z"
+          "startedAt": "2026-05-23T12:57:19.659Z",
+          "finishedAt": "2026-05-23T12:57:20.268Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:36.234Z",
-          "finishedAt": "2026-05-22T17:45:37.120Z"
+          "startedAt": "2026-05-23T12:57:20.268Z",
+          "finishedAt": "2026-05-23T12:57:20.864Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:37.120Z",
-          "finishedAt": "2026-05-22T17:45:38.418Z"
+          "startedAt": "2026-05-23T12:57:20.864Z",
+          "finishedAt": "2026-05-23T12:57:21.742Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:38.418Z",
-          "finishedAt": "2026-05-22T17:45:39.465Z"
+          "startedAt": "2026-05-23T12:57:21.742Z",
+          "finishedAt": "2026-05-23T12:57:22.704Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-22T17:45:10.165Z",
-      "finishedAt": "2026-05-22T17:45:39.465Z"
+      "startedAt": "2026-05-23T12:56:59.142Z",
+      "finishedAt": "2026-05-23T12:57:22.705Z"
     },
     {
       "device": "optional macOS",
       "browser": "Safari",
       "optional": true,
       "status": "bestanden mit Hinweis",
-      "testedAt": "2026-05-22",
+      "testedAt": "2026-05-23",
       "testedBy": "Codex",
       "notes": "Playwright WebKit-Desktoplauf als Safari-Näherung; optionaler Zusatzcheck",
       "findings": [],
@@ -176,152 +176,152 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:39.612Z",
-          "finishedAt": "2026-05-22T17:45:41.199Z"
+          "startedAt": "2026-05-23T12:57:22.832Z",
+          "finishedAt": "2026-05-23T12:57:24.442Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:41.199Z",
-          "finishedAt": "2026-05-22T17:45:42.067Z"
+          "startedAt": "2026-05-23T12:57:24.442Z",
+          "finishedAt": "2026-05-23T12:57:25.308Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:42.067Z",
-          "finishedAt": "2026-05-22T17:45:42.069Z"
+          "startedAt": "2026-05-23T12:57:25.308Z",
+          "finishedAt": "2026-05-23T12:57:25.310Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:42.069Z",
-          "finishedAt": "2026-05-22T17:45:42.884Z"
+          "startedAt": "2026-05-23T12:57:25.310Z",
+          "finishedAt": "2026-05-23T12:57:26.198Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:42.884Z",
-          "finishedAt": "2026-05-22T17:45:43.858Z"
+          "startedAt": "2026-05-23T12:57:26.198Z",
+          "finishedAt": "2026-05-23T12:57:27.008Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:43.859Z",
-          "finishedAt": "2026-05-22T17:45:45.088Z"
+          "startedAt": "2026-05-23T12:57:27.008Z",
+          "finishedAt": "2026-05-23T12:57:28.224Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:45.088Z",
-          "finishedAt": "2026-05-22T17:45:47.960Z"
+          "startedAt": "2026-05-23T12:57:28.224Z",
+          "finishedAt": "2026-05-23T12:57:31.068Z"
         },
         {
           "name": "Notfallkarte Kontaktlimit bis 3",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:47.960Z",
-          "finishedAt": "2026-05-22T17:45:48.072Z"
+          "startedAt": "2026-05-23T12:57:31.068Z",
+          "finishedAt": "2026-05-23T12:57:31.142Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:48.072Z",
-          "finishedAt": "2026-05-22T17:45:49.843Z"
+          "startedAt": "2026-05-23T12:57:31.142Z",
+          "finishedAt": "2026-05-23T12:57:32.803Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:49.843Z",
-          "finishedAt": "2026-05-22T17:45:50.479Z"
+          "startedAt": "2026-05-23T12:57:32.803Z",
+          "finishedAt": "2026-05-23T12:57:33.424Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:50.479Z",
-          "finishedAt": "2026-05-22T17:45:51.700Z"
+          "startedAt": "2026-05-23T12:57:33.424Z",
+          "finishedAt": "2026-05-23T12:57:34.757Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:51.700Z",
-          "finishedAt": "2026-05-22T17:45:52.543Z"
+          "startedAt": "2026-05-23T12:57:34.757Z",
+          "finishedAt": "2026-05-23T12:57:35.596Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:52.543Z",
-          "finishedAt": "2026-05-22T17:45:53.560Z"
+          "startedAt": "2026-05-23T12:57:35.596Z",
+          "finishedAt": "2026-05-23T12:57:36.489Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:53.560Z",
-          "finishedAt": "2026-05-22T17:45:54.094Z"
+          "startedAt": "2026-05-23T12:57:36.489Z",
+          "finishedAt": "2026-05-23T12:57:36.898Z"
         },
         {
           "name": "Release-PDF-Routen direkt prüfen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:54.094Z",
-          "finishedAt": "2026-05-22T17:45:55.893Z"
+          "startedAt": "2026-05-23T12:57:36.898Z",
+          "finishedAt": "2026-05-23T12:57:37.788Z"
         },
         {
           "name": "/unterstuetzen/therapie#therapieangebote öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:55.893Z",
-          "finishedAt": "2026-05-22T17:45:56.799Z"
+          "startedAt": "2026-05-23T12:57:37.788Z",
+          "finishedAt": "2026-05-23T12:57:38.818Z"
         },
         {
           "name": "/diagnostik#anbieter öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:56.799Z",
-          "finishedAt": "2026-05-22T17:45:57.735Z"
+          "startedAt": "2026-05-23T12:57:38.818Z",
+          "finishedAt": "2026-05-23T12:57:39.698Z"
         },
         {
           "name": "/begleiterkrankungen#depression öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:57.735Z",
-          "finishedAt": "2026-05-22T17:45:58.750Z"
+          "startedAt": "2026-05-23T12:57:39.698Z",
+          "finishedAt": "2026-05-23T12:57:40.704Z"
         },
         {
           "name": "/grenzen#gewalt öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:45:58.750Z",
-          "finishedAt": "2026-05-22T17:46:00.511Z"
+          "startedAt": "2026-05-23T12:57:40.704Z",
+          "finishedAt": "2026-05-23T12:57:42.076Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:00.511Z",
-          "finishedAt": "2026-05-22T17:46:01.162Z"
+          "startedAt": "2026-05-23T12:57:42.076Z",
+          "finishedAt": "2026-05-23T12:57:42.706Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:01.162Z",
-          "finishedAt": "2026-05-22T17:46:01.823Z"
+          "startedAt": "2026-05-23T12:57:42.706Z",
+          "finishedAt": "2026-05-23T12:57:43.335Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:01.823Z",
-          "finishedAt": "2026-05-22T17:46:02.965Z"
+          "startedAt": "2026-05-23T12:57:43.335Z",
+          "finishedAt": "2026-05-23T12:57:44.176Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:02.965Z",
-          "finishedAt": "2026-05-22T17:46:04.026Z"
+          "startedAt": "2026-05-23T12:57:44.176Z",
+          "finishedAt": "2026-05-23T12:57:45.014Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-22T17:45:39.478Z",
-      "finishedAt": "2026-05-22T17:46:04.026Z"
+      "startedAt": "2026-05-23T12:57:22.710Z",
+      "finishedAt": "2026-05-23T12:57:45.014Z"
     },
     {
       "device": "iPhone",
       "browser": "Chrome",
       "optional": false,
       "status": "bestanden mit Hinweis",
-      "testedAt": "2026-05-22",
+      "testedAt": "2026-05-23",
       "testedBy": "Codex",
       "notes": "mobile Chrome-Emulation in Chromium; kein echter iOS-Lauf, aber Pflichtpfade und Flows technisch grün",
       "findings": [],
@@ -329,158 +329,158 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:05.050Z",
-          "finishedAt": "2026-05-22T17:46:06.686Z"
+          "startedAt": "2026-05-23T12:57:46.007Z",
+          "finishedAt": "2026-05-23T12:57:47.851Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:06.686Z",
-          "finishedAt": "2026-05-22T17:46:07.570Z"
+          "startedAt": "2026-05-23T12:57:47.851Z",
+          "finishedAt": "2026-05-23T12:57:48.724Z"
         },
         {
           "name": "Mobiles Menü öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:07.570Z",
-          "finishedAt": "2026-05-22T17:46:07.633Z"
+          "startedAt": "2026-05-23T12:57:48.724Z",
+          "finishedAt": "2026-05-23T12:57:48.790Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:07.633Z",
-          "finishedAt": "2026-05-22T17:46:07.635Z"
+          "startedAt": "2026-05-23T12:57:48.790Z",
+          "finishedAt": "2026-05-23T12:57:48.792Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:07.635Z",
-          "finishedAt": "2026-05-22T17:46:08.434Z"
+          "startedAt": "2026-05-23T12:57:48.792Z",
+          "finishedAt": "2026-05-23T12:57:49.620Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:08.434Z",
-          "finishedAt": "2026-05-22T17:46:09.394Z"
+          "startedAt": "2026-05-23T12:57:49.620Z",
+          "finishedAt": "2026-05-23T12:57:50.559Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:09.394Z",
-          "finishedAt": "2026-05-22T17:46:10.462Z"
+          "startedAt": "2026-05-23T12:57:50.559Z",
+          "finishedAt": "2026-05-23T12:57:51.537Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:10.462Z",
-          "finishedAt": "2026-05-22T17:46:13.384Z"
+          "startedAt": "2026-05-23T12:57:51.537Z",
+          "finishedAt": "2026-05-23T12:57:54.338Z"
         },
         {
           "name": "Notfallkarte Kontaktlimit bis 3",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:13.384Z",
-          "finishedAt": "2026-05-22T17:46:13.471Z"
+          "startedAt": "2026-05-23T12:57:54.338Z",
+          "finishedAt": "2026-05-23T12:57:54.409Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:13.471Z",
-          "finishedAt": "2026-05-22T17:46:15.329Z"
+          "startedAt": "2026-05-23T12:57:54.409Z",
+          "finishedAt": "2026-05-23T12:57:56.374Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:15.329Z",
-          "finishedAt": "2026-05-22T17:46:16.276Z"
+          "startedAt": "2026-05-23T12:57:56.374Z",
+          "finishedAt": "2026-05-23T12:57:57.341Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:16.276Z",
-          "finishedAt": "2026-05-22T17:46:17.458Z"
+          "startedAt": "2026-05-23T12:57:57.341Z",
+          "finishedAt": "2026-05-23T12:57:58.598Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:17.458Z",
-          "finishedAt": "2026-05-22T17:46:17.827Z"
+          "startedAt": "2026-05-23T12:57:58.598Z",
+          "finishedAt": "2026-05-23T12:57:59.477Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:17.827Z",
-          "finishedAt": "2026-05-22T17:46:18.727Z"
+          "startedAt": "2026-05-23T12:57:59.477Z",
+          "finishedAt": "2026-05-23T12:58:00.347Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:18.727Z",
-          "finishedAt": "2026-05-22T17:46:19.351Z"
+          "startedAt": "2026-05-23T12:58:00.347Z",
+          "finishedAt": "2026-05-23T12:58:00.745Z"
         },
         {
           "name": "Release-PDF-Routen direkt prüfen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:19.351Z",
-          "finishedAt": "2026-05-22T17:46:20.411Z"
+          "startedAt": "2026-05-23T12:58:00.745Z",
+          "finishedAt": "2026-05-23T12:58:01.887Z"
         },
         {
           "name": "/unterstuetzen/therapie#therapieangebote öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:20.412Z",
-          "finishedAt": "2026-05-22T17:46:21.394Z"
+          "startedAt": "2026-05-23T12:58:01.887Z",
+          "finishedAt": "2026-05-23T12:58:02.707Z"
         },
         {
           "name": "/diagnostik#anbieter öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:21.394Z",
-          "finishedAt": "2026-05-22T17:46:22.339Z"
+          "startedAt": "2026-05-23T12:58:02.707Z",
+          "finishedAt": "2026-05-23T12:58:03.743Z"
         },
         {
           "name": "/begleiterkrankungen#depression öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:22.339Z",
-          "finishedAt": "2026-05-22T17:46:23.238Z"
+          "startedAt": "2026-05-23T12:58:03.743Z",
+          "finishedAt": "2026-05-23T12:58:04.843Z"
         },
         {
           "name": "/grenzen#gewalt öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:23.238Z",
-          "finishedAt": "2026-05-22T17:46:24.429Z"
+          "startedAt": "2026-05-23T12:58:04.843Z",
+          "finishedAt": "2026-05-23T12:58:06.139Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:24.429Z",
-          "finishedAt": "2026-05-22T17:46:25.126Z"
+          "startedAt": "2026-05-23T12:58:06.139Z",
+          "finishedAt": "2026-05-23T12:58:06.727Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:25.126Z",
-          "finishedAt": "2026-05-22T17:46:25.765Z"
+          "startedAt": "2026-05-23T12:58:06.727Z",
+          "finishedAt": "2026-05-23T12:58:07.319Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:25.765Z",
-          "finishedAt": "2026-05-22T17:46:26.620Z"
+          "startedAt": "2026-05-23T12:58:07.319Z",
+          "finishedAt": "2026-05-23T12:58:08.136Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:26.620Z",
-          "finishedAt": "2026-05-22T17:46:27.478Z"
+          "startedAt": "2026-05-23T12:58:08.136Z",
+          "finishedAt": "2026-05-23T12:58:08.935Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-22T17:46:04.802Z",
-      "finishedAt": "2026-05-22T17:46:27.478Z"
+      "startedAt": "2026-05-23T12:57:45.787Z",
+      "finishedAt": "2026-05-23T12:58:08.936Z"
     },
     {
       "device": "Android",
       "browser": "Chrome",
       "optional": false,
       "status": "bestanden mit Hinweis",
-      "testedAt": "2026-05-22",
+      "testedAt": "2026-05-23",
       "testedBy": "Codex",
       "notes": "mobile Chrome-Emulation in Chromium; Pflichtpfade und Flows technisch grün",
       "findings": [],
@@ -488,158 +488,158 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:27.625Z",
-          "finishedAt": "2026-05-22T17:46:29.633Z"
+          "startedAt": "2026-05-23T12:58:09.081Z",
+          "finishedAt": "2026-05-23T12:58:10.817Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:29.633Z",
-          "finishedAt": "2026-05-22T17:46:30.498Z"
+          "startedAt": "2026-05-23T12:58:10.818Z",
+          "finishedAt": "2026-05-23T12:58:11.672Z"
         },
         {
           "name": "Mobiles Menü öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:30.498Z",
-          "finishedAt": "2026-05-22T17:46:30.565Z"
+          "startedAt": "2026-05-23T12:58:11.672Z",
+          "finishedAt": "2026-05-23T12:58:11.740Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:30.565Z",
-          "finishedAt": "2026-05-22T17:46:30.567Z"
+          "startedAt": "2026-05-23T12:58:11.740Z",
+          "finishedAt": "2026-05-23T12:58:11.742Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:30.567Z",
-          "finishedAt": "2026-05-22T17:46:31.345Z"
+          "startedAt": "2026-05-23T12:58:11.742Z",
+          "finishedAt": "2026-05-23T12:58:12.521Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:31.345Z",
-          "finishedAt": "2026-05-22T17:46:32.206Z"
+          "startedAt": "2026-05-23T12:58:12.521Z",
+          "finishedAt": "2026-05-23T12:58:13.301Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:32.206Z",
-          "finishedAt": "2026-05-22T17:46:33.541Z"
+          "startedAt": "2026-05-23T12:58:13.301Z",
+          "finishedAt": "2026-05-23T12:58:14.525Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:33.541Z",
-          "finishedAt": "2026-05-22T17:46:36.400Z"
+          "startedAt": "2026-05-23T12:58:14.525Z",
+          "finishedAt": "2026-05-23T12:58:17.383Z"
         },
         {
           "name": "Notfallkarte Kontaktlimit bis 3",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:36.400Z",
-          "finishedAt": "2026-05-22T17:46:36.471Z"
+          "startedAt": "2026-05-23T12:58:17.383Z",
+          "finishedAt": "2026-05-23T12:58:17.460Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:36.471Z",
-          "finishedAt": "2026-05-22T17:46:38.261Z"
+          "startedAt": "2026-05-23T12:58:17.460Z",
+          "finishedAt": "2026-05-23T12:58:19.247Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:38.261Z",
-          "finishedAt": "2026-05-22T17:46:39.222Z"
+          "startedAt": "2026-05-23T12:58:19.247Z",
+          "finishedAt": "2026-05-23T12:58:20.191Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:39.222Z",
-          "finishedAt": "2026-05-22T17:46:40.290Z"
+          "startedAt": "2026-05-23T12:58:20.191Z",
+          "finishedAt": "2026-05-23T12:58:21.395Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:40.290Z",
-          "finishedAt": "2026-05-22T17:46:41.152Z"
+          "startedAt": "2026-05-23T12:58:21.396Z",
+          "finishedAt": "2026-05-23T12:58:22.245Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:41.152Z",
-          "finishedAt": "2026-05-22T17:46:42.045Z"
+          "startedAt": "2026-05-23T12:58:22.245Z",
+          "finishedAt": "2026-05-23T12:58:22.944Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:42.045Z",
-          "finishedAt": "2026-05-22T17:46:42.430Z"
+          "startedAt": "2026-05-23T12:58:22.944Z",
+          "finishedAt": "2026-05-23T12:58:23.312Z"
         },
         {
           "name": "Release-PDF-Routen direkt prüfen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:42.430Z",
-          "finishedAt": "2026-05-22T17:46:43.671Z"
+          "startedAt": "2026-05-23T12:58:23.312Z",
+          "finishedAt": "2026-05-23T12:58:24.217Z"
         },
         {
           "name": "/unterstuetzen/therapie#therapieangebote öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:43.671Z",
-          "finishedAt": "2026-05-22T17:46:44.560Z"
+          "startedAt": "2026-05-23T12:58:24.217Z",
+          "finishedAt": "2026-05-23T12:58:25.058Z"
         },
         {
           "name": "/diagnostik#anbieter öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:44.560Z",
-          "finishedAt": "2026-05-22T17:46:45.525Z"
+          "startedAt": "2026-05-23T12:58:25.058Z",
+          "finishedAt": "2026-05-23T12:58:26.090Z"
         },
         {
           "name": "/begleiterkrankungen#depression öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:45.525Z",
-          "finishedAt": "2026-05-22T17:46:46.548Z"
+          "startedAt": "2026-05-23T12:58:26.090Z",
+          "finishedAt": "2026-05-23T12:58:27.048Z"
         },
         {
           "name": "/grenzen#gewalt öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:46.548Z",
-          "finishedAt": "2026-05-22T17:46:47.943Z"
+          "startedAt": "2026-05-23T12:58:27.048Z",
+          "finishedAt": "2026-05-23T12:58:27.900Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:47.943Z",
-          "finishedAt": "2026-05-22T17:46:48.572Z"
+          "startedAt": "2026-05-23T12:58:27.900Z",
+          "finishedAt": "2026-05-23T12:58:28.489Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:48.572Z",
-          "finishedAt": "2026-05-22T17:46:49.206Z"
+          "startedAt": "2026-05-23T12:58:28.489Z",
+          "finishedAt": "2026-05-23T12:58:29.076Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:49.206Z",
-          "finishedAt": "2026-05-22T17:46:50.058Z"
+          "startedAt": "2026-05-23T12:58:29.076Z",
+          "finishedAt": "2026-05-23T12:58:30.110Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:50.058Z",
-          "finishedAt": "2026-05-22T17:46:50.900Z"
+          "startedAt": "2026-05-23T12:58:30.110Z",
+          "finishedAt": "2026-05-23T12:58:30.920Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-22T17:46:27.493Z",
-      "finishedAt": "2026-05-22T17:46:50.900Z"
+      "startedAt": "2026-05-23T12:58:08.949Z",
+      "finishedAt": "2026-05-23T12:58:30.920Z"
     },
     {
       "device": "Desktop",
       "browser": "Chrome",
       "optional": false,
       "status": "bestanden",
-      "testedAt": "2026-05-22",
+      "testedAt": "2026-05-23",
       "testedBy": "Codex",
       "notes": "Playwright-Lauf gegen Production mit System-Chrome/Chromium",
       "findings": [],
@@ -647,152 +647,152 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:51.048Z",
-          "finishedAt": "2026-05-22T17:46:52.742Z"
+          "startedAt": "2026-05-23T12:58:31.065Z",
+          "finishedAt": "2026-05-23T12:58:32.909Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:52.742Z",
-          "finishedAt": "2026-05-22T17:46:53.620Z"
+          "startedAt": "2026-05-23T12:58:32.909Z",
+          "finishedAt": "2026-05-23T12:58:33.794Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:53.620Z",
-          "finishedAt": "2026-05-22T17:46:53.624Z"
+          "startedAt": "2026-05-23T12:58:33.794Z",
+          "finishedAt": "2026-05-23T12:58:33.797Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:53.624Z",
-          "finishedAt": "2026-05-22T17:46:54.449Z"
+          "startedAt": "2026-05-23T12:58:33.797Z",
+          "finishedAt": "2026-05-23T12:58:34.700Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:54.449Z",
-          "finishedAt": "2026-05-22T17:46:55.342Z"
+          "startedAt": "2026-05-23T12:58:34.700Z",
+          "finishedAt": "2026-05-23T12:58:35.653Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:55.342Z",
-          "finishedAt": "2026-05-22T17:46:56.671Z"
+          "startedAt": "2026-05-23T12:58:35.653Z",
+          "finishedAt": "2026-05-23T12:58:36.624Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:56.671Z",
-          "finishedAt": "2026-05-22T17:46:59.478Z"
+          "startedAt": "2026-05-23T12:58:36.624Z",
+          "finishedAt": "2026-05-23T12:58:39.404Z"
         },
         {
           "name": "Notfallkarte Kontaktlimit bis 3",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:59.478Z",
-          "finishedAt": "2026-05-22T17:46:59.549Z"
+          "startedAt": "2026-05-23T12:58:39.404Z",
+          "finishedAt": "2026-05-23T12:58:39.476Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-22T17:46:59.549Z",
-          "finishedAt": "2026-05-22T17:47:01.379Z"
+          "startedAt": "2026-05-23T12:58:39.476Z",
+          "finishedAt": "2026-05-23T12:58:41.186Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:01.379Z",
-          "finishedAt": "2026-05-22T17:47:02.324Z"
+          "startedAt": "2026-05-23T12:58:41.186Z",
+          "finishedAt": "2026-05-23T12:58:42.115Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:02.324Z",
-          "finishedAt": "2026-05-22T17:47:03.624Z"
+          "startedAt": "2026-05-23T12:58:42.115Z",
+          "finishedAt": "2026-05-23T12:58:43.296Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:03.624Z",
-          "finishedAt": "2026-05-22T17:47:03.995Z"
+          "startedAt": "2026-05-23T12:58:43.297Z",
+          "finishedAt": "2026-05-23T12:58:44.128Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:03.995Z",
-          "finishedAt": "2026-05-22T17:47:04.816Z"
+          "startedAt": "2026-05-23T12:58:44.128Z",
+          "finishedAt": "2026-05-23T12:58:44.726Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:04.816Z",
-          "finishedAt": "2026-05-22T17:47:05.135Z"
+          "startedAt": "2026-05-23T12:58:44.726Z",
+          "finishedAt": "2026-05-23T12:58:45.107Z"
         },
         {
           "name": "Release-PDF-Routen direkt prüfen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:05.136Z",
-          "finishedAt": "2026-05-22T17:47:06.296Z"
+          "startedAt": "2026-05-23T12:58:45.107Z",
+          "finishedAt": "2026-05-23T12:58:46.227Z"
         },
         {
           "name": "/unterstuetzen/therapie#therapieangebote öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:06.296Z",
-          "finishedAt": "2026-05-22T17:47:07.187Z"
+          "startedAt": "2026-05-23T12:58:46.227Z",
+          "finishedAt": "2026-05-23T12:58:47.180Z"
         },
         {
           "name": "/diagnostik#anbieter öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:07.187Z",
-          "finishedAt": "2026-05-22T17:47:08.058Z"
+          "startedAt": "2026-05-23T12:58:47.180Z",
+          "finishedAt": "2026-05-23T12:58:48.224Z"
         },
         {
           "name": "/begleiterkrankungen#depression öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:08.058Z",
-          "finishedAt": "2026-05-22T17:47:08.993Z"
+          "startedAt": "2026-05-23T12:58:48.224Z",
+          "finishedAt": "2026-05-23T12:58:49.328Z"
         },
         {
           "name": "/grenzen#gewalt öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:08.993Z",
-          "finishedAt": "2026-05-22T17:47:10.521Z"
+          "startedAt": "2026-05-23T12:58:49.328Z",
+          "finishedAt": "2026-05-23T12:58:50.590Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:10.521Z",
-          "finishedAt": "2026-05-22T17:47:11.141Z"
+          "startedAt": "2026-05-23T12:58:50.590Z",
+          "finishedAt": "2026-05-23T12:58:51.173Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:11.141Z",
-          "finishedAt": "2026-05-22T17:47:11.795Z"
+          "startedAt": "2026-05-23T12:58:51.173Z",
+          "finishedAt": "2026-05-23T12:58:51.769Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:11.795Z",
-          "finishedAt": "2026-05-22T17:47:12.663Z"
+          "startedAt": "2026-05-23T12:58:51.769Z",
+          "finishedAt": "2026-05-23T12:58:52.675Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:12.663Z",
-          "finishedAt": "2026-05-22T17:47:13.620Z"
+          "startedAt": "2026-05-23T12:58:52.675Z",
+          "finishedAt": "2026-05-23T12:58:53.482Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-22T17:46:50.907Z",
-      "finishedAt": "2026-05-22T17:47:13.620Z"
+      "startedAt": "2026-05-23T12:58:30.926Z",
+      "finishedAt": "2026-05-23T12:58:53.483Z"
     },
     {
       "device": "Desktop",
       "browser": "Firefox",
       "optional": false,
       "status": "bestanden",
-      "testedAt": "2026-05-22",
+      "testedAt": "2026-05-23",
       "testedBy": "Codex",
       "notes": "Playwright-Firefox-Lauf gegen Production",
       "findings": [],
@@ -800,145 +800,145 @@
         {
           "name": "Startseite direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:14.628Z",
-          "finishedAt": "2026-05-22T17:47:17.028Z"
+          "startedAt": "2026-05-23T12:58:55.745Z",
+          "finishedAt": "2026-05-23T12:58:57.517Z"
         },
         {
           "name": "Suche öffnen und schließen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:17.028Z",
-          "finishedAt": "2026-05-22T17:47:18.002Z"
+          "startedAt": "2026-05-23T12:58:57.517Z",
+          "finishedAt": "2026-05-23T12:58:58.479Z"
         },
         {
           "name": "Sticky Header über Scrollstrecke sichtbar",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:18.002Z",
-          "finishedAt": "2026-05-22T17:47:18.005Z"
+          "startedAt": "2026-05-23T12:58:58.479Z",
+          "finishedAt": "2026-05-23T12:58:58.483Z"
         },
         {
           "name": "/soforthilfe direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:18.005Z",
-          "finishedAt": "2026-05-22T17:47:18.886Z"
+          "startedAt": "2026-05-23T12:58:58.483Z",
+          "finishedAt": "2026-05-23T12:58:59.412Z"
         },
         {
           "name": "/notfallkarte direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:18.886Z",
-          "finishedAt": "2026-05-22T17:47:19.800Z"
+          "startedAt": "2026-05-23T12:58:59.412Z",
+          "finishedAt": "2026-05-23T12:59:00.340Z"
         },
         {
           "name": "/notfallkarte/erstellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:19.800Z",
-          "finishedAt": "2026-05-22T17:47:21.022Z"
+          "startedAt": "2026-05-23T12:59:00.340Z",
+          "finishedAt": "2026-05-23T12:59:01.362Z"
         },
         {
           "name": "Notfallkarte Eingaben + Reload + Zurück/Vorwärts",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:21.022Z",
-          "finishedAt": "2026-05-22T17:47:24.399Z"
+          "startedAt": "2026-05-23T12:59:01.362Z",
+          "finishedAt": "2026-05-23T12:59:04.679Z"
         },
         {
           "name": "Notfallkarte Kontaktlimit bis 3",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:24.399Z",
-          "finishedAt": "2026-05-22T17:47:24.537Z"
+          "startedAt": "2026-05-23T12:59:04.679Z",
+          "finishedAt": "2026-05-23T12:59:04.815Z"
         },
         {
           "name": "Notfallkarte Druckansicht",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:24.537Z",
-          "finishedAt": "2026-05-22T17:47:26.357Z"
+          "startedAt": "2026-05-23T12:59:04.815Z",
+          "finishedAt": "2026-05-23T12:59:06.512Z"
         },
         {
           "name": "Notfallkarte löschen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:26.357Z",
-          "finishedAt": "2026-05-22T17:47:27.461Z"
+          "startedAt": "2026-05-23T12:59:06.512Z",
+          "finishedAt": "2026-05-23T12:59:07.634Z"
         },
         {
           "name": "/materialien + Filter",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:27.461Z",
-          "finishedAt": "2026-05-22T17:47:28.711Z"
+          "startedAt": "2026-05-23T12:59:07.634Z",
+          "finishedAt": "2026-05-23T12:59:08.972Z"
         },
         {
           "name": "Materialien Textversion öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:28.711Z",
-          "finishedAt": "2026-05-22T17:47:29.599Z"
+          "startedAt": "2026-05-23T12:59:08.972Z",
+          "finishedAt": "2026-05-23T12:59:09.855Z"
         },
         {
           "name": "Materialien PDF inline öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:29.599Z",
-          "finishedAt": "2026-05-22T17:47:30.548Z"
+          "startedAt": "2026-05-23T12:59:09.855Z",
+          "finishedAt": "2026-05-23T12:59:10.690Z"
         },
         {
           "name": "Materialien PDF herunterladen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:30.548Z",
-          "finishedAt": "2026-05-22T17:47:30.980Z"
+          "startedAt": "2026-05-23T12:59:10.690Z",
+          "finishedAt": "2026-05-23T12:59:10.956Z"
         },
         {
           "name": "Release-PDF-Routen direkt prüfen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:30.980Z",
-          "finishedAt": "2026-05-22T17:47:32.423Z"
+          "startedAt": "2026-05-23T12:59:10.956Z",
+          "finishedAt": "2026-05-23T12:59:12.211Z"
         },
         {
           "name": "/unterstuetzen/therapie#therapieangebote öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:32.423Z",
-          "finishedAt": "2026-05-22T17:47:33.413Z"
+          "startedAt": "2026-05-23T12:59:12.211Z",
+          "finishedAt": "2026-05-23T12:59:13.252Z"
         },
         {
           "name": "/diagnostik#anbieter öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:33.413Z",
-          "finishedAt": "2026-05-22T17:47:34.856Z"
+          "startedAt": "2026-05-23T12:59:13.252Z",
+          "finishedAt": "2026-05-23T12:59:14.357Z"
         },
         {
           "name": "/begleiterkrankungen#depression öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:34.856Z",
-          "finishedAt": "2026-05-22T17:47:35.794Z"
+          "startedAt": "2026-05-23T12:59:14.357Z",
+          "finishedAt": "2026-05-23T12:59:15.252Z"
         },
         {
           "name": "/grenzen#gewalt öffnet Zielabschnitt",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:35.794Z",
-          "finishedAt": "2026-05-22T17:47:38.046Z"
+          "startedAt": "2026-05-23T12:59:15.252Z",
+          "finishedAt": "2026-05-23T12:59:16.588Z"
         },
         {
           "name": "/diagnostik direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:38.046Z",
-          "finishedAt": "2026-05-22T17:47:38.687Z"
+          "startedAt": "2026-05-23T12:59:16.588Z",
+          "finishedAt": "2026-05-23T12:59:17.212Z"
         },
         {
           "name": "/grenzen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:38.687Z",
-          "finishedAt": "2026-05-22T17:47:39.365Z"
+          "startedAt": "2026-05-23T12:59:17.212Z",
+          "finishedAt": "2026-05-23T12:59:17.859Z"
         },
         {
           "name": "/beratung direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:39.365Z",
-          "finishedAt": "2026-05-22T17:47:40.365Z"
+          "startedAt": "2026-05-23T12:59:17.859Z",
+          "finishedAt": "2026-05-23T12:59:18.954Z"
         },
         {
           "name": "/quellen direkt öffnen",
           "status": "passed",
-          "startedAt": "2026-05-22T17:47:40.365Z",
-          "finishedAt": "2026-05-22T17:47:41.282Z"
+          "startedAt": "2026-05-23T12:59:18.954Z",
+          "finishedAt": "2026-05-23T12:59:19.831Z"
         }
       ],
       "available": true,
-      "startedAt": "2026-05-22T17:47:14.269Z",
-      "finishedAt": "2026-05-22T17:47:41.282Z"
+      "startedAt": "2026-05-23T12:58:55.338Z",
+      "finishedAt": "2026-05-23T12:59:19.831Z"
     }
   ],
   "releaseDecision": "green-with-notes"

--- a/qa/release-browser-matrix.md
+++ b/qa/release-browser-matrix.md
@@ -107,8 +107,8 @@ Dabei prüfen:
 ## Browser-Matrix
 
 - Release / PR: main
-- Commit / Deploy-Stand: 30eaf5a
-- Datum: 2026-05-22
+- Commit / Deploy-Stand: 244a527
+- Datum: 2026-05-23
 - Basis-URL: https://borderline-angehoerige.netlify.app
 
 | Gerät          | Browser | Status                | Notizen                                                                                               |

--- a/qa/release-http-gates.json
+++ b/qa/release-http-gates.json
@@ -1,11 +1,12 @@
 {
-  "createdAt": "2026-05-03T18:38:26.704Z",
+  "createdAt": "2026-05-23T12:53:59.887Z",
   "baseUrl": "https://borderline-angehoerige.netlify.app",
   "counts": {
     "pdfs": 16,
     "previews": 16,
     "textversions": 16,
-    "pages": 2
+    "pages": 2,
+    "headers": 8
   },
   "results": [
     {
@@ -19,8 +20,8 @@
       "contentType": "application/pdf",
       "byteLength": 363941,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:07.225Z",
-      "finishedAt": "2026-05-03T18:38:08.902Z",
+      "startedAt": "2026-05-23T12:53:33.994Z",
+      "finishedAt": "2026-05-23T12:53:36.023Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/notfallkarte-zuerich"
     },
     {
@@ -34,8 +35,8 @@
       "contentType": "application/pdf",
       "byteLength": 439930,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:08.902Z",
-      "finishedAt": "2026-05-03T18:38:09.382Z",
+      "startedAt": "2026-05-23T12:53:36.023Z",
+      "finishedAt": "2026-05-23T12:53:36.492Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/notfallplan-krise"
     },
     {
@@ -49,8 +50,8 @@
       "contentType": "application/pdf",
       "byteLength": 3214789,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:09.382Z",
-      "finishedAt": "2026-05-03T18:38:10.183Z",
+      "startedAt": "2026-05-23T12:53:36.492Z",
+      "finishedAt": "2026-05-23T12:53:37.287Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/leuchtturm"
     },
     {
@@ -64,8 +65,8 @@
       "contentType": "application/pdf",
       "byteLength": 5407090,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:10.183Z",
-      "finishedAt": "2026-05-03T18:38:10.977Z",
+      "startedAt": "2026-05-23T12:53:37.287Z",
+      "finishedAt": "2026-05-23T12:53:38.076Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/eisberg"
     },
     {
@@ -79,8 +80,8 @@
       "contentType": "application/pdf",
       "byteLength": 415477,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:10.977Z",
-      "finishedAt": "2026-05-03T18:38:11.292Z",
+      "startedAt": "2026-05-23T12:53:38.076Z",
+      "finishedAt": "2026-05-23T12:53:38.484Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/rolle-klaeren"
     },
     {
@@ -94,8 +95,8 @@
       "contentType": "application/pdf",
       "byteLength": 279830,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:11.292Z",
-      "finishedAt": "2026-05-03T18:38:11.540Z",
+      "startedAt": "2026-05-23T12:53:38.484Z",
+      "finishedAt": "2026-05-23T12:53:38.940Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/krisenkommunikation"
     },
     {
@@ -109,8 +110,8 @@
       "contentType": "application/pdf",
       "byteLength": 2885399,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:11.540Z",
-      "finishedAt": "2026-05-03T18:38:12.102Z",
+      "startedAt": "2026-05-23T12:53:38.940Z",
+      "finishedAt": "2026-05-23T12:53:39.530Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/grenzen-spickzettel"
     },
     {
@@ -124,8 +125,8 @@
       "contentType": "application/pdf",
       "byteLength": 2967379,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:12.102Z",
-      "finishedAt": "2026-05-03T18:38:12.640Z",
+      "startedAt": "2026-05-23T12:53:39.530Z",
+      "finishedAt": "2026-05-23T12:53:40.089Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/warnsignale"
     },
     {
@@ -139,8 +140,8 @@
       "contentType": "application/pdf",
       "byteLength": 1125351,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:12.640Z",
-      "finishedAt": "2026-05-03T18:38:13.016Z",
+      "startedAt": "2026-05-23T12:53:40.089Z",
+      "finishedAt": "2026-05-23T12:53:40.609Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/schuld-verantwortung"
     },
     {
@@ -154,8 +155,8 @@
       "contentType": "application/pdf",
       "byteLength": 247521,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:13.016Z",
-      "finishedAt": "2026-05-03T18:38:13.463Z",
+      "startedAt": "2026-05-23T12:53:40.609Z",
+      "finishedAt": "2026-05-23T12:53:41.088Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/spaltung"
     },
     {
@@ -169,8 +170,8 @@
       "contentType": "application/pdf",
       "byteLength": 340805,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:13.464Z",
-      "finishedAt": "2026-05-03T18:38:13.860Z",
+      "startedAt": "2026-05-23T12:53:41.088Z",
+      "finishedAt": "2026-05-23T12:53:41.603Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/alarm-modus"
     },
     {
@@ -184,8 +185,8 @@
       "contentType": "application/pdf",
       "byteLength": 1032269,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:13.860Z",
-      "finishedAt": "2026-05-03T18:38:14.290Z",
+      "startedAt": "2026-05-23T12:53:41.603Z",
+      "finishedAt": "2026-05-23T12:53:43.251Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/wenn-worte-treffen"
     },
     {
@@ -199,8 +200,8 @@
       "contentType": "application/pdf",
       "byteLength": 2858355,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:14.290Z",
-      "finishedAt": "2026-05-03T18:38:14.798Z",
+      "startedAt": "2026-05-23T12:53:43.252Z",
+      "finishedAt": "2026-05-23T12:53:44.042Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/dear"
     },
     {
@@ -214,8 +215,8 @@
       "contentType": "application/pdf",
       "byteLength": 3168314,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:14.799Z",
-      "finishedAt": "2026-05-03T18:38:15.523Z",
+      "startedAt": "2026-05-23T12:53:44.042Z",
+      "finishedAt": "2026-05-23T12:53:44.621Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/radikale-akzeptanz"
     },
     {
@@ -229,8 +230,8 @@
       "contentType": "application/pdf",
       "byteLength": 2753141,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:15.523Z",
-      "finishedAt": "2026-05-03T18:38:16.004Z",
+      "startedAt": "2026-05-23T12:53:44.621Z",
+      "finishedAt": "2026-05-23T12:53:45.288Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/genesung-zahlen"
     },
     {
@@ -244,8 +245,8 @@
       "contentType": "application/pdf",
       "byteLength": 3519033,
       "pdfSignature": "%PDF-",
-      "startedAt": "2026-05-03T18:38:16.004Z",
-      "finishedAt": "2026-05-03T18:38:16.554Z",
+      "startedAt": "2026-05-23T12:53:45.288Z",
+      "finishedAt": "2026-05-23T12:53:45.896Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/kinder"
     },
     {
@@ -257,8 +258,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:16.554Z",
-      "finishedAt": "2026-05-03T18:38:17.121Z",
+      "startedAt": "2026-05-23T12:53:45.897Z",
+      "finishedAt": "2026-05-23T12:53:46.209Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/notfallkarte-preview.webp"
     },
     {
@@ -270,8 +271,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:17.121Z",
-      "finishedAt": "2026-05-03T18:38:17.387Z",
+      "startedAt": "2026-05-23T12:53:46.209Z",
+      "finishedAt": "2026-05-23T12:53:46.656Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/notfallplan-krise-v03-preview.webp"
     },
     {
@@ -283,48 +284,48 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:17.387Z",
-      "finishedAt": "2026-05-03T18:38:17.655Z",
+      "startedAt": "2026-05-23T12:53:46.656Z",
+      "finishedAt": "2026-05-23T12:53:47.074Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-leuchtturm-v1.webp"
     },
     {
       "id": "eisberg",
       "title": "Der Eisberg – Wut ist oft die Spitze",
       "kind": "preview",
-      "route": "/infografiken/eisberg-der-eisberg-v6.png",
-      "url": "https://borderline-angehoerige.netlify.app/infografiken/eisberg-der-eisberg-v6.png",
+      "route": "/infografiken/eisberg-der-eisberg-v6.webp",
+      "url": "https://borderline-angehoerige.netlify.app/infografiken/eisberg-der-eisberg-v6.webp",
       "status": "passed",
       "httpStatus": 200,
-      "contentType": "image/png",
-      "startedAt": "2026-05-03T18:38:17.655Z",
-      "finishedAt": "2026-05-03T18:38:18.142Z",
-      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/eisberg-der-eisberg-v6.png"
+      "contentType": "image/webp",
+      "startedAt": "2026-05-23T12:53:47.074Z",
+      "finishedAt": "2026-05-23T12:53:47.527Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/eisberg-der-eisberg-v6.webp"
     },
     {
       "id": "rolle-klaeren",
       "title": "Ihre Rolle klären – Was Sie sein können (und was nicht)",
       "kind": "preview",
-      "route": "/infografiken/sphären-die-einfluss-sphären-v3.png",
-      "url": "https://borderline-angehoerige.netlify.app/infografiken/sph%C3%A4ren-die-einfluss-sph%C3%A4ren-v3.png",
+      "route": "/infografiken/sphären-die-einfluss-sphären-v3.webp",
+      "url": "https://borderline-angehoerige.netlify.app/infografiken/sph%C3%A4ren-die-einfluss-sph%C3%A4ren-v3.webp",
       "status": "passed",
       "httpStatus": 200,
-      "contentType": "image/png",
-      "startedAt": "2026-05-03T18:38:18.142Z",
-      "finishedAt": "2026-05-03T18:38:18.762Z",
-      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/sph%C3%A4ren-die-einfluss-sph%C3%A4ren-v3.png"
+      "contentType": "image/webp",
+      "startedAt": "2026-05-23T12:53:47.527Z",
+      "finishedAt": "2026-05-23T12:53:47.926Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/sph%C3%A4ren-die-einfluss-sph%C3%A4ren-v3.webp"
     },
     {
       "id": "krisenkommunikation",
       "title": "Spickzettel Krisenkommunikation (A4)",
       "kind": "preview",
-      "route": "/infografiken/deeskalation-der-deeskalations-pfad-v9.png",
-      "url": "https://borderline-angehoerige.netlify.app/infografiken/deeskalation-der-deeskalations-pfad-v9.png",
+      "route": "/infografiken/deeskalation-der-deeskalations-pfad-v9.webp",
+      "url": "https://borderline-angehoerige.netlify.app/infografiken/deeskalation-der-deeskalations-pfad-v9.webp",
       "status": "passed",
       "httpStatus": 200,
-      "contentType": "image/png",
-      "startedAt": "2026-05-03T18:38:18.762Z",
-      "finishedAt": "2026-05-03T18:38:19.030Z",
-      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/deeskalation-der-deeskalations-pfad-v9.png"
+      "contentType": "image/webp",
+      "startedAt": "2026-05-23T12:53:47.926Z",
+      "finishedAt": "2026-05-23T12:53:48.438Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/deeskalation-der-deeskalations-pfad-v9.webp"
     },
     {
       "id": "grenzen-spickzettel",
@@ -335,8 +336,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:19.030Z",
-      "finishedAt": "2026-05-03T18:38:19.422Z",
+      "startedAt": "2026-05-23T12:53:48.438Z",
+      "finishedAt": "2026-05-23T12:53:49.208Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-grenzen-spickzettel-v1.webp"
     },
     {
@@ -348,8 +349,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:19.422Z",
-      "finishedAt": "2026-05-03T18:38:19.584Z",
+      "startedAt": "2026-05-23T12:53:49.208Z",
+      "finishedAt": "2026-05-23T12:53:49.638Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-warnsignale-v1.webp"
     },
     {
@@ -361,35 +362,35 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:19.584Z",
-      "finishedAt": "2026-05-03T18:38:19.995Z",
+      "startedAt": "2026-05-23T12:53:49.638Z",
+      "finishedAt": "2026-05-23T12:53:50.076Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-schuld-verantwortung-v1.webp"
     },
     {
       "id": "spaltung",
       "title": "Spaltung – das Pendel zwischen Extremen",
       "kind": "preview",
-      "route": "/infografiken/pendel-das-bewertungs-pendel-v14.png",
-      "url": "https://borderline-angehoerige.netlify.app/infografiken/pendel-das-bewertungs-pendel-v14.png",
+      "route": "/infografiken/pendel-das-bewertungs-pendel-v14.webp",
+      "url": "https://borderline-angehoerige.netlify.app/infografiken/pendel-das-bewertungs-pendel-v14.webp",
       "status": "passed",
       "httpStatus": 200,
-      "contentType": "image/png",
-      "startedAt": "2026-05-03T18:38:19.995Z",
-      "finishedAt": "2026-05-03T18:38:20.254Z",
-      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/pendel-das-bewertungs-pendel-v14.png"
+      "contentType": "image/webp",
+      "startedAt": "2026-05-23T12:53:50.076Z",
+      "finishedAt": "2026-05-23T12:53:50.379Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/pendel-das-bewertungs-pendel-v14.webp"
     },
     {
       "id": "alarm-modus",
       "title": "Alarm-Modus vs. Denk-Modus",
       "kind": "preview",
-      "route": "/infografiken/alarm-der-alarm-modus-v3.png",
-      "url": "https://borderline-angehoerige.netlify.app/infografiken/alarm-der-alarm-modus-v3.png",
+      "route": "/infografiken/alarm-der-alarm-modus-v3.webp",
+      "url": "https://borderline-angehoerige.netlify.app/infografiken/alarm-der-alarm-modus-v3.webp",
       "status": "passed",
       "httpStatus": 200,
-      "contentType": "image/png",
-      "startedAt": "2026-05-03T18:38:20.254Z",
-      "finishedAt": "2026-05-03T18:38:20.632Z",
-      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/alarm-der-alarm-modus-v3.png"
+      "contentType": "image/webp",
+      "startedAt": "2026-05-23T12:53:50.379Z",
+      "finishedAt": "2026-05-23T12:53:50.898Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/alarm-der-alarm-modus-v3.webp"
     },
     {
       "id": "wenn-worte-treffen",
@@ -400,8 +401,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:20.632Z",
-      "finishedAt": "2026-05-03T18:38:20.985Z",
+      "startedAt": "2026-05-23T12:53:50.898Z",
+      "finishedAt": "2026-05-23T12:53:51.205Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-wenn-worte-treffen-v1.webp"
     },
     {
@@ -413,8 +414,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:20.985Z",
-      "finishedAt": "2026-05-03T18:38:21.142Z",
+      "startedAt": "2026-05-23T12:53:51.205Z",
+      "finishedAt": "2026-05-23T12:53:51.608Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-dear-v1.webp"
     },
     {
@@ -426,8 +427,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:21.142Z",
-      "finishedAt": "2026-05-03T18:38:21.525Z",
+      "startedAt": "2026-05-23T12:53:51.608Z",
+      "finishedAt": "2026-05-23T12:53:51.922Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-radikale-akzeptanz-v1.webp"
     },
     {
@@ -439,8 +440,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:21.525Z",
-      "finishedAt": "2026-05-03T18:38:21.686Z",
+      "startedAt": "2026-05-23T12:53:51.922Z",
+      "finishedAt": "2026-05-23T12:53:52.228Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-genesung-zahlen-v1.webp"
     },
     {
@@ -452,8 +453,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "image/webp",
-      "startedAt": "2026-05-03T18:38:21.686Z",
-      "finishedAt": "2026-05-03T18:38:21.957Z",
+      "startedAt": "2026-05-23T12:53:52.229Z",
+      "finishedAt": "2026-05-23T12:53:52.672Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/infografiken/manus-kinder-v1.webp"
     },
     {
@@ -462,8 +463,8 @@
       "kind": "textversion",
       "route": null,
       "status": "passed",
-      "startedAt": "2026-05-03T18:38:21.957Z",
-      "finishedAt": "2026-05-03T18:38:21.957Z",
+      "startedAt": "2026-05-23T12:53:52.672Z",
+      "finishedAt": "2026-05-23T12:53:52.672Z",
       "note": "HTML-Notfallkarte erwartet keine Textversion"
     },
     {
@@ -475,8 +476,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:21.957Z",
-      "finishedAt": "2026-05-03T18:38:22.292Z",
+      "startedAt": "2026-05-23T12:53:52.673Z",
+      "finishedAt": "2026-05-23T12:53:52.949Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/notfallplan-krise"
     },
     {
@@ -488,8 +489,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:22.292Z",
-      "finishedAt": "2026-05-03T18:38:22.683Z",
+      "startedAt": "2026-05-23T12:53:52.950Z",
+      "finishedAt": "2026-05-23T12:53:53.220Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/leuchtturm"
     },
     {
@@ -501,8 +502,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:22.683Z",
-      "finishedAt": "2026-05-03T18:38:22.929Z",
+      "startedAt": "2026-05-23T12:53:53.220Z",
+      "finishedAt": "2026-05-23T12:53:53.467Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/eisberg"
     },
     {
@@ -514,8 +515,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:22.929Z",
-      "finishedAt": "2026-05-03T18:38:23.162Z",
+      "startedAt": "2026-05-23T12:53:53.467Z",
+      "finishedAt": "2026-05-23T12:53:53.716Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/rolle-klaeren"
     },
     {
@@ -527,8 +528,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:23.162Z",
-      "finishedAt": "2026-05-03T18:38:23.401Z",
+      "startedAt": "2026-05-23T12:53:53.716Z",
+      "finishedAt": "2026-05-23T12:53:54.263Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/krisenkommunikation"
     },
     {
@@ -540,8 +541,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:23.401Z",
-      "finishedAt": "2026-05-03T18:38:23.675Z",
+      "startedAt": "2026-05-23T12:53:54.263Z",
+      "finishedAt": "2026-05-23T12:53:54.525Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/grenzen-spickzettel"
     },
     {
@@ -553,8 +554,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:23.675Z",
-      "finishedAt": "2026-05-03T18:38:24.084Z",
+      "startedAt": "2026-05-23T12:53:54.525Z",
+      "finishedAt": "2026-05-23T12:53:54.769Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/warnsignale"
     },
     {
@@ -566,8 +567,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:24.084Z",
-      "finishedAt": "2026-05-03T18:38:24.449Z",
+      "startedAt": "2026-05-23T12:53:54.769Z",
+      "finishedAt": "2026-05-23T12:53:55.125Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/schuld-verantwortung"
     },
     {
@@ -579,8 +580,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:24.449Z",
-      "finishedAt": "2026-05-03T18:38:24.801Z",
+      "startedAt": "2026-05-23T12:53:55.125Z",
+      "finishedAt": "2026-05-23T12:53:55.503Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/spaltung"
     },
     {
@@ -592,8 +593,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:24.801Z",
-      "finishedAt": "2026-05-03T18:38:25.054Z",
+      "startedAt": "2026-05-23T12:53:55.503Z",
+      "finishedAt": "2026-05-23T12:53:55.731Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/alarm-modus"
     },
     {
@@ -605,8 +606,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:25.055Z",
-      "finishedAt": "2026-05-03T18:38:25.282Z",
+      "startedAt": "2026-05-23T12:53:55.731Z",
+      "finishedAt": "2026-05-23T12:53:56.016Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/wenn-worte-treffen"
     },
     {
@@ -618,8 +619,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:25.282Z",
-      "finishedAt": "2026-05-03T18:38:25.516Z",
+      "startedAt": "2026-05-23T12:53:56.017Z",
+      "finishedAt": "2026-05-23T12:53:56.259Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/dear"
     },
     {
@@ -631,8 +632,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:25.516Z",
-      "finishedAt": "2026-05-03T18:38:25.885Z",
+      "startedAt": "2026-05-23T12:53:56.259Z",
+      "finishedAt": "2026-05-23T12:53:56.531Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/radikale-akzeptanz"
     },
     {
@@ -644,8 +645,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:25.885Z",
-      "finishedAt": "2026-05-03T18:38:26.144Z",
+      "startedAt": "2026-05-23T12:53:56.531Z",
+      "finishedAt": "2026-05-23T12:53:56.769Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/genesung-zahlen"
     },
     {
@@ -657,8 +658,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:26.144Z",
-      "finishedAt": "2026-05-03T18:38:26.442Z",
+      "startedAt": "2026-05-23T12:53:56.769Z",
+      "finishedAt": "2026-05-23T12:53:57.007Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/materialien/text/kinder"
     },
     {
@@ -670,8 +671,8 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:26.442Z",
-      "finishedAt": "2026-05-03T18:38:26.574Z",
+      "startedAt": "2026-05-23T12:53:57.007Z",
+      "finishedAt": "2026-05-23T12:53:57.270Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/notfallkarte"
     },
     {
@@ -683,9 +684,129 @@
       "status": "passed",
       "httpStatus": 200,
       "contentType": "text/html; charset=UTF-8",
-      "startedAt": "2026-05-03T18:38:26.574Z",
-      "finishedAt": "2026-05-03T18:38:26.704Z",
+      "startedAt": "2026-05-23T12:53:57.270Z",
+      "finishedAt": "2026-05-23T12:53:57.524Z",
       "finalUrl": "https://borderline-angehoerige.netlify.app/notfallkarte/erstellen"
+    },
+    {
+      "id": "home",
+      "title": "Startseite",
+      "kind": "header",
+      "route": "/",
+      "url": "https://borderline-angehoerige.netlify.app/",
+      "status": "passed",
+      "httpStatus": 200,
+      "contentType": "text/html; charset=UTF-8",
+      "cacheControl": "public,max-age=0,must-revalidate",
+      "contentDisposition": null,
+      "startedAt": "2026-05-23T12:53:58.079Z",
+      "finishedAt": "2026-05-23T12:53:58.209Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/"
+    },
+    {
+      "id": "index-html",
+      "title": "Index HTML",
+      "kind": "header",
+      "route": "/index.html",
+      "url": "https://borderline-angehoerige.netlify.app/index.html",
+      "status": "passed",
+      "httpStatus": 200,
+      "contentType": "text/html; charset=UTF-8",
+      "cacheControl": "public,max-age=3600,must-revalidate",
+      "contentDisposition": null,
+      "startedAt": "2026-05-23T12:53:58.209Z",
+      "finishedAt": "2026-05-23T12:53:58.436Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/index.html"
+    },
+    {
+      "id": "soforthilfe",
+      "title": "Soforthilfe",
+      "kind": "header",
+      "route": "/soforthilfe",
+      "url": "https://borderline-angehoerige.netlify.app/soforthilfe",
+      "status": "passed",
+      "httpStatus": 200,
+      "contentType": "text/html; charset=UTF-8",
+      "cacheControl": "public,max-age=0,must-revalidate",
+      "contentDisposition": null,
+      "startedAt": "2026-05-23T12:53:58.436Z",
+      "finishedAt": "2026-05-23T12:53:58.679Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/soforthilfe"
+    },
+    {
+      "id": "notfallkarte",
+      "title": "Notfallkarte",
+      "kind": "header",
+      "route": "/notfallkarte",
+      "url": "https://borderline-angehoerige.netlify.app/notfallkarte",
+      "status": "passed",
+      "httpStatus": 200,
+      "contentType": "text/html; charset=UTF-8",
+      "cacheControl": "public,max-age=0,must-revalidate",
+      "contentDisposition": null,
+      "startedAt": "2026-05-23T12:53:58.679Z",
+      "finishedAt": "2026-05-23T12:53:58.694Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/notfallkarte"
+    },
+    {
+      "id": "not-found",
+      "title": "404 Seite",
+      "kind": "header",
+      "route": "/404",
+      "url": "https://borderline-angehoerige.netlify.app/404",
+      "status": "passed",
+      "httpStatus": 404,
+      "contentType": "text/html; charset=UTF-8",
+      "cacheControl": "public,max-age=0,must-revalidate",
+      "contentDisposition": null,
+      "startedAt": "2026-05-23T12:53:58.695Z",
+      "finishedAt": "2026-05-23T12:53:58.934Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/404"
+    },
+    {
+      "id": "material-inline",
+      "title": "Material Inline Download",
+      "kind": "header",
+      "route": "/api/material-download/notfallplan-krise?disposition=inline",
+      "url": "https://borderline-angehoerige.netlify.app/api/material-download/notfallplan-krise?disposition=inline",
+      "status": "passed",
+      "httpStatus": 200,
+      "contentType": "application/pdf",
+      "cacheControl": "public,max-age=0,must-revalidate",
+      "contentDisposition": "inline; filename=\"notfallplan-krise-v03.pdf\"; filename*=UTF-8''notfallplan-krise-v03.pdf",
+      "startedAt": "2026-05-23T12:53:58.934Z",
+      "finishedAt": "2026-05-23T12:53:59.209Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/api/material-download/notfallplan-krise?disposition=inline"
+    },
+    {
+      "id": "static-pdf",
+      "title": "Statisches PDF",
+      "kind": "header",
+      "route": "/notfallplan-krise-v03.pdf",
+      "url": "https://borderline-angehoerige.netlify.app/notfallplan-krise-v03.pdf",
+      "status": "passed",
+      "httpStatus": 200,
+      "contentType": "application/pdf",
+      "cacheControl": "public,max-age=0,must-revalidate",
+      "contentDisposition": null,
+      "startedAt": "2026-05-23T12:53:59.209Z",
+      "finishedAt": "2026-05-23T12:53:59.429Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/notfallplan-krise-v03.pdf"
+    },
+    {
+      "id": "runtime-asset",
+      "title": "Gebautes Asset",
+      "kind": "header",
+      "route": "/assets/index-DxdPYkXv.js",
+      "url": "https://borderline-angehoerige.netlify.app/assets/index-DxdPYkXv.js",
+      "status": "passed",
+      "httpStatus": 200,
+      "contentType": "application/javascript; charset=UTF-8",
+      "cacheControl": "public,max-age=31536000,immutable",
+      "contentDisposition": null,
+      "startedAt": "2026-05-23T12:53:59.429Z",
+      "finishedAt": "2026-05-23T12:53:59.887Z",
+      "finalUrl": "https://borderline-angehoerige.netlify.app/assets/index-DxdPYkXv.js"
     }
   ],
   "status": "passed"

--- a/qa/release-http-gates.md
+++ b/qa/release-http-gates.md
@@ -1,60 +1,68 @@
 ## Letzter Lauf
 
-- Datum: 2026-05-03
+- Datum: 2026-05-23
 - Basis-URL: https://borderline-angehoerige.netlify.app
 
-| Typ         | ID                      | Ergebnis | HTTP | Content-Type             |
-| ----------- | ----------------------- | -------- | ---- | ------------------------ |
-| pdf         | notfallkarte-zuerich    | passed   | 200  | application/pdf          |
-| pdf         | notfallplan-krise       | passed   | 200  | application/pdf          |
-| pdf         | leuchtturm              | passed   | 200  | application/pdf          |
-| pdf         | eisberg                 | passed   | 200  | application/pdf          |
-| pdf         | rolle-klaeren           | passed   | 200  | application/pdf          |
-| pdf         | krisenkommunikation     | passed   | 200  | application/pdf          |
-| pdf         | grenzen-spickzettel     | passed   | 200  | application/pdf          |
-| pdf         | warnsignale             | passed   | 200  | application/pdf          |
-| pdf         | schuld-verantwortung    | passed   | 200  | application/pdf          |
-| pdf         | spaltung                | passed   | 200  | application/pdf          |
-| pdf         | alarm-modus             | passed   | 200  | application/pdf          |
-| pdf         | wenn-worte-treffen      | passed   | 200  | application/pdf          |
-| pdf         | dear                    | passed   | 200  | application/pdf          |
-| pdf         | radikale-akzeptanz      | passed   | 200  | application/pdf          |
-| pdf         | genesung-zahlen         | passed   | 200  | application/pdf          |
-| pdf         | kinder                  | passed   | 200  | application/pdf          |
-| preview     | notfallkarte-zuerich    | passed   | 200  | image/webp               |
-| preview     | notfallplan-krise       | passed   | 200  | image/webp               |
-| preview     | leuchtturm              | passed   | 200  | image/webp               |
-| preview     | eisberg                 | passed   | 200  | image/png                |
-| preview     | rolle-klaeren           | passed   | 200  | image/png                |
-| preview     | krisenkommunikation     | passed   | 200  | image/png                |
-| preview     | grenzen-spickzettel     | passed   | 200  | image/webp               |
-| preview     | warnsignale             | passed   | 200  | image/webp               |
-| preview     | schuld-verantwortung    | passed   | 200  | image/webp               |
-| preview     | spaltung                | passed   | 200  | image/png                |
-| preview     | alarm-modus             | passed   | 200  | image/png                |
-| preview     | wenn-worte-treffen      | passed   | 200  | image/webp               |
-| preview     | dear                    | passed   | 200  | image/webp               |
-| preview     | radikale-akzeptanz      | passed   | 200  | image/webp               |
-| preview     | genesung-zahlen         | passed   | 200  | image/webp               |
-| preview     | kinder                  | passed   | 200  | image/webp               |
-| textversion | notfallkarte-zuerich    | passed   | -    | -                        |
-| textversion | notfallplan-krise       | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | leuchtturm              | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | eisberg                 | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | rolle-klaeren           | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | krisenkommunikation     | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | grenzen-spickzettel     | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | warnsignale             | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | schuld-verantwortung    | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | spaltung                | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | alarm-modus             | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | wenn-worte-treffen      | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | dear                    | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | radikale-akzeptanz      | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | genesung-zahlen         | passed   | 200  | text/html; charset=UTF-8 |
-| textversion | kinder                  | passed   | 200  | text/html; charset=UTF-8 |
-| page        | /notfallkarte           | passed   | 200  | text/html; charset=UTF-8 |
-| page        | /notfallkarte/erstellen | passed   | 200  | text/html; charset=UTF-8 |
+| Typ         | ID                      | Ergebnis | HTTP | Content-Type                          |
+| ----------- | ----------------------- | -------- | ---- | ------------------------------------- |
+| pdf         | notfallkarte-zuerich    | passed   | 200  | application/pdf                       |
+| pdf         | notfallplan-krise       | passed   | 200  | application/pdf                       |
+| pdf         | leuchtturm              | passed   | 200  | application/pdf                       |
+| pdf         | eisberg                 | passed   | 200  | application/pdf                       |
+| pdf         | rolle-klaeren           | passed   | 200  | application/pdf                       |
+| pdf         | krisenkommunikation     | passed   | 200  | application/pdf                       |
+| pdf         | grenzen-spickzettel     | passed   | 200  | application/pdf                       |
+| pdf         | warnsignale             | passed   | 200  | application/pdf                       |
+| pdf         | schuld-verantwortung    | passed   | 200  | application/pdf                       |
+| pdf         | spaltung                | passed   | 200  | application/pdf                       |
+| pdf         | alarm-modus             | passed   | 200  | application/pdf                       |
+| pdf         | wenn-worte-treffen      | passed   | 200  | application/pdf                       |
+| pdf         | dear                    | passed   | 200  | application/pdf                       |
+| pdf         | radikale-akzeptanz      | passed   | 200  | application/pdf                       |
+| pdf         | genesung-zahlen         | passed   | 200  | application/pdf                       |
+| pdf         | kinder                  | passed   | 200  | application/pdf                       |
+| preview     | notfallkarte-zuerich    | passed   | 200  | image/webp                            |
+| preview     | notfallplan-krise       | passed   | 200  | image/webp                            |
+| preview     | leuchtturm              | passed   | 200  | image/webp                            |
+| preview     | eisberg                 | passed   | 200  | image/webp                            |
+| preview     | rolle-klaeren           | passed   | 200  | image/webp                            |
+| preview     | krisenkommunikation     | passed   | 200  | image/webp                            |
+| preview     | grenzen-spickzettel     | passed   | 200  | image/webp                            |
+| preview     | warnsignale             | passed   | 200  | image/webp                            |
+| preview     | schuld-verantwortung    | passed   | 200  | image/webp                            |
+| preview     | spaltung                | passed   | 200  | image/webp                            |
+| preview     | alarm-modus             | passed   | 200  | image/webp                            |
+| preview     | wenn-worte-treffen      | passed   | 200  | image/webp                            |
+| preview     | dear                    | passed   | 200  | image/webp                            |
+| preview     | radikale-akzeptanz      | passed   | 200  | image/webp                            |
+| preview     | genesung-zahlen         | passed   | 200  | image/webp                            |
+| preview     | kinder                  | passed   | 200  | image/webp                            |
+| textversion | notfallkarte-zuerich    | passed   | -    | -                                     |
+| textversion | notfallplan-krise       | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | leuchtturm              | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | eisberg                 | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | rolle-klaeren           | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | krisenkommunikation     | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | grenzen-spickzettel     | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | warnsignale             | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | schuld-verantwortung    | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | spaltung                | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | alarm-modus             | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | wenn-worte-treffen      | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | dear                    | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | radikale-akzeptanz      | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | genesung-zahlen         | passed   | 200  | text/html; charset=UTF-8              |
+| textversion | kinder                  | passed   | 200  | text/html; charset=UTF-8              |
+| page        | /notfallkarte           | passed   | 200  | text/html; charset=UTF-8              |
+| page        | /notfallkarte/erstellen | passed   | 200  | text/html; charset=UTF-8              |
+| header      | home                    | passed   | 200  | text/html; charset=UTF-8              |
+| header      | index-html              | passed   | 200  | text/html; charset=UTF-8              |
+| header      | soforthilfe             | passed   | 200  | text/html; charset=UTF-8              |
+| header      | notfallkarte            | passed   | 200  | text/html; charset=UTF-8              |
+| header      | not-found               | passed   | 404  | text/html; charset=UTF-8              |
+| header      | material-inline         | passed   | 200  | application/pdf                       |
+| header      | static-pdf              | passed   | 200  | application/pdf                       |
+| header      | runtime-asset           | passed   | 200  | application/javascript; charset=UTF-8 |
 
 ### Befunde
 


### PR DESCRIPTION
## Summary
- update production HTTP release gate report for commit 244a527
- update browser matrix after installing local WebKit and Firefox Playwright browsers
- document green-with-notes browser release decision with non-physical-device caveat

## Verification
- pnpm audit:release-http-gates
- pnpm audit:browser-matrix

## Notes
- HTTP gates passed for 16 PDFs, 16 previews, 16 text versions, /notfallkarte, /notfallkarte/erstellen, and header/cache checks.
- Browser matrix passed for iPhone Safari via Playwright WebKit emulation, optional desktop WebKit, iPhone/Android Chrome emulation, desktop Chrome, and desktop Firefox. Remaining note: no physical iPhone/Android hardware run in this automated gate.