### PR TITLE
refactor(home): Soforthilfe-Dopplung auflösen (Krisen-Karte aus Triage)

### DIFF
--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -16,14 +16,11 @@ const FACHSTELLE = INFO.find(k => k.id === "INFO_FACHSTELLE");
 const EMAIL_ANGEHOERIGEN = EMAILS.find(e => e.id === "EMAIL_ANGEHOERIGEN");
 const ADRESSE_PUK = ADRESSEN.find(a => a.id === "ADRESSE_PUK");
 
+// Krise/Soforthilfe ist bewusst NICHT als Triage-Karte hier: die akute Lage
+// läuft prominent über den Krisen-Aside im Hero und den persistenten roten
+// Header-Button. So bleibt diese Triage auf die nicht-akuten Situationen
+// fokussiert (verstehen / Worte / am Limit) statt Soforthilfe zu doppeln.
 const PATHWAYS = [
-  {
-    kicker: "Gefahr oder Krise",
-    title: "Schnell den richtigen Kontakt finden",
-    body: "Notfallnummern, psychiatrische Krisenstellen und Gewalt-/Opferhilfe ohne Umwege.",
-    href: "/soforthilfe",
-    link: "Soforthilfe öffnen",
-  },
   {
     kicker: "Ich will verstehen",
     title: "Muster erkennen, ohne zu entschuldigen",


### PR DESCRIPTION
## Home — Soforthilfe-Dopplung auflösen (Follow-up zu Aufgabe 2 / #549)

**Befund:** Der Krisen-Aside im Hero („Wenn es akut ist" → Soforthilfe) und die Triage-Karte „Gefahr oder Krise" → Soforthilfe lagen direkt beieinander — zwei konkurrierende Soforthilfe-Einstiege.

### Fix
Die **„Gefahr oder Krise"-Karte aus `PATHWAYS` entfernt**. „Was brauchen Sie gerade?" fokussiert jetzt auf die nicht-akuten Situationen: **Ich will verstehen · Ich brauche Worte · Ich bin am Limit** (3 Karten). Die akute Lage läuft prominent über den **Krisen-Aside im Hero** + den **persistenten roten Header-Button**; der kontextuelle Soforthilfe-Link im Fachstelle-Absatz bleibt.

### Verifikation
- DOM: 3 Pathway-Karten, Krisen-Aside vorhanden, keine konkurrierende Triage-Karte mehr. Soforthilfe weiterhin erreichbar (Header · Hero-Aside · Fachstelle-Link) — **kein Zielverlust**.
- `typecheck` · `lint` · `test` (361/361) · `build` · **Visual 30/30** (home-hero unverändert) grün.

https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N

---
_Generated by [Claude Code](https://claude.ai/code/session_01SYg92SwjHx2AUUE8uxky7N)_