### PR TITLE
Extend handout style bridge to teasers

### DIFF
--- a/client/src/components/visualizations/VisualOrientationGrid.tsx
+++ b/client/src/components/visualizations/VisualOrientationGrid.tsx
@@ -55,11 +55,6 @@ export function VisualOrientationGrid({
     : typeof maxItems === "number"
       ? homeFeaturedInfografiken.slice(0, maxItems)
       : homeFeaturedInfografiken;
-  const gridClass =
-    tiles.length <= 3
-      ? "grid grid-cols-1 gap-x-6 gap-y-10 md:grid-cols-2 md:gap-y-12 lg:grid-cols-3"
-      : "grid grid-cols-1 gap-x-6 gap-y-10 md:grid-cols-2 md:gap-y-12 lg:grid-cols-4";
-
   return (
     <>
       <EditorialSection variant="cream">
@@ -106,21 +101,18 @@ export function VisualOrientationGrid({
         data-toc-skip
       >
         <div className="mx-auto max-w-page">
-          <ul className={gridClass}>
+          <ul
+            className="featured-infographic-grid"
+            data-grid-size={tiles.length <= 3 ? "compact" : "default"}
+          >
             {tiles.map(tile => (
-              <li key={tile.id} className="group">
+              <li key={tile.id}>
                 <AppLink
                   href={tile.href}
-                  className="block rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--accent-primary)] focus-visible:ring-offset-4 focus-visible:ring-offset-[color:var(--bg-primary)]"
+                  className="featured-infographic-card"
+                  data-feature-tone={getFeatureTone(tile.categoryLabel)}
                 >
-                  <div
-                    className="overflow-hidden rounded-md border"
-                    style={{
-                      borderColor: "var(--rule-color)",
-                      background: "var(--bg-elevated)",
-                      aspectRatio: `600 / ${tile.thumbnailHeight}`,
-                    }}
-                  >
+                  <div className="featured-infographic-card__media">
                     <img
                       src={tile.thumbnailUrl}
                       alt={tile.alt}
@@ -128,32 +120,20 @@ export function VisualOrientationGrid({
                       height={tile.thumbnailHeight}
                       loading="lazy"
                       decoding="async"
-                      className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                      className="featured-infographic-card__image"
                     />
                   </div>
-                  <EyebrowLabel className="mt-4" spacing="compact">
-                    {tile.categoryLabel}
-                  </EyebrowLabel>
-                  <h3
-                    className="mt-2 font-display transition-colors duration-200 group-hover:text-[color:var(--accent-primary)]"
-                    style={{
-                      fontSize: "1.125rem",
-                      lineHeight: "var(--lh-snug)",
-                      color: "var(--fg-primary)",
-                      fontWeight: 500,
-                    }}
-                  >
-                    {tile.title}
-                  </h3>
-                  <p
-                    className="mt-2 text-sm"
-                    style={{
-                      color: "var(--fg-secondary)",
-                      lineHeight: "var(--lh-snug)",
-                    }}
-                  >
-                    {tile.description}
-                  </p>
+                  <div className="featured-infographic-card__content">
+                    <p className="featured-infographic-card__kicker">
+                      {tile.categoryLabel}
+                    </p>
+                    <h3 className="featured-infographic-card__title">
+                      {tile.title}
+                    </h3>
+                    <p className="featured-infographic-card__description">
+                      {tile.description}
+                    </p>
+                  </div>
                 </AppLink>
               </li>
             ))}
@@ -162,4 +142,17 @@ export function VisualOrientationGrid({
       </section>
     </>
   );
+}
+
+function getFeatureTone(categoryLabel: string) {
+  if (categoryLabel === "Kommunizieren" || categoryLabel === "Grenzen") {
+    return "terracotta";
+  }
+  if (categoryLabel === "Krise begleiten") {
+    return "danger";
+  }
+  if (categoryLabel === "Genesung") {
+    return "steel";
+  }
+  return "sage";
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -651,8 +651,11 @@
   }
 
   .topic-material-card {
+    --material-accent: var(--fs-sage);
+    --material-accent-soft: var(--fs-sage-soft);
     display: flex;
     min-width: 0;
+    height: 100%;
     overflow: hidden;
     flex-direction: column;
     border: 1px solid var(--fs-rule);
@@ -665,27 +668,70 @@
       ),
       var(--fs-paper);
     box-shadow: 0 1px 0 rgba(31, 42, 55, 0.04);
+    transition:
+      border-color 160ms ease,
+      transform 160ms ease,
+      box-shadow 160ms ease;
+  }
+
+  .topic-material-card[data-material-tone="terracotta"] {
+    --material-accent: var(--fs-terracotta);
+    --material-accent-soft: var(--fs-terracotta-soft);
+  }
+
+  .topic-material-card[data-material-tone="steel"] {
+    --material-accent: var(--fs-steel);
+    --material-accent-soft: var(--fs-steel-soft);
+  }
+
+  .topic-material-card[data-material-tone="sand"] {
+    --material-accent: var(--fs-sand);
+    --material-accent-soft: var(--fs-sand-soft);
+  }
+
+  .topic-material-card[data-material-tone="danger"] {
+    --material-accent: var(--fs-danger);
+    --material-accent-soft: var(--fs-danger-soft);
+  }
+
+  .topic-material-card:hover {
+    border-color: color-mix(in srgb, var(--material-accent) 48%, transparent);
+    box-shadow: 0 14px 32px rgba(31, 42, 55, 0.06);
+    transform: translateY(-1px);
   }
 
   .topic-material-card__media {
-    display: block;
+    display: grid;
+    place-items: center;
     min-width: 0;
+    overflow: hidden;
     aspect-ratio: 4 / 3;
     border-bottom: 1px solid var(--fs-rule);
     background:
+      radial-gradient(
+        circle at 50% 10%,
+        rgba(255, 253, 248, 0.76),
+        transparent 52%
+      ),
       linear-gradient(
         135deg,
-        rgba(237, 243, 236, 0.82),
-        rgba(246, 239, 226, 0.72)
-      ),
-      var(--fs-paper-muted);
+        var(--material-accent-soft),
+        rgba(255, 253, 248, 0.88)
+      );
   }
 
   .topic-material-card__media img {
     width: 100%;
     height: 100%;
     object-fit: contain;
+    object-position: center top;
     padding: var(--space-3);
+    filter: saturate(0.96) drop-shadow(0 8px 14px rgba(31, 42, 55, 0.12));
+    transition: transform 180ms ease;
+  }
+
+  .topic-material-card:hover .topic-material-card__media img {
+    transform: scale(1.025);
   }
 
   .topic-material-card__content {
@@ -702,7 +748,7 @@
     font-weight: 500;
     letter-spacing: var(--tracking-caps);
     text-transform: uppercase;
-    color: var(--fg-tertiary);
+    color: var(--material-accent);
   }
 
   .topic-material-card__title {
@@ -724,8 +770,16 @@
   }
 
   .topic-material-card__guidance {
+    padding: 0.65rem 0.75rem;
     padding-left: var(--space-3);
-    border-left: 2px solid var(--fs-rule-strong);
+    border-left: 2px solid
+      color-mix(in srgb, var(--material-accent) 82%, transparent);
+    border-radius: 0 10px 10px 0;
+    background: color-mix(
+      in srgb,
+      var(--material-accent-soft) 68%,
+      transparent
+    );
   }
 
   .topic-material-card__actions {
@@ -734,6 +788,7 @@
     gap: var(--space-2) var(--space-4);
     margin-top: auto;
     padding-top: var(--space-3);
+    border-top: 1px solid var(--fs-rule);
     font-size: var(--text-sm);
   }
 
@@ -808,6 +863,159 @@
     .material-starter-shelf {
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
+  }
+
+  .featured-infographic-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--space-4);
+  }
+
+  @media (min-width: 768px) {
+    .featured-infographic-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: var(--space-5) var(--space-4);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .featured-infographic-grid[data-grid-size="compact"] {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .featured-infographic-grid[data-grid-size="default"] {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+  }
+
+  .featured-infographic-card {
+    --material-accent: var(--fs-sage);
+    --material-accent-soft: var(--fs-sage-soft);
+    display: flex;
+    height: 100%;
+    min-width: 0;
+    overflow: hidden;
+    flex-direction: column;
+    color: inherit;
+    text-decoration: none;
+    border: 1px solid var(--fs-rule);
+    border-radius: var(--fs-radius-panel);
+    background:
+      linear-gradient(
+        180deg,
+        rgba(255, 253, 248, 0.98),
+        rgba(255, 253, 248, 0.9)
+      ),
+      var(--fs-paper);
+    box-shadow: 0 1px 0 rgba(31, 42, 55, 0.04);
+    transition:
+      border-color 160ms ease,
+      transform 160ms ease,
+      box-shadow 160ms ease;
+  }
+
+  .featured-infographic-card[data-feature-tone="terracotta"] {
+    --material-accent: var(--fs-terracotta);
+    --material-accent-soft: var(--fs-terracotta-soft);
+  }
+
+  .featured-infographic-card[data-feature-tone="steel"] {
+    --material-accent: var(--fs-steel);
+    --material-accent-soft: var(--fs-steel-soft);
+  }
+
+  .featured-infographic-card[data-feature-tone="sand"] {
+    --material-accent: var(--fs-sand);
+    --material-accent-soft: var(--fs-sand-soft);
+  }
+
+  .featured-infographic-card[data-feature-tone="danger"] {
+    --material-accent: var(--fs-danger);
+    --material-accent-soft: var(--fs-danger-soft);
+  }
+
+  .featured-infographic-card:hover,
+  .featured-infographic-card:focus-visible {
+    border-color: color-mix(in srgb, var(--material-accent) 54%, transparent);
+    box-shadow: 0 14px 32px rgba(31, 42, 55, 0.07);
+    transform: translateY(-1px);
+  }
+
+  .featured-infographic-card:focus-visible {
+    outline: 2px solid var(--material-accent);
+    outline-offset: 4px;
+  }
+
+  .featured-infographic-card__media {
+    display: grid;
+    place-items: center;
+    overflow: hidden;
+    aspect-ratio: 4 / 3;
+    border-bottom: 1px solid var(--fs-rule);
+    background:
+      radial-gradient(
+        circle at 50% 10%,
+        rgba(255, 253, 248, 0.78),
+        transparent 52%
+      ),
+      linear-gradient(
+        135deg,
+        var(--material-accent-soft),
+        rgba(255, 253, 248, 0.88)
+      );
+  }
+
+  .featured-infographic-card__image {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    object-position: center top;
+    padding: 0.85rem;
+    filter: saturate(0.96) drop-shadow(0 8px 14px rgba(31, 42, 55, 0.12));
+    transition: transform 180ms ease;
+  }
+
+  .featured-infographic-card:hover .featured-infographic-card__image {
+    transform: scale(1.025);
+  }
+
+  .featured-infographic-card__content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: var(--space-2);
+    padding: calc(var(--space-4) + 0.125rem);
+  }
+
+  .featured-infographic-card__kicker {
+    margin: 0;
+    color: var(--material-accent);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    letter-spacing: var(--tracking-caps);
+    text-transform: uppercase;
+  }
+
+  .featured-infographic-card__title {
+    margin: 0;
+    color: var(--fg-primary);
+    font-family: var(--font-display);
+    font-size: clamp(1.125rem, 1.15vw, 1.25rem);
+    font-weight: var(--weight-display);
+    letter-spacing: var(--tracking-tight);
+    line-height: var(--lh-snug);
+    transition: color 160ms ease;
+  }
+
+  .featured-infographic-card:hover .featured-infographic-card__title {
+    color: var(--material-accent);
+  }
+
+  .featured-infographic-card__description {
+    margin: 0;
+    color: var(--fg-secondary);
+    font-size: var(--text-sm);
+    line-height: var(--lh-relaxed);
   }
 
   /* Material library cards: same quiet family as curated topic materials,

--- a/client/src/sections/CuratedMaterialsSection.tsx
+++ b/client/src/sections/CuratedMaterialsSection.tsx
@@ -20,6 +20,8 @@ export interface CuratedMaterialCard {
   guidance?: string;
 }
 
+type CuratedMaterialTone = "sage" | "terracotta" | "steel" | "sand" | "danger";
+
 interface CuratedMaterialsSectionProps {
   marginLabel: string;
   title: string;
@@ -28,6 +30,7 @@ interface CuratedMaterialsSectionProps {
   items: CuratedMaterialCard[];
   ariaLabel: string;
   allMaterialsLabel?: string;
+  tone?: CuratedMaterialTone;
 }
 
 export default function CuratedMaterialsSection({
@@ -38,6 +41,7 @@ export default function CuratedMaterialsSection({
   items,
   ariaLabel,
   allMaterialsLabel = "Alle Materialien ansehen",
+  tone = "sage",
 }: CuratedMaterialsSectionProps) {
   const visibleItems = items.slice(0, 3);
 
@@ -81,7 +85,7 @@ export default function CuratedMaterialsSection({
         <div className="mx-auto max-w-page">
           <div className="topic-materials-grid">
             {visibleItems.map(item => (
-              <MaterialCard key={item.id} item={item} />
+              <MaterialCard key={item.id} item={item} tone={tone} />
             ))}
           </div>
           <p className="topic-materials-library-link">
@@ -95,14 +99,20 @@ export default function CuratedMaterialsSection({
   );
 }
 
-function MaterialCard({ item }: { item: CuratedMaterialCard }) {
+function MaterialCard({
+  item,
+  tone,
+}: {
+  item: CuratedMaterialCard;
+  tone: CuratedMaterialTone;
+}) {
   const textVersionHref = getHandoutTextVersionHrefBySource(item.pdfUrl);
   const pdfHref = getHandoutOpenHref(item.pdfUrl) ?? item.pdfUrl;
   const imageSrc = item.thumbnailUrl ?? item.imageUrl;
   const previewHref = item.previewUrl ?? item.imageUrl;
 
   return (
-    <article className="topic-material-card">
+    <article className="topic-material-card" data-material-tone={tone}>
       <a
         href={previewHref}
         target="_blank"

--- a/client/src/sections/GrenzenMaterialsSection.tsx
+++ b/client/src/sections/GrenzenMaterialsSection.tsx
@@ -27,6 +27,7 @@ export default function GrenzenMaterialsSection() {
       curationNote="Grenzsetzung wird schnell unübersichtlich. Diese Auswahl ist deshalb absichtlich klein: erst sortieren, dann formulieren, dann konsequent bleiben."
       items={curatedItems}
       ariaLabel="Ausgewählte Materialien zu Grenzen"
+      tone="terracotta"
     />
   );
 }

--- a/client/src/sections/KommunizierenMaterialsSection.tsx
+++ b/client/src/sections/KommunizierenMaterialsSection.tsx
@@ -27,6 +27,7 @@ export default function KommunizierenMaterialsSection() {
       curationNote="Die vollständige Materialsammlung bleibt auf der Bibliotheksseite. Hier stehen nur die drei Hilfen, die beim Lesen dieser Seite unmittelbar weiterführen."
       items={curatedItems}
       ariaLabel="Ausgewählte Materialien für schwierige Gespräche"
+      tone="terracotta"
     />
   );
 }


### PR DESCRIPTION
## Summary
- align Home infographic tiles with the new handout-style card language
- add tone-aware curated material cards for communication and boundaries pages
- reuse the material preview matte, accent and action hierarchy outside /materialien

## Verification
- pnpm check
- pnpm lint
- pnpm test
- pnpm build
- visual spot-checks: Home, Kommunizieren, Grenzen, Selbstfürsorge

Note: local Playwright visual run could not compare because Darwin baselines are intentionally absent; GitHub/Linux visual regression remains the release gate.