### PR TITLE
Aufgabe 1 (Rollout) — /kommunizieren: Kernabschnitte als offene Prosa (Abschluss)

### DIFF
--- a/client/src/pages/Kommunizieren.tsx
+++ b/client/src/pages/Kommunizieren.tsx
@@ -255,10 +255,9 @@ export default function Kommunizieren() {
         <EditorialSection.Body>
           <ContentSection
             variant="editorial"
+            collapsible={false}
             title="Kommunikation beginnt nicht mit Technik"
             id="haltung"
-            defaultOpen={true}
-            preview="Viele Gespräche scheitern nicht nur am Wortlaut, sondern daran, dass beide Seiten bereits im Alarmzustand, in Rechtfertigung oder in Kränkung sprechen."
           >
             <EditorialProse>
               <p>
@@ -279,10 +278,9 @@ export default function Kommunizieren() {
 
           <ContentSection
             variant="editorial"
+            collapsible={false}
             title="Validierung: der wichtigste Ausgangspunkt"
             id="validierung"
-            defaultOpen={true}
-            preview="Validierung heisst nicht zustimmen. Sie signalisiert: Ich nehme dein Erleben ernst, auch wenn ich nicht jede Sichtweise teile."
           >
             <EditorialProse>
               <p>
@@ -309,14 +307,13 @@ export default function Kommunizieren() {
 
           <ContentSection
             variant="editorial"
+            collapsible={false}
             title="Timing ist oft wichtiger als der perfekte Satz"
             id="timing"
-            defaultOpen={true}
-            preview="Viele Gespräche scheitern daran, dass Inhalte zu früh geklärt werden sollen, während Anspannung, Scham oder Wut noch den ganzen Raum füllen."
           >
             <div className="mt-2 grid gap-8 sm:grid-cols-2">
               <div>
-                <h4
+                <h3
                   className="mb-3"
                   style={{
                     fontSize: "var(--text-md)",
@@ -325,7 +322,7 @@ export default function Kommunizieren() {
                   }}
                 >
                   Eher jetzt
-                </h4>
+                </h3>
                 <ul
                   className="space-y-2"
                   style={{
@@ -341,7 +338,7 @@ export default function Kommunizieren() {
                 </ul>
               </div>
               <div>
-                <h4
+                <h3
                   className="mb-3"
                   style={{
                     fontSize: "var(--text-md)",
@@ -350,7 +347,7 @@ export default function Kommunizieren() {
                   }}
                 >
                   Eher später
-                </h4>
+                </h3>
                 <ul
                   className="space-y-2"
                   style={{
@@ -368,7 +365,7 @@ export default function Kommunizieren() {
             </div>
           </ContentSection>
 
-          <KommunizierenEscalationSection defaultOpen />
+          <KommunizierenEscalationSection collapsible={false} />
 
           <KommunizierenSituationsSection />
 

--- a/client/src/sections/KommunizierenPatternSections.tsx
+++ b/client/src/sections/KommunizierenPatternSections.tsx
@@ -7,14 +7,18 @@ import {
 
 interface KommunizierenPatternSectionProps {
   defaultOpen?: boolean;
+  /** Wenn false: dauerhaft offene Prosa ohne Toggle (an ContentSection durchgereicht). */
+  collapsible?: boolean;
 }
 
 export function KommunizierenEscalationSection({
   defaultOpen = false,
+  collapsible = true,
 }: KommunizierenPatternSectionProps) {
   return (
     <ContentSection
       variant="editorial"
+      collapsible={collapsible}
       title="Wenn Gespräche kippen"
       id="eskalation"
       defaultOpen={defaultOpen}


### PR DESCRIPTION
## Aufgabe 1 — Rollout auf Kommunizieren (Seite 10 von 10 · Abschluss)

Freigegebene Klassifikation. Letzte Seite des Roll-outs.

### Umsetzung
- **4 ContentSections offen** (`collapsible={false}`): Kommunikation beginnt nicht mit Technik · Validierung: der wichtigste Ausgangspunkt · Timing ist oft wichtiger als der perfekte Satz · Wenn Gespräche kippen *(Deeskalation)*.
- **Akkordeon (2):** Typische schwierige Situationen *(Einzelszenarien)* · Kommunikation aus verschiedenen Angehörigenrollen *(Rollen-Varianten)*.
- `KommunizierenEscalationSection` um durchgereichtes `collapsible`-Prop erweitert; `ValidierungsStufenleiter` (interaktiv) unverändert.

### Technik-Audit
- 2× `<h4>` → `<h3>` (Hierarchie lückenlos).

### Verifikation
- **Vollständige DOM-Inventur vorab** (inkl. Sub-Komponenten) — keine versteckten Abschnitte übersehen.
- DOM-Check **h1–h6**: keine Sprünge; **4 offen / 2 Akkordeon**.
- `typecheck` · `lint` · `test` (361/361) · `build` grün. Nicht visuell getestet.

### Roll-out abgeschlossen 🎉
Damit sind **alle 10 ContentSection-Seiten** auf das „Kern offen / Optional als Akkordeon"-Muster umgestellt (Pilot Verstehen + Grenzen, Diagnostik, Alltag, Therapie, Begleiterkrankungen, Übersicht, Krise, Genesung, Selbstfürsorge, Kommunizieren).

https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N)_