### PR TITLE
Aufgabe 3 (Folge) — Home-Teaser auf die übrigen Infografiken umstellen

### DIFF
--- a/client/src/components/visualizations/VisualOrientationGrid.tsx
+++ b/client/src/components/visualizations/VisualOrientationGrid.tsx
@@ -12,6 +12,12 @@ interface VisualOrientationGridProps {
    * Home kann daraus eine ruhigere Vorschau machen.
    */
   maxItems?: number;
+  /**
+   * Explizite Tile-Auswahl per id (in dieser Reihenfolge). Hat Vorrang vor
+   * `maxItems` — z.B. damit die Home gezielt andere Konzepte zeigt als jene,
+   * die bereits inline an ihrem Wirkort stehen.
+   */
+  ids?: string[];
   title?: string;
   intro?: string;
 }
@@ -35,15 +41,22 @@ interface VisualOrientationGridProps {
  */
 export function VisualOrientationGrid({
   maxItems,
+  ids,
   title = "Acht Konzepte, in Lese-Reihenfolge — ein Bild pro Idee.",
   intro,
 }: VisualOrientationGridProps) {
-  const tiles =
-    typeof maxItems === "number"
+  const tiles = ids
+    ? ids
+        .map(id => homeFeaturedInfografiken.find(tile => tile.id === id))
+        .filter(
+          (tile): tile is (typeof homeFeaturedInfografiken)[number] =>
+            tile !== undefined
+        )
+    : typeof maxItems === "number"
       ? homeFeaturedInfografiken.slice(0, maxItems)
       : homeFeaturedInfografiken;
   const gridClass =
-    typeof maxItems === "number" && maxItems <= 3
+    tiles.length <= 3
       ? "grid grid-cols-1 gap-x-6 gap-y-10 md:grid-cols-2 md:gap-y-12 lg:grid-cols-3"
       : "grid grid-cols-1 gap-x-6 gap-y-10 md:grid-cols-2 md:gap-y-12 lg:grid-cols-4";
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -133,9 +133,9 @@ export default function Home() {
       </EditorialSection>
 
       <VisualOrientationGrid
-        maxItems={3}
-        title="Drei Bilder für den ersten Überblick."
-        intro="Nicht als Galerie, sondern als Einstieg: Was passiert innerlich, wann wird es akut, und warum hilft Beruhigung vor Klärung?"
+        ids={["validierungs-treppe", "vier-arten-grenzen", "sauerstoffmaske"]}
+        title="Drei Bilder für die nächsten Schritte."
+        intro="Nicht als Galerie, sondern als Einstieg: validieren ohne nachzugeben, Grenzen halten und die eigene Kraft schützen — je ein Bild pro Idee."
       />
 
       <EditorialSection variant="cream-deep" density="compact">


### PR DESCRIPTION
## Home-Teaser „verschlanken" (Folge zu #551)

Freigegeben. Eisberg/Alarm/Ampel leben jetzt an ihren Wirkorten (#551 inline auf `/verstehen`; Ampel als interaktive Viz auf `/krise`). Der Home-Teaser „Drei Bilder" zeigte aber weiter genau diese drei → Redundanz.

### Umsetzung
- `VisualOrientationGrid` um optionalen **`ids`-Prop** erweitert (gezielte Tile-Auswahl, Vorrang vor `maxItems`; bestehende Callsites unverändert).
- Home-Teaser zeigt jetzt **die nächsten Schritte**: Validierungs-Treppe (Kommunizieren) · 4 Arten von Grenzen (Grenzen) · Sauerstoffmaske (Selbstfürsorge).
- Titel: „Drei Bilder für die nächsten Schritte." · Intro: „… validieren ohne nachzugeben, Grenzen halten und die eigene Kraft schützen — je ein Bild pro Idee."

### Verifikation
- DOM: Teaser zeigt die 3 neuen Tiles; `typecheck` · `lint` · `test` (361/361) · `build` · Visual 30/30 grün.
- Enthält denselben `fix(test)` home-hero-Baseline wie #551 (nach #549) — identische Bytes, konfliktfrei beim Merge.

> **Merge-Reihenfolge:** unabhängig von #551 (andere Dateien), aber inhaltlich die Fortsetzung. Reihenfolge egal; die doppelte home-hero-Baseline-Korrektur merged konfliktfrei.

### Commits
- `refactor(home): Teaser-Block auf die übrigen Infografiken umstellen`
- `fix(test): home-hero Baseline nachziehen (nach #549)`

https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N)_