### PR TITLE
Aufgabe 1 (Rollout) — /selbstfuersorge: Kernabschnitte als offene Prosa

### DIFF
--- a/client/src/pages/Selbstfuersorge.tsx
+++ b/client/src/pages/Selbstfuersorge.tsx
@@ -425,10 +425,9 @@ export default function Selbstfuersorge() {
         <EditorialSection.Body>
           <ContentSection
             variant="editorial"
+            collapsible={false}
             title="Warum Selbstfürsorge so wichtig ist"
             id="selbstfuersorge-warum-wichtig"
-            defaultOpen={true}
-            preview="Angehörige tragen eine besondere Last. Selbstfürsorge ist keine Selbstsucht, sondern Selbsterhaltung."
           >
             <EditorialProse>
               <p>
@@ -476,7 +475,7 @@ export default function Selbstfuersorge() {
           />
         </EditorialSection.MarginNote>
         <EditorialSection.Body>
-          <SelbstfuersorgeSignalsSection defaultOpen />
+          <SelbstfuersorgeSignalsSection collapsible={false} />
           <SelbstfuersorgeCheck />
         </EditorialSection.Body>
       </EditorialSection>
@@ -504,13 +503,13 @@ export default function Selbstfuersorge() {
           />
         </EditorialSection.MarginNote>
         <EditorialSection.Body>
-          <SelbstfuersorgeExercisesSection immediateDefaultOpen />
+          <SelbstfuersorgeExercisesSection immediateCollapsible={false} />
 
           <ContentSection
             variant="editorial"
+            collapsible={false}
             title="Radikale Akzeptanz"
             id="radikale-akzeptanz"
-            preview="«Es ist, wie es ist.» – Dieses DBT-Konzept kann auch für Angehörige befreiend sein."
           >
             <div className="mt-2">
               <EditorialPullQuote cite="Dieser Satz kann befreiend sein.">
@@ -530,9 +529,9 @@ export default function Selbstfuersorge() {
             </EditorialProse>
             <div className="mt-6 grid gap-8 sm:grid-cols-2">
               <div>
-                <h4 className="mb-2" style={h4Style}>
+                <h3 className="mb-2" style={h4Style}>
                   Was radikale Akzeptanz NICHT ist
-                </h4>
+                </h3>
                 <ul className="ml-5 list-disc space-y-1" style={bodyStyle}>
                   <li>Aufgeben</li>
                   <li>Gutheissen</li>
@@ -541,9 +540,9 @@ export default function Selbstfuersorge() {
                 </ul>
               </div>
               <div>
-                <h4 className="mb-2" style={h4Style}>
+                <h3 className="mb-2" style={h4Style}>
                   Was radikale Akzeptanz IST
-                </h4>
+                </h3>
                 <ul className="ml-5 list-disc space-y-1" style={bodyStyle}>
                   <li>Anerkennen, was Sie nicht ändern können</li>
                   <li>Energie sparen für das, was Sie beeinflussen können</li>
@@ -553,9 +552,9 @@ export default function Selbstfuersorge() {
               </div>
             </div>
             <div className="mt-8">
-              <h4 className="mb-3" style={h4Style}>
+              <h3 className="mb-3" style={h4Style}>
                 Übung: Radikale Akzeptanz praktizieren
-              </h4>
+              </h3>
               <ol className="ml-5 list-decimal space-y-2" style={bodyStyle}>
                 <li>Benennen Sie die Situation: «Es ist so, dass…»</li>
                 <li>
@@ -581,10 +580,9 @@ export default function Selbstfuersorge() {
 
           <ContentSection
             variant="editorial"
+            collapsible={false}
             title="Geben Sie sich die Erlaubnis"
             id="erlaubnis"
-            defaultOpen={true}
-            preview="Als Angehöriger dürfen Sie auch mal wütend sein, Nein sagen und Ihre eigenen Bedürfnisse ernst nehmen."
           >
             <EditorialProse>
               <p>Als Angehöriger dürfen Sie:</p>
@@ -623,10 +621,9 @@ export default function Selbstfuersorge() {
         <EditorialSection.Body>
           <ContentSection
             variant="editorial"
+            collapsible={false}
             title="Beratung & Netzwerke"
             id="beratung-netzwerke"
-            defaultOpen={true}
-            preview="Sie müssen das nicht allein tragen – professionelle Beratung und Austausch mit anderen Angehörigen helfen."
           >
             <EditorialProse>
               <p>

--- a/client/src/sections/SelbstfuersorgeExercisesSection.tsx
+++ b/client/src/sections/SelbstfuersorgeExercisesSection.tsx
@@ -224,11 +224,14 @@ function UebungAkkordeon({
 interface SelbstfuersorgeExercisesSectionProps {
   immediateDefaultOpen?: boolean;
   longTermDefaultOpen?: boolean;
+  /** Wenn false: «Sofort-Übungen» dauerhaft offen (akute Hilfe, kein Toggle). */
+  immediateCollapsible?: boolean;
 }
 
 export function SelbstfuersorgeExercisesSection({
   immediateDefaultOpen = false,
   longTermDefaultOpen = false,
+  immediateCollapsible = true,
 }: SelbstfuersorgeExercisesSectionProps) {
   const bodyStyle = {
     fontSize: "var(--text-sm)",
@@ -246,6 +249,7 @@ export function SelbstfuersorgeExercisesSection({
     <>
       <ContentSection
         variant="editorial"
+        collapsible={immediateCollapsible}
         title="Sofort-Übungen für akute Belastung"
         id="sofort-uebungen"
         defaultOpen={immediateDefaultOpen}

--- a/client/src/sections/SelbstfuersorgeSignalsSection.tsx
+++ b/client/src/sections/SelbstfuersorgeSignalsSection.tsx
@@ -3,14 +3,18 @@ import { warningSignalGroups } from "@/content/selbstfuersorge-page";
 
 interface SelbstfuersorgeSignalsSectionProps {
   defaultOpen?: boolean;
+  /** Wenn false: dauerhaft offene Prosa ohne Toggle (an ContentSection durchgereicht). */
+  collapsible?: boolean;
 }
 
 export function SelbstfuersorgeSignalsSection({
   defaultOpen = false,
+  collapsible = true,
 }: SelbstfuersorgeSignalsSectionProps) {
   return (
     <ContentSection
       variant="editorial"
+      collapsible={collapsible}
       title="Warnsignale für Überlastung"
       id="warnsignale"
       defaultOpen={defaultOpen}


### PR DESCRIPTION
## Aufgabe 1 — Rollout auf Selbstfürsorge (Seite 9 von 10)

Freigegebene Klassifikation + Nachklärung zu 3 Sub-Komponenten-Abschnitten.

### Umsetzung
- **Offen (6):** Warum Selbstfürsorge wichtig ist · Warnsignale für Überlastung · **Sofort-Übungen für akute Belastung** · Radikale Akzeptanz · Geben Sie sich die Erlaubnis · Beratung & Netzwerke.
- **Akkordeon (2):** Langfristige Selbstfürsorge-Strategien *(opt-in Techniken)* · Hinweise für Ihre Situation *(situationsspezifisch)*. Beide Quellen-Boxen unverändert.

### Transparenz-Hinweis
Drei Abschnitte (Sofort-Übungen, Langfristige Strategien, Hinweise für Ihre Situation) stammen aus Sub-Komponenten und hatte meine erste Inventur übersehen. Nach Rückfrage freigegeben: **Sofort-Übungen offen** (akute, konkrete Hilfe gehört nicht hinter einen Klick), die anderen beiden bleiben Akkordeon. Dafür Sub-Komponenten um durchgereichte `collapsible`-Props erweitert (`SelbstfuersorgeSignalsSection`, `SelbstfuersorgeExercisesSection`).

### Technik-Audit
- 3× `<h4>` → `<h3>` (Hierarchie lückenlos).

### Verifikation
- DOM-Check **h1–h6**: keine Sprünge; **6 offen / 2 Akkordeon**.
- `typecheck` · `lint` · `test` (361/361) · `build` grün. Nicht visuell getestet.

### Roll-out-Fortschritt
9/10. Letzte Seite: Kommunizieren.

https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N)_