### PR TITLE
docs(dev): Feinschliff-Briefs versioniert ablegen

### DIFF
--- a/_dev/feinschliff-brief.md
+++ b/_dev/feinschliff-brief.md
@@ -1,0 +1,99 @@
+# Feinschliff-Briefs — Archiv
+
+Versionierte Ablage der Feinschliff-Aufträge (Design & Technik) samt
+Ergebnis je Aufgabe. Damit liegen Brief und Umsetzung nachvollziehbar
+beieinander. Neueste Blöcke unten anhängen.
+
+Konventionen, die in allen Blöcken gelten: WCAG AA, das editoriale System
+und Schweizer Orthografie (ss statt ß, Guillemets «») bleiben unangetastet.
+Arbeitsweise immer: erst Ist-Stand verifizieren, dann ändern.
+
+---
+
+## Block 1 — Editorial-Feinschliff Layout & Hero
+
+**Erstellt:** 28. Mai 2026 · **Grundlage:** Design-Review (Desktop 1440 / Mobile 390)
+**PRs:** #544 (Aufgaben 1–4), #545 (Folge-Befund Sektionsabstände)
+
+### Aufgabe 1 — Versetztes Raster ohne Gegengewicht
+- **Symptom (Annahme):** Auf Tool-Seiten (`/wegweiser`, `/selbsttest`) sitze der
+  Inhalt in einer aussermittigen Lesespalte; das rechte Drittel bleibe ab
+  ~1280px leer → wirke unfertig.
+- **Ergebnis: kein Eingriff (Befund statt Fix).** Verifikation ergab, dass
+  diese Seiten ihre Spalte bereits über `EditorialLayout` (`mx-auto`)
+  zentrieren — symmetrischer Weissraum, kein offenes rechtes Drittel. Das
+  versetzte Raster existiert nur in `EditorialSection` und trägt dort immer
+  ein gefülltes Aside/MarginNote (z. B. Verstehen-Hero mit Illustration).
+  Briefing-Ziel war damit bereits erfüllt.
+
+### Aufgabe 2 — Leerband oben auf schlanken Seiten
+- **Symptom:** ~150–180px Abstand zwischen Header und erstem Caps-Eyebrow auf
+  `/wegweiser`, `/quellen` u. a.; das Eyebrow «schwebt».
+- **Ergebnis: erledigt (`fix(layout)`).** Oberes Header-Padding auf acht
+  Eyebrow-Start-Seiten von `pt-16 md:pt-24` auf `pt-12 md:pt-16` gesenkt —
+  exakt der Wert, den fünf andere Inhaltsseiten (Diagnostik,
+  Begleiterkrankungen, Barrierefreiheit, Übungsszenarien, HandoutText)
+  bereits nutzen → systemweit konsistent. Hero-Seiten unverändert.
+
+### Aufgabe 3 — Kursiv-ein-Wort-Motiv in H1
+- **Symptom:** Das `<em>`-Motiv stand auf fast jeder H1 und nutzte sich ab.
+- **Entscheidung (Christa, freigegeben):** Motiv auf Hero/Landing beschränken,
+  Innenseiten-H1 plain.
+- **Ergebnis: erledigt (`style(headings)`).** `<em>` aus 16 Innenseiten-H1
+  entfernt (Wortlaut unverändert). Die 10 Hero/Landing-Seiten (Home,
+  Verstehen, Kommunizieren, Selbstfürsorge, Unterstützen-\*, Grenzen,
+  Genesung) behalten das Motiv.
+
+### Aufgabe 4 — Vertikales Caps-Label im Startseiten-Hero
+- **Symptom:** «FACHSTELLE ANGEHÖRIGENARBEIT · PSYCHIATRISCHE
+  UNIVERSITÄTSKLINIK ZÜRICH» brach in der schmalen Hero-Margin auf fünf
+  gesperrte Zeilen um — schwerstes Element im ruhigen Hero.
+- **Entscheidung (Christa, freigegeben):** kürzen.
+- **Ergebnis: erledigt (`style(hero)`).** Auf die schon im Site-Header
+  etablierte Kurzform «Fachstelle Angehörigenarbeit · PUK Zürich» verkürzt
+  → von fünf auf zwei Zeilen, Sperrung/Grösse unverändert.
+
+### Folge-Befund — Sektionsabstände (PR #545)
+- **Symptom (Christa, mobil):** Auf `/verstehen` unnötig grosse vertikale
+  Abstände zwischen Sektionen.
+- **Diagnose (gemessen):** Gestapelte gleichfarbige `EditorialSection`-Blöcke
+  addieren an jeder Naht Unter- + Oberkante zum doppelten Abstand
+  (mobil 112px, Desktop 160px) — ohne Hintergrundwechsel ein unmotivierter
+  Leerraum.
+- **Ergebnis: erledigt (`fix(layout)`, freigegeben — site-weit).** Regel in
+  `layer(utilities)`: folgt eine Sektion direkt auf eine gleichfarbige,
+  entfällt ihr oberes Padding (Naht mobil 56px, Desktop 80px). Farbwechsel-
+  Nähte (z. B. cream → cream-deep) bleiben voll. Zusätzlich die handgebaute
+  Materialien-Tile-Liste als cream-Sektion ausgezeichnet, damit auch ihre
+  Naht abbaut.
+
+---
+
+## Block 2 — Quick-Wins Technik & A11y
+
+**PR:** #546 · drei atomare Commits
+
+### Aufgabe 1 — Fokus-Rückgabe nach Schliessen des Such-Dialogs (WCAG 2.4.3)
+- **Symptom:** Nach Escape / Schliessen-Button / Backdrop-Klick / Treffer-
+  Auswahl landete der Fokus auf `<body>` statt zurück auf dem Such-Auslöser.
+- **Ergebnis: erledigt (`fix(a11y)`).** `Search` wird nur bei `isOpen`
+  gemountet; ein Effect merkt sich beim Mount `document.activeElement` und
+  gibt den Fokus beim Unmount per `.focus()` zurück — deckt alle Schliesswege
+  ab. Fokus-Trap unberührt. Tastatur-Check (Playwright): nach Escape, Button
+  und Backdrop jeweils `button[aria-label="Suchen"]` fokussiert.
+- **Mitgeprüft:** Mobile-Menü gibt den Fokus bereits korrekt zurück
+  (`HeaderNav`, `menuButtonRef`) — kein Defekt, nicht angefasst.
+
+### Aufgabe 2 — Infografik-Thumbnails auf `loading="lazy"`
+- **Symptom:** Die drei Orientierungs-Tiles auf der Home («Drei Bilder für den
+  ersten Überblick») waren `loading="eager"`, liegen aber unter dem Fold und
+  sind nicht LCP-relevant (~124 KB unnötig im kritischen Pfad).
+- **Ergebnis: erledigt (`perf(home)`).** Alle Thumbnails auf `loading="lazy"`
+  vereinheitlicht (eager-Sonderlogik entfällt). `width`/`height` +
+  `aspect-ratio` bleiben → kein CLS. Hero unverändert; Test angepasst.
+
+### Aufgabe 3 — `<meta name="theme-color">` ergänzen
+- **Symptom:** Tag fehlte im Head; das Manifest hatte `theme_color: #C67A5C`.
+- **Ergebnis: erledigt (`chore(head)`).** `<meta name="theme-color"
+  content="#C67A5C" />` in `client/index.html`, Wert identisch zum Manifest;
+  im ausgelieferten HTML verifiziert.


### PR DESCRIPTION
## Feinschliff-Briefs versioniert ablegen

Reine Doku-Änderung — legt `_dev/feinschliff-brief.md` an, damit Brief und Umsetzung der Feinschliff-Aufträge nachvollziehbar beieinander liegen. Kein Code, kein Build-Einfluss.

- **Block 1 — Editorial-Feinschliff Layout & Hero** (PRs #544 / #545): Aufgaben 1–4 + Folge-Befund Sektionsabstände, je mit Symptom, Entscheidung und Ergebnis.
- **Block 2 — Quick-Wins Technik & A11y** (PR #546): Fokus-Rückgabe Such-Dialog, Lazy-Thumbnails, theme-color.

Format: neueste Blöcke unten anhängen; Status je Aufgabe (umgesetzt / als „kein Bug" verworfen).

https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N)_