### PR TITLE
[codex] Add notfallplan crisis v04 asset brief

### DIFF
--- a/qa/handout-asset-blockers.md
+++ b/qa/handout-asset-blockers.md
@@ -139,6 +139,7 @@ PDF/WebP-Ebene dieselbe entlastende Sprache spricht wie die Web-Textversion.
 
 Für einen kleinen, sicheren Folge-PR zuerst nur die P0-Gruppe behandeln:
 
-1. `notfallplan-krise` PDF/WebP gegen die gehärtete Textversion prüfen.
-2. Falls Drift sichtbar ist: neues Krisenhandout-Asset exportieren.
-3. Danach `approvedVersion`, Materialregister und Release-Gates aktualisieren.
+1. `notfallplan-krise-v04` gemäss
+   `qa/notfallplan-krise-v04-asset-brief.md` aus editierbarer Quelle
+   exportieren.
+2. Danach `approvedVersion`, Materialregister und Release-Gates aktualisieren.

--- a/qa/notfallplan-krise-fidelity-audit.md
+++ b/qa/notfallplan-krise-fidelity-audit.md
@@ -132,7 +132,9 @@ Ein neues Asset sollte mindestens diese Punkte erfüllen:
 
 ## Operativer nächster Schritt
 
-Neues `notfallplan-krise-v04` aus editierbarer Quelle exportieren. Danach:
+Neues `notfallplan-krise-v04` gemäss
+`qa/notfallplan-krise-v04-asset-brief.md` aus editierbarer Quelle
+exportieren. Danach:
 
 1. `client/public/notfallplan-krise-v04.pdf` und Preview ablegen.
 2. `client/src/content/handoutGovernance.ts` auf `notfallplan-krise-v04`

