### PR TITLE
Aufgabe 1 (Rollout) — /verstehen/begleiterkrankungen: alle Kernabschnitte offen

### DIFF
--- a/client/src/__tests__/hash-accordion-links.test.tsx
+++ b/client/src/__tests__/hash-accordion-links.test.tsx
@@ -114,12 +114,6 @@ const HASH_CASES = [
       /Abschnitt Wo eine Diagnose im Kanton Zürich gestellt werden kann/i,
     contentText: /Psychiatrische Universitätsklinik Zürich \(PUK\)/i,
   },
-  {
-    route: "/verstehen/begleiterkrankungen#depression",
-    loadPage: () => import("@/pages/Begleiterkrankungen"),
-    buttonName: /Abschnitt Depression bei Borderline/i,
-    contentText: /Forschung zeigt, dass im Lebenszeitverlauf/i,
-  },
 ] as const;
 
 describe("hash-linked content sections", () => {
@@ -140,6 +134,23 @@ describe("hash-linked content sections", () => {
       expect(window.scrollTo).toHaveBeenCalled();
     }
   );
+
+  it("scrollt bei Hash-Navigation zum jetzt offenen Abschnitt /verstehen/begleiterkrankungen#depression", async () => {
+    const { default: Page } = await import("@/pages/Begleiterkrankungen");
+    renderWithRoute(<Page />, "/verstehen/begleiterkrankungen#depression");
+
+    // «Depression bei Borderline» ist jetzt offene Prosa (collapsible={false}):
+    // kein Toggle-Button, Inhalt direkt sichtbar, Deep-Link scrollt trotzdem.
+    expect(
+      screen.queryByRole("button", {
+        name: /Abschnitt Depression bei Borderline/i,
+      })
+    ).toBeNull();
+    expect(
+      screen.getByText(/Forschung zeigt, dass im Lebenszeitverlauf/i)
+    ).toBeInTheDocument();
+    await waitFor(() => expect(window.scrollTo).toHaveBeenCalled());
+  });
 
   it("scrollt bei Hash-Navigation zum jetzt offenen Abschnitt /grenzen#gewalt", async () => {
     const { default: Page } = await import("@/pages/Grenzen");

--- a/client/src/pages/Begleiterkrankungen.tsx
+++ b/client/src/pages/Begleiterkrankungen.tsx
@@ -179,10 +179,9 @@ export default function Begleiterkrankungen() {
         {/* ── 1: Was Komorbidität bedeutet ── */}
         <ContentSection
           variant="editorial"
+          collapsible={false}
           title="Was Komorbidität bei Borderline bedeutet"
           id="was-ist-komorbiditaet"
-          defaultOpen={true}
-          preview="Komorbidität heisst: mehrere Erkrankungen, die gleichzeitig oder nacheinander auftreten. Bei Borderline ist das die Regel, nicht die Ausnahme."
         >
           <EditorialProse>
             <p>
@@ -213,9 +212,9 @@ export default function Begleiterkrankungen() {
         {/* ── 2: Depression bei Borderline ── */}
         <ContentSection
           variant="editorial"
+          collapsible={false}
           title="Depression bei Borderline — die häufigste Komorbidität"
           id="depression"
-          preview="Depression ist die mit Abstand häufigste Begleiterkrankung. Borderline-Stimmungsschwankungen und depressive Episoden überlagern sich oft — die Differenzierung ist klinische Aufgabe."
         >
           <EditorialProse>
             <p>
@@ -282,9 +281,9 @@ export default function Begleiterkrankungen() {
         {/* ── 3: Suizidrisiko ── */}
         <ContentSection
           variant="editorial"
+          collapsible={false}
           title="Erhöhtes Suizidrisiko bei depressiver Komorbidität"
           id="suizidrisiko"
-          preview="Eine schwere depressive Episode zusätzlich zur Borderline-Erkrankung erhöht das Suizidrisiko. Bei Hinweisen auf konkrete Suizidalität gilt: nicht abwarten, sondern Soforthilfe nutzen."
         >
           <EditorialProse>
             <p>
@@ -337,9 +336,9 @@ export default function Begleiterkrankungen() {
         {/* ── 4: Was Sie als Angehörige wissen sollten ── */}
         <ContentSection
           variant="editorial"
+          collapsible={false}
           title="Was Sie als Angehörige wissen sollten"
           id="angehoerige"
-          preview="Validieren, ohne diagnostisch zu werden. Was bei längerem Rückzug zu tun ist. Warum die eigene Erschöpfung in depressiven Phasen oft besonders gross wird."
         >
           <EditorialProse>
             <p>
@@ -392,9 +391,9 @@ export default function Begleiterkrankungen() {
         {/* ── 5: Andere häufige Komorbiditäten ── */}
         <ContentSection
           variant="editorial"
+          collapsible={false}
           title="Andere häufige Komorbiditäten — knapp"
           id="andere"
-          preview="Angststörungen, PTBS, Essstörungen, Substanzgebrauchsstörungen — die wichtigsten weiteren Erkrankungen, die mit Borderline auftreten können."
         >
           <EditorialProse>
             <p>
@@ -407,7 +406,7 @@ export default function Begleiterkrankungen() {
           <div className="mt-6 space-y-6">
             {andereKomorbiditaeten.map(item => (
               <article key={item.title} className="space-y-2">
-                <h4 style={h4Style}>{item.title}</h4>
+                <h3 style={h4Style}>{item.title}</h3>
                 <p style={bodyStyle}>{item.desc}</p>
               </article>
             ))}
@@ -417,9 +416,9 @@ export default function Begleiterkrankungen() {
         {/* ── 6: Was bedeutet das für die Behandlung ── */}
         <ContentSection
           variant="editorial"
+          collapsible={false}
           title="Was bedeutet das für die Behandlung?"
           id="behandlung"
-          preview="Komorbide Erkrankungen werden in der Regel mitbehandelt, nicht ignoriert. Reine «Borderline-Therapie» gibt es selten."
         >
           <EditorialProse>
             <p>
@@ -484,9 +483,9 @@ export default function Begleiterkrankungen() {
         {/* ── 7: Auch bei Ihnen (Mini-Sektion) ── */}
         <ContentSection
           variant="editorial"
+          collapsible={false}
           title="Wenn die Belastung gross wird — auch bei Ihnen"
           id="auch-bei-ihnen"
-          preview="Komorbidität auf Seiten der betroffenen Person erhöht oft auch die Belastung der Angehörigen. Eigene Beratung ist legitim."
         >
           <EditorialProse>
             <p>


### PR DESCRIPTION
## Aufgabe 1 — Rollout auf Begleiterkrankungen (Seite 5 von 10)

Freigegeben mit **„mehr öffnen" + Suizidrisiko offen**.

### Umsetzung
- **Alle 7 ContentSections offen** (`collapsible={false}`), keine Akkordeons mehr: Was Komorbidität bedeutet · Depression (häufigste Komorbidität) · **Erhöhtes Suizidrisiko** (sicherheitsrelevant, offen) · Was Sie als Angehörige wissen sollten · Andere häufige Komorbiditäten · Was bedeutet das für die Behandlung · Wenn die Belastung gross wird.
- Intro & Schluss sind bereits offene `EditorialSectionBlock`s; 3 Quellen-Boxen (EvidenceNote) unverändert.

### Technik-Audit + Test
- 1× `<h4>` → `<h3>` (Hierarchie lückenlos).
- Deep-Link-Test `…/begleiterkrankungen#depression` angepasst → prüft jetzt das **offene** „Depression"-Verhalten (kein Toggle, Inhalt sichtbar, Hash scrollt), analog `/grenzen#gewalt`.

### Verifikation
- DOM-Check **h1–h6**: keine Sprünge; **7 offen / 0 Akkordeon**.
- `typecheck` · `lint` · `test` (361/361) · `build` grün. Nicht visuell getestet → keine Baseline-Änderung.

### Roll-out-Fortschritt
Grenzen ✅ · Diagnostik ✅ · Alltag #555 · Therapie #556 · Begleiterkrankungen (dieser PR). Nächste: Unterstützen-Übersicht.

https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N)_