--- a/qa/notfallplan-krise-v04-asset-brief.md
+++ b/qa/notfallplan-krise-v04-asset-brief.md
@@ -1,0 +1,282 @@
+# Asset-Brief: Notfallplan Krise v04
+
+Stand: 2026-06-02  
+Zielasset: `notfallplan-krise-v04`  
+Dokumenttyp: `KRISEN-HANDOUT`  
+Ausgangslage: `notfallplan-krise-v03` hat bestätigten P0-Fidelity-Drift
+gegenüber der gehärteten Web-Textversion.
+
+## Ziel
+
+`notfallplan-krise-v04` soll die bestehende Notfallplan-Funktion erhalten, aber
+die Krisenlogik fachlich synchron zur Web-Textversion machen:
+
+- klare Hierarchie: Lebensgefahr, Gewalt/Bedrohung, psychiatrische Krise,
+  Entlastung
+- aktuelle Telefonnummern aus `client/src/data/kontakte.ts`
+- Selbstschutz-Caveat überall dort, wo Angehörige zum Dableiben oder
+  Nicht-allein-Lassen aufgefordert werden
+- keine methodenspezifischen Suizidinformationen
+- schnell erfassbar unter Stress
+
+## Pflichtkorrekturen gegenüber v03
+
+1. `117 Polizei` muss im Haupt-Akutblock sichtbar sein:
+   Gewalt, akute Bedrohung oder wenn sofort Schutz vor Ort nötig ist.
+2. PUK-Nummern müssen vollständig nach Altersgruppe vorkommen:
+   - Erwachsene 18-64: `058 384 20 00`
+   - Kinder/Jugendliche bis 18: `058 384 66 66`
+   - ab 65: `058 384 46 82`
+3. `143 Dargebotene Hand` muss als Entlastung/Gespräch eingeordnet werden:
+   kein Einsatzdienst, niemand kommt vorbei.
+4. `Dableiben` und `nicht allein lassen` nur mit Selbstschutz:
+   `sofern Sie selbst sicher bleiben können`.
+5. `die Person trotz akuter Gefahr allein lassen` präzisieren:
+   nicht ohne Hilfe, Sicherheitsplan oder professionelle Einschätzung allein
+   lassen.
+6. Fachstelle Angehörigenarbeit nicht als Akutnummer darstellen. Falls genannt,
+   dann separat als Angehörigen-Unterstützung nach der Akutlage.
+
+## Format
+
+Bevorzugt: A4 hoch, 2 Seiten, v03-kompatibel.
+
+Seite 1 muss allein als Akutblatt funktionieren. Seite 2 darf Kurzreferenz,
+Nachsorge und Angehörigen-Selbstschutz ergänzen. Wenn ein A4-Querformat oder
+ein einseitiges Krisenblatt vorgeschlagen wird, darf keine Pflichtinformation
+wegfallen und die Lesbarkeit muss sichtbar besser sein als in v03.
+
+## Finale Copy
+
+### Header
+
+Eyebrow:
+
+`KRISEN-HANDOUT · SOFORTHILFE`
+
+Titel:
+
+`Notfallplan bei psychischer Krise`
+
+Untertitel:
+
+`Konkrete Schritte bei Suizidgedanken, Selbstverletzung oder akuter seelischer Krise`
+
+Lead:
+
+`Wenn Suizidgedanken, Selbstverletzung oder eine akute psychische Krise im Raum stehen, zählt zuerst Sicherheit. Dieser Plan hilft Angehörigen, ruhig zu bleiben, Gefahr einzuschätzen und Hilfe einzubeziehen. Er ersetzt keine professionelle Beurteilung.`
+
+### Seite 1: Akutpfad
+
+#### Akute Gefahr? Sofort handeln.
+
+Sofort `144` anrufen, wenn medizinische Hilfe oder Rettung vor Ort nötig ist,
+zum Beispiel wenn die Person:
+
+- sich gerade schwer verletzt
+- eine Überdosis eingenommen hat oder eine schwere Intoxikation vermutet wird
+- bewusstlos ist
+- einen konkreten Suizidplan äussert oder unmittelbar in Gefahr ist
+
+Bei Gewalt, akuter Bedrohung oder wenn sofort Schutz vor Ort nötig ist:
+
+`117 Polizei`
+
+#### Psychiatrische Krise ohne unmittelbare Lebensgefahr
+
+PUK Zürich, 24/7:
+
+- Erwachsene 18-64: `058 384 20 00`
+- Kinder/Jugendliche bis 18: `058 384 66 66`
+- ab 65: `058 384 46 82`
+
+Ärztefon Zürich, medizinische oder psychiatrische Triage 24/7:
+
+`0800 33 66 55`
+
+#### Entlastung und Gespräch
+
+`143 Dargebotene Hand`
+
+Anonymes Gespräch, 24/7. Kein Einsatzdienst.
+
+#### Wichtiger Soforthinweis
+
+`Die Person nach Möglichkeit nicht ohne Hilfe, Notfallplan oder professionelle Einschätzung allein lassen — sofern Sie selbst sicher bleiben können. Gefährliche Gegenstände, Medikamente, Alkohol oder andere Mittel wenn möglich entfernen. Bei Unsicherheit lieber einmal zu viel Hilfe holen als einmal zu wenig.`
+
+### 4 Schritte in der Krise
+
+#### 1 · Ruhe bewahren
+
+`Ihre Angst ist verständlich. Sprechen Sie langsam, vermeiden Sie Druck und bleiben Sie so ruhig wie möglich. Ihre Ruhe kann vorübergehend Halt geben.`
+
+#### 2 · Ernst nehmen und direkt ansprechen
+
+`Jede Äusserung über Suizid oder Selbstverletzung ernst nehmen. Direktes Nachfragen erhöht das Risiko nicht, sondern kann entlasten.`
+
+Beispiele:
+
+- `«Ich habe gehört, was du gesagt hast. Ich nehme das ernst.»`
+- `«Denkst du daran, dir etwas anzutun?»`
+
+#### 3 · Zuhören und Gefühle anerkennen
+
+`Hören Sie zu, ohne vorschnell zu beruhigen, zu argumentieren oder sofort Lösungen anzubieten. Es geht zuerst darum, die Not wahrzunehmen.`
+
+Beispiele:
+
+- `«Ich sehe, dass es dir gerade sehr schlecht geht.»`
+- `«Du musst das gerade nicht allein aushalten.»`
+
+#### 4 · Professionelle Hilfe einbeziehen
+
+`Sie müssen diese Situation nicht allein tragen. Ziehen Sie frühzeitig professionelle Hilfe bei. Informieren Sie wenn möglich die behandelnde Fachperson oder nutzen Sie die Notfallnummern. Suizidgedanken und akute Selbstgefährdung sollten nicht als Geheimnis mitgetragen werden.`
+
+### Merksatz
+
+`«Ich nehme dich ernst. Ich bin da. Und ich hole Hilfe — für dich und für mich.»`
+
+### Seite 2: Was hilft / Nach der Akutlage
+
+#### Das hilft
+
+- ruhig bleiben und, wenn es für Sie sicher ist, dableiben
+- direkt und klar nachfragen
+- Gefühle ernst nehmen und anerkennen
+- Gefährdung einschätzen und Hilfe holen
+- Fachpersonen oder Notfallstellen einbeziehen
+- konkrete Sicherheit vor Diskussion stellen
+
+#### Das schadet eher
+
+- Panik, Vorwürfe oder Druck
+- bagatellisieren oder ablenken
+- lange Diskussionen, warum das Leben doch schön sei
+- argumentieren oder überzeugen wollen
+- drohen oder bestrafen
+- die Person trotz akuter Gefahr ohne Hilfe, Sicherheitsplan oder
+  professionelle Einschätzung allein lassen
+- selbst in einer unsicheren oder bedrohlichen Situation bleiben
+- Suizidgedanken als Geheimnis für sich behalten
+
+#### Nach der akuten Situation
+
+- behandelnde Fachperson informieren
+- gemeinsam überlegen, was jetzt Sicherheit gibt
+- Unterstützung auch für Angehörige organisieren
+- nächste Stunden und Nacht nicht dem Zufall überlassen
+- Warnzeichen und Auslöser festhalten
+
+#### Selbstfürsorge für Angehörige
+
+`Auch Sie brauchen Unterstützung. Krisen belasten Angehörige stark — das ist normal und kein Zeichen von Schwäche.`
+
+- eigene Belastungsgrenze wahrnehmen
+- Gespräch mit eigener Fachperson suchen
+- nicht alles allein tragen müssen
+- eigene Gefühle wie Angst, Wut oder Erschöpfung zulassen
+- Entlastungsgespräch nutzen, zum Beispiel `143 Dargebotene Hand`
+
+Optional separat, klar nicht als Akutnummer:
+
+`Fachstelle Angehörigenarbeit PUK Zürich: Unterstützung für Angehörige nach oder ausserhalb der Akutlage.`
+
+#### Notfallnummern — Kurzreferenz
+
+Akute Lebensgefahr / medizinischer Notfall:
+
+- `144 Sanität`
+
+Gewalt / akute Bedrohung:
+
+- `117 Polizei`
+
+Medizinische oder psychiatrische Triage:
+
+- `0800 33 66 55 Ärztefon`
+
+Psychiatrische Krise ohne unmittelbare Lebensgefahr:
+
+- `058 384 20 00 PUK Erwachsene 18-64`
+- `058 384 66 66 PUK Kinder/Jugendliche`
+- `058 384 46 82 PUK ab 65`
+
+Entlastendes Gespräch:
+
+- `143 Dargebotene Hand`
+
+#### Wichtiger Hinweis
+
+`Dieser Notfallplan ersetzt keine professionelle Beurteilung und keine psychiatrische Diagnose. Er dient der Orientierung in einer akuten Situation. Bei akuter Lebensgefahr sofort 144 anrufen.`
+
+## Quellen- und Footerlogik
+
+Quellenzeile:
+
+`Quellen: Berkowitz & Gunderson, BPD Family Guidelines (NEABPD); Project Air Strategy, Understanding Self-Harm & Suicidal Thinking for Families & Carers.`
+
+Institutioneller Footer:
+
+`Fachstelle Angehörigenarbeit · Psychiatrische Universitätsklinik Zürich`
+
+Stand-/Versionszeile:
+
+`Stand: Juni 2026 · v04`
+
+Keine Website-Navigation, keine Modulverweise, keine zusätzlichen
+Footer-Links.
+
+## Visuelle Vorgaben
+
+- Krisen-Handout, nicht psychoedukatives Poster.
+- Sofort erfassbare Hierarchie: Rot/Akut, Gelb/Psychiatrische Krise,
+  Grün/Entlastung.
+- Keine dekorative Überinszenierung.
+- Keine methodenspezifischen Suizidbilder, keine Messer-/Tablettenbilder,
+  keine dramatische Person am Abgrund.
+- Sehr klare Typografie, grosse Nummern, kurze Textblöcke.
+- Seite 1 muss unter Stress in weniger als 30 Sekunden scannbar sein.
+- Seite 2 darf ruhiger und erklärender sein, aber nicht textlastiger als v03.
+- Schweizer Orthografie: ss, keine ß.
+- Zitate mit Schweizer Guillemets: `«...»`.
+
+## Abnahmekriterien
+
+Vor Integration ins Repo muss das neue v04-Asset diese Prüfungen bestehen:
+
+1. PDF und Preview enthalten alle Nummern exakt wie oben.
+2. Keine alte PUK- oder Fachstellenlogik aus v03 bleibt sichtbar.
+3. `117` ist sichtbar im Akutpfad enthalten.
+4. KJP und 65+ PUK-Nummern sind sichtbar enthalten.
+5. `143` ist als Entlastung/Gespräch und nicht als Einsatzdienst markiert.
+6. `Dableiben` und `nicht allein lassen` enthalten den Selbstschutz-Caveat.
+7. Keine methodenspezifischen Suizidinformationen wurden ergänzt.
+8. PDF ist lesbar, druckbar und nicht kleiner gesetzt als v03.
+9. WebP/Preview und PDF stimmen in Nummern, Labels, Hierarchie und Stand überein.
+10. Nach Integration:
+    - `client/src/content/handoutGovernance.ts` auf `notfallplan-krise-v04`
+      aktualisieren.
+    - `client/src/content/materialien.ts` auf v04 aktualisieren.
+    - `pnpm test -- handout-governance`
+    - `pnpm audit:release-http-gates`
+
+## Copy-Prompt für Bild-/Layout-Erstellung
+
+```text
+Erstelle ein professionelles A4-Krisen-Handout für die Fachstelle Angehörigenarbeit der Psychiatrischen Universitätsklinik Zürich.
+
+Dokumenttyp: KRISEN-HANDOUT · SOFORTHILFE
+Titel: Notfallplan bei psychischer Krise
+Version: v04
+Format: bevorzugt A4 hoch, 2 Seiten. Seite 1 muss allein als Akutblatt funktionieren; Seite 2 enthält Kurzreferenz, Nachsorge und Angehörigen-Selbstschutz.
+
+Stil:
+Ruhig, klar, institutionell, schweizerisch, sehr gut lesbar. Kein Canva-Look, keine dramatischen Suizidbilder, keine Personen am Abgrund, keine methodenspezifischen Suizidvisuals. Nutze klare Notfallhierarchie mit gedämpftem Rot/Sand für akute Gefahr, Gelb/Sand für psychiatrische Krise, Grün/Sage für Entlastung. Sehr grosse Telefonnummern, kurze Textblöcke, klare Typografie, viel Luft.
+
+Wichtig:
+Alle Nummern exakt übernehmen. 143 ist Entlastung/Gespräch, kein Einsatzdienst. Fachstelle Angehörigenarbeit nicht als Akutnummer darstellen. Dableiben und Nicht-allein-Lassen immer mit Selbstschutz-Caveat formulieren: sofern Sie selbst sicher bleiben können.
+
+Verwende folgenden freigegebenen Inhalt unverändert:
+
+[Hier die Abschnitte aus dem Asset-Brief ab "Finale Copy" einfügen.]
+```


### PR DESCRIPTION
## Summary

- adds a concrete v04 asset brief for `notfallplan-krise`
- links the blocker report and fidelity audit to the new brief
- captures final copy, required crisis hierarchy, self-protection caveats, and acceptance criteria for the next PDF/WebP export

## Context

The editable source for `notfallplan-krise-v03` is not present in the repo. This PR therefore prepares the clean handoff for producing `notfallplan-krise-v04` from an editable design source instead of patching the flattened PDF/WebP.

## Validation

- `pnpm prettier --check qa/handout-asset-blockers.md qa/notfallplan-krise-fidelity-audit.md qa/notfallplan-krise-v04-asset-brief.md`
- `pnpm test -- handout-governance